### PR TITLE
Specific test tag for MPI Tests

### DIFF
--- a/tests/test/faaslet/test_mpi.cpp
+++ b/tests/test/faaslet/test_mpi.cpp
@@ -11,87 +11,87 @@ void checkMpiFunc(const char* funcName)
     execFuncWithPool(msg, false, 1, true, 10);
 }
 
-TEST_CASE("Test MPI allgather", "[wasm]")
+TEST_CASE("Test MPI allgather", "[mpi]")
 {
     checkMpiFunc("mpi_allgather");
 }
 
-TEST_CASE("Test MPI allreduce", "[wasm]")
+TEST_CASE("Test MPI allreduce", "[mpi]")
 {
     checkMpiFunc("mpi_allreduce");
 }
 
-TEST_CASE("Test MPI alltoall", "[wasm]")
+TEST_CASE("Test MPI alltoall", "[mpi]")
 {
     checkMpiFunc("mpi_alltoall");
 }
 
-TEST_CASE("Test MPI barrier", "[wasm]")
+TEST_CASE("Test MPI barrier", "[mpi]")
 {
     checkMpiFunc("mpi_barrier");
 }
 
-TEST_CASE("Test MPI broadcast", "[wasm]")
+TEST_CASE("Test MPI broadcast", "[mpi]")
 {
     checkMpiFunc("mpi_bcast");
 }
 
-TEST_CASE("Test general MPI functionality", "[wasm]")
+TEST_CASE("Test general MPI functionality", "[mpi]")
 {
     checkMpiFunc("mpi_checks");
 }
 
-TEST_CASE("Test MPI gather", "[wasm]")
+TEST_CASE("Test MPI gather", "[mpi]")
 {
     checkMpiFunc("mpi_gather");
 }
 
-TEST_CASE("Test MPI message ordering", "[wasm]")
+TEST_CASE("Test MPI message ordering", "[mpi]")
 {
     checkMpiFunc("mpi_order");
 }
 
-TEST_CASE("Test MPI one-sided comms", "[wasm]")
+TEST_CASE("Test MPI one-sided comms", "[mpi]")
 {
     checkMpiFunc("mpi_onesided");
 }
 
-TEST_CASE("Test MPI probe", "[wasm]")
+TEST_CASE("Test MPI probe", "[mpi]")
 {
     checkMpiFunc("mpi_probe");
 }
 
-TEST_CASE("Test MPI put", "[wasm]")
+TEST_CASE("Test MPI put", "[mpi]")
 {
     checkMpiFunc("mpi_put");
 }
 
-TEST_CASE("Test MPI reduce", "[wasm]")
+TEST_CASE("Test MPI reduce", "[mpi]")
 {
     checkMpiFunc("mpi_reduce");
 }
 
-TEST_CASE("Test MPI scatter", "[wasm]")
+TEST_CASE("Test MPI scatter", "[mpi]")
 {
     checkMpiFunc("mpi_scatter");
 }
 
-TEST_CASE("Test MPI status", "[wasm]")
+TEST_CASE("Test MPI status", "[mpi]")
 {
     checkMpiFunc("mpi_status");
 }
 
-TEST_CASE("Test MPI type sizes", "[wasm]")
+TEST_CASE("Test MPI type sizes", "[mpi]")
 {
     checkMpiFunc("mpi_typesize");
 }
 
-TEST_CASE("Test MPI window creation", "[wasm]")
+TEST_CASE("Test MPI window creation", "[mpi]")
 {
     checkMpiFunc("mpi_wincreate");
 }
 
-TEST_CASE("Test MPI async", "[wasm]")
+TEST_CASE("Test MPI async", "[mpi]")
 {
     checkMpiFunc("mpi_isendrecv");
 }


### PR DESCRIPTION
As requested, changing the tag for MPI tests which can now be run as:
```
tests [mpi]
```