### PR TITLE
Adding stubbed syscalls for popen and pclose

### DIFF
--- a/src/wavm/process.cpp
+++ b/src/wavm/process.cpp
@@ -48,7 +48,17 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env, "wait", I32, s__wait, I32 a)
     throwException(Runtime::ExceptionTypes::calledUnimplementedIntrinsic);
 }
 
+WAVM_DEFINE_INTRINSIC_FUNCTION(env, "pclose", I32, s__pclose, I32 a)
+{
+    throwException(Runtime::ExceptionTypes::calledUnimplementedIntrinsic);
+}
+
 WAVM_DEFINE_INTRINSIC_FUNCTION(env, "pipe", I32, s__pipe, I32 a)
+{
+    throwException(Runtime::ExceptionTypes::calledUnimplementedIntrinsic);
+}
+
+WAVM_DEFINE_INTRINSIC_FUNCTION(env, "popen", I32, s__popen, I32 a, I32 b)
 {
     throwException(Runtime::ExceptionTypes::calledUnimplementedIntrinsic);
 }


### PR DESCRIPTION
This is the first of a series of PRs to offload #317 which has turned into a beast itself, and really is lacking context/losing it's point. The reason being that LAMMPS already runs on Faasm, but there needs to be some implementation on the Faabric and Faasm side to get it to properly work with MPI. As a consequence, I'd rather chunk this contributions into different PRs, this way we can ensure that more advanced features (unlike this PR) are properly tested and developed in isolation from the use-case itself.

In this particular PR I include the syscall stub definitions required to cross-compile LAMMPS.