### PR TITLE
Preserve user `host` and `port` in `inv invoke`

### DIFF
--- a/faasmcli/faasmcli/util/call.py
+++ b/faasmcli/faasmcli/util/call.py
@@ -39,7 +39,7 @@ def invoke_impl(
 ):
     # Provider-specific stuff
     if knative:
-        host, port = get_invoke_host_port()
+        host, port = get_invoke_host_port(host, port)
 
     # Defaults
     host = host if host else "127.0.0.1"


### PR DESCRIPTION
The `host` doesn't take effect in `inv invoke demo hello -h 172.18.0.1` since it is overwritten by `get_invoke_host_port`.
This PR passes the user-provided `host` and `port` to `get_invoke_host_port`, so that they are not dropped when `knative` is true.