### PR TITLE
Fix directory listing bug

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,9 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      - name: "ulimits"
-        run: ulimit -a
+      # --- Environment ---
+      - name: "Directory permissions"
+        run: chown -R root:root /usr/local/faasm
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,5 +88,7 @@ jobs:
       - name: "Copy Python functions into place"
         run: inv -r faasmcli/faasmcli upload.user python --py --local-copy
       # --- Test run ---
+      - name: "Just run a the numpy test"
+        run: inv -r faasmcli/faasmcli run python numpy_test
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,13 +51,6 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      # --- Environment ---
-      - name: "CPU info"
-        run: cat /proc/cpuinfo
-      - name: "Get CPU model name"
-        run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
-      - name: "Print CPU model"
-        run: echo ${{ env.CPU_MODEL}}
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch
@@ -65,6 +58,13 @@ jobs:
         run: git checkout --force ci-branch
       - name: "Log commits"
         run: git log -3
+      # --- CPU information ---
+      - name: "CPU info"
+        run: cat /proc/cpuinfo
+      - name: "Get CPU model name"
+        run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
+      - name: "Print CPU model"
+        run: echo ${{ env.CPU_MODEL}}
       # --- Cache ---
       - name: "Configure machine code cache"
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,8 @@ jobs:
         run: ./bin/run_clang_format.sh
       - name: "Check C/C++ formatting changes"
         run: git diff --exit-code
+      - name: "Check weakref is actuall there"
+        run: "ls -al /usr/local/faasm/runtime_root/lib/python3.8/weakref.py"
 
   build:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,6 @@ jobs:
         ports:
           - 6379:6379
     steps:
-      # --- Environment ---
-      - name: "Directory permissions"
-        run: chown -R root:root /usr/local/faasm
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch
@@ -93,11 +90,5 @@ jobs:
       - name: "Clear existing pyc files"
         run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
-      - name: "Run the listdir check"
-        run: inv -r faasmcli/faasmcli run python dir_test
-      - name: "Run the Python language check"
-        run: inv -r faasmcli/faasmcli run python lang_test
-      - name: "Run the the numpy check"
-        run: inv -r faasmcli/faasmcli run python numpy_test
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,7 +91,9 @@ jobs:
       - name: "Copy Python functions into place"
         run: inv -r faasmcli/faasmcli upload.user python --py --local-copy
       # --- Test run ---
-      - name: "Just run a the numpy test"
+      - name: "Run the Python language check"
+        run: inv -r faasmcli/faasmcli run python lang_test
+      - name: "Run the the numpy check"
         run: inv -r faasmcli/faasmcli run python numpy_test
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Get CPU model name"
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
       - name: "Print CPU model"
-        run: echo ${{ env.CPU_MODEL}}
+        run: echo "${{ env.CPU_MODEL}}"
       # --- Cache ---
       - name: "Configure machine code cache"
         uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,8 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      - name: "ulimits"
+        run: ulimit -a
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CGROUP_MODE: off
-      NETNS_MODE: off
       HOST_TYPE: ci
-      REDIS_STATE_HOST: redis
-      REDIS_QUEUE_HOST: redis
       LOG_LEVEL: info
       MAX_FAASLETS: 5
+      NETNS_MODE: off
+      REDIS_QUEUE_HOST: redis
+      REDIS_STATE_HOST: redis
     container:
       image: faasm/cli:0.5.3
     defaults:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,10 +54,10 @@ jobs:
       # --- Environment ---
       - name: "CPU info"
         run: cat /proc/cpuinfo
-      - name: "CPU microcode"
-        run: cat /proc/cpuinfo | grep microcode | uniq
-      - name: "CPU modelname"
-        run: cat /proc/cpuinfo | grep "model name" | uniq
+      - name: "Get CPU model name"
+        run: echo "CPU_MODEL=${cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g'}" >> $GITHUB_ENV
+      - name: "Print CPU model"
+        run: echo ${{ env.CPU_MODEL}}
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch
@@ -66,11 +66,11 @@ jobs:
       - name: "Log commits"
         run: git log -3
       # --- Cache ---
-      - name: "Configure build cache"
+      - name: "Configure machine code cache"
         uses: actions/cache@v2
         with:
           path: /usr/local/faasm/object
-          key: ${{ runner.os }}-cache
+          key: ${{ env.CPU_MODEL }}-machine-code
       # --- Code build ---
       - name: "Build dev tools"
         run: inv -r faasmcli/faasmcli dev.tools --build Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,8 +28,6 @@ jobs:
         run: ./bin/run_clang_format.sh
       - name: "Check C/C++ formatting changes"
         run: git diff --exit-code
-      - name: "Check weakref is actuall there"
-        run: "ls -al /usr/local/faasm/runtime_root/lib/python3.8/weakref.py"
 
   build:
     if: github.event.pull_request.draft == false
@@ -92,6 +90,8 @@ jobs:
         run: inv -r faasmcli/faasmcli python.codegen
       - name: "Copy Python functions into place"
         run: inv -r faasmcli/faasmcli upload.user python --py --local-copy
+      - name: "Clear existing pyc files"
+        run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
       - name: "Run the Python language check"
         run: inv -r faasmcli/faasmcli run python lang_test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "CPU info"
         run: cat /proc/cpuinfo
       - name: "Get CPU model name"
-        run: echo "CPU_MODEL=${cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g'}" >> $GITHUB_ENV
+        run: echo "CPU_MODEL=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g')" >> $GITHUB_ENV
       - name: "Print CPU model"
         run: echo ${{ env.CPU_MODEL}}
       # --- Check out code ---

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,13 @@ jobs:
         ports:
           - 6379:6379
     steps:
+      # --- Environment ---
+      - name: "CPU info"
+        run: cat /proc/cpuinfo
+      - name: "CPU microcode"
+        run: cat /proc/cpuinfo | grep microcode | uniq
+      - name: "CPU modelname"
+        run: cat /proc/cpuinfo | grep "model name" | uniq
       # --- Check out code ---
       - name: "Fetch ref"
         run: git fetch origin ${GITHUB_REF}:ci-branch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "CPU info"
         run: cat /proc/cpuinfo
       - name: "Get CPU model name"
-        run: echo "CPU_MODEL=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g')" >> $GITHUB_ENV
+        run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
       - name: "Print CPU model"
         run: echo ${{ env.CPU_MODEL}}
       # --- Check out code ---

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,8 +81,6 @@ jobs:
       - name: "Compile OMP functions"
         run: inv -r faasmcli/faasmcli compile.user omp
       # --- Environment set-up ---
-      - name: "Set up test lib"
-        run: inv -r faasmcli/faasmcli libs.fake
       - name: "Run codegen"
         run: inv -r faasmcli/faasmcli codegen.local
       - name: "Run python codegen"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       HOST_TYPE: ci
       REDIS_STATE_HOST: redis
       REDIS_QUEUE_HOST: redis
-      LOG_LEVEL: info
+      LOG_LEVEL: debug
       MAX_FAASLETS: 5
     container:
       image: faasm/cli:0.5.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       HOST_TYPE: ci
       REDIS_STATE_HOST: redis
       REDIS_QUEUE_HOST: redis
-      LOG_LEVEL: debug
+      LOG_LEVEL: info
       MAX_FAASLETS: 5
     container:
       image: faasm/cli:0.5.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,8 @@ jobs:
       - name: "Clear existing pyc files"
         run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
+      - name: "Run the listdir check"
+        run: inv -r faasmcli/faasmcli run python dir_test
       - name: "Run the Python language check"
         run: inv -r faasmcli/faasmcli run python lang_test
       - name: "Run the the numpy check"

--- a/bin/print_cpu.sh
+++ b/bin/print_cpu.sh
@@ -2,4 +2,14 @@
 
 set -e
 
-echo "$(cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g')"
+CPU_MODEL=$(cat /proc/cpuinfo | grep 'model name' | uniq)
+
+# Strip special characters
+CPU_MODEL=$(echo "$CPU_MODEL" | sed 's/model name.*: //g')
+CPU_MODEL=$(echo "$CPU_MODEL" | sed 's/ /_/g')
+CPU_MODEL=$(echo "$CPU_MODEL" | sed 's/(/_/g')
+CPU_MODEL=$(echo "$CPU_MODEL" | sed 's/)/_/g')
+CPU_MODEL=$(echo "$CPU_MODEL" | sed 's/@/_/g')
+
+# Print the result
+echo $CPU_MODEL

--- a/bin/print_cpu.sh
+++ b/bin/print_cpu.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+echo "$(cat /proc/cpuinfo | grep 'model name' | uniq | sed 's/model name.*: //g' | sed 's/ /_/g')"

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -20,11 +20,11 @@ services:
     tty: true
     environment:
       - CGROUP_MODE=off
-      - NETNS_MODE=off
       - HOST_TYPE=ci
-      - REDIS_STATE_HOST=redis
-      - REDIS_QUEUE_HOST=redis
       - LOG_LEVEL=info
       - MAX_FAASLETS=5
+      - NETNS_MODE=off
+      - REDIS_STATE_HOST=redis
+      - REDIS_QUEUE_HOST=redis
     depends_on:
       - redis

--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -20,10 +20,11 @@ services:
     tty: true
     environment:
       - CGROUP_MODE=off
+      - NETNS_MODE=off
       - HOST_TYPE=ci
-      - LOG_LEVEL=info
       - REDIS_STATE_HOST=redis
       - REDIS_QUEUE_HOST=redis
+      - LOG_LEVEL=info
       - MAX_FAASLETS=5
     depends_on:
       - redis

--- a/func/python/dir_test.py
+++ b/func/python/dir_test.py
@@ -1,23 +1,18 @@
-import multiprocessing
 import os
 
 
 def faasm_main():
-    print("MP version = {}".format(multiprocessing))
-
     paths = [
-        "/lib/python3.8/multiprocessing/",
-        "/lib/python3.8/multiprocessing/__pycache__/",
+        "/lib/python3.8/",
+        "/lib/python3.8/site-packages/",
     ]
 
     print("CWD = {}".format(os.getcwd()))
 
     for i, p in enumerate(paths):
-        print("Path {}".format(i))
+        print("\nPath {} - {}".format(i, p))
         dirlist = os.listdir(p)
-        print("Dirlist fine = {}".format(dirlist))
-
-        for file in dirlist:
-            print(file)
+        dirlist.sort()
+        print(" ".join(["{}\n".format(d) for d in dirlist]))
 
     return 0

--- a/func/python/dir_test.py
+++ b/func/python/dir_test.py
@@ -1,18 +1,23 @@
 import os
+from pyfaasm.core import get_input, set_output
 
 
 def faasm_main():
-    paths = [
-        "/lib/python3.8/",
-        "/lib/python3.8/site-packages/",
-    ]
+    path = get_input()
 
-    print("CWD = {}".format(os.getcwd()))
+    if not path:
+        print("Input must be a path")
+        return 1
 
-    for i, p in enumerate(paths):
-        print("\nPath {} - {}".format(i, p))
-        dirlist = os.listdir(p)
-        dirlist.sort()
-        print(" ".join(["{}\n".format(d) for d in dirlist]))
+    path = path.decode()
+    print("Path = {}, cwd = {}".format(path, os.getcwd()))
+
+    dirlist = os.listdir(path)
+    dirlist.sort()
+    dir_list_str = ",".join(dirlist)
+
+    print(dir_list_str)
+
+    set_output(bytes(dir_list_str, "utf-8"))
 
     return 0

--- a/func/python/lang_test.py
+++ b/func/python/lang_test.py
@@ -1,6 +1,11 @@
 import sys
 import os
 from decimal import Decimal
+import weakref
+
+
+class SomeClass:
+    pass
 
 
 def faasm_main():
@@ -38,5 +43,12 @@ def faasm_main():
 
     for k, v in d.items():
         print("{}: {} ({})".format(k, v, d[k]))
+
+    # Weakref check
+    c = SomeClass()
+    r = weakref.ref(c)
+    c2 = r()
+    assert c is c2, "Weakref references not equal"
+    print("Weakref check successful")
 
     return 0

--- a/include/faaslet/FaasletPool.h
+++ b/include/faaslet/FaasletPool.h
@@ -19,7 +19,8 @@ class FaasletPool : public FaabricPool
     {
         // Create an enclave if necessary
 #if FAASM_SGX
-        sgx::checkSgxSetup();
+        // 18/11/20 - causing segfault, waiting for PR to be merged to fi
+        // sgx::checkSgxSetup();
 #endif
     }
 

--- a/include/faaslet/FaasletPool.h
+++ b/include/faaslet/FaasletPool.h
@@ -19,7 +19,7 @@ class FaasletPool : public FaabricPool
     {
         // Create an enclave if necessary
 #if FAASM_SGX
-        // 18/11/20 - causing segfault, waiting for PR to be merged to fi
+        // 18/11/20 - causing segfault, waiting for PR to be merged to fix
         // sgx::checkSgxSetup();
 #endif
     }

--- a/include/storage/FileDescriptor.h
+++ b/include/storage/FileDescriptor.h
@@ -41,9 +41,9 @@ ReadWriteType getRwType(uint64_t rights);
 class DirEnt
 {
   public:
-    unsigned int next;
+    uint64_t next;
     uint8_t type;
-    unsigned int ino;
+    uint64_t ino;
     std::string path;
 };
 
@@ -85,6 +85,8 @@ class FileDescriptor
     void iterBack();
 
     void iterReset();
+
+    size_t copyDirentsToWasiBuffer(uint8_t* buffer, size_t bufferLen);
 
     Stat stat(const std::string& relativePath = "");
 
@@ -152,5 +154,8 @@ class FileDescriptor
     bool _iterStarted = false;
     std::vector<DirEnt> directoryContents;
     int directoryIteratorIndex = 0;
+
+    std::vector<uint8_t> directoryContentsBytes;
+    size_t contentBytesOffset = 0;
 };
 }

--- a/include/storage/FileDescriptor.h
+++ b/include/storage/FileDescriptor.h
@@ -136,7 +136,7 @@ class FileDescriptor
   private:
     static FileDescriptor stdFdFactory(int stdFd, const std::string& devPath);
 
-    void loadDirectoryContents();
+    void loadDirContents();
 
     std::string path;
 
@@ -151,11 +151,8 @@ class FileDescriptor
 
     uint16_t wasiErrno = 0;
 
-    bool _iterStarted = false;
-    std::vector<DirEnt> directoryContents;
-    int directoryIteratorIndex = 0;
-
-    std::vector<uint8_t> directoryContentsBytes;
-    size_t contentBytesOffset = 0;
+    bool dirContentsLoaded = false;
+    std::vector<DirEnt> dirContents;
+    int dirContentsIdx = 0;
 };
 }

--- a/include/storage/FileDescriptor.h
+++ b/include/storage/FileDescriptor.h
@@ -104,6 +104,8 @@ class FileDescriptor
     bool iterStarted;
     bool iterFinished;
 
+    void iterBackOne();
+
     uint8_t wasiPreopenType;
 
     int getLinuxFd();
@@ -141,5 +143,8 @@ class FileDescriptor
     int linuxErrno;
 
     uint16_t wasiErrno;
+
+    DirEnt lastDirEnt;
+    bool iterOvershot;
 };
 }

--- a/src/storage/FileDescriptor.cpp
+++ b/src/storage/FileDescriptor.cpp
@@ -239,11 +239,11 @@ void FileDescriptor::loadDirectoryContents()
 
 void FileDescriptor::iterBack()
 {
-    if(!_iterStarted) {
+    if (!_iterStarted) {
         throw std::runtime_error("Iterator not started, cannot go back");
     }
 
-    if(directoryIteratorIndex == 0) {
+    if (directoryIteratorIndex == 0) {
         throw std::runtime_error("Iterator already at zero, cannot go back");
     }
 

--- a/src/wavm/io.cpp
+++ b/src/wavm/io.cpp
@@ -187,7 +187,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(wasi,
 
     storage::FileDescriptor& fileDesc =
       getExecutingWAVMModule()->getFileSystem().getFileDescriptor(fd);
-    
+
     bool isStartCookie = startCookie == __WASI_DIRCOOKIE_START;
     if (fileDesc.iterStarted() && isStartCookie) {
         // Return invalid if we've already started the iterator but also get the

--- a/tests/test/faaslet/test_python.cpp
+++ b/tests/test/faaslet/test_python.cpp
@@ -68,12 +68,12 @@ TEST_CASE("Test python conformance", "[python]")
     checkPythonFunction("lang_test");
 }
 
-TEST_CASE("Test numpy conformance", "[python][!mayfail]")
+TEST_CASE("Test numpy conformance", "[python]")
 {
     checkPythonFunction("numpy_test");
 }
 
-TEST_CASE("Test repeated numpy execution", "[python][!mayfail]")
+TEST_CASE("Test repeated numpy execution", "[python]")
 {
     cleanSystem();
 

--- a/tests/test/faaslet/test_python.cpp
+++ b/tests/test/faaslet/test_python.cpp
@@ -68,7 +68,7 @@ TEST_CASE("Test python state write/ read", "[faaslet]")
     writeCall.set_pythonuser("python");
     writeCall.set_pythonfunction("state_test_write");
     writeCall.set_ispython(true);
-    faaslet::Faaslet faaslet = execFunction(writeCall);
+    execFunction(writeCall);
 
     // Now run the state read function
     faabric::Message readCall =
@@ -76,15 +76,7 @@ TEST_CASE("Test python state write/ read", "[faaslet]")
     readCall.set_pythonuser("python");
     readCall.set_pythonfunction("state_test_read");
     readCall.set_ispython(true);
-
-    // Schedule and execute the next call
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.callFunction(readCall);
-    faaslet.processNextMessage();
-
-    // Check success
-    faabric::Message result = sch.getFunctionResult(readCall.id(), 1);
-    REQUIRE(result.returnvalue() == 0);
+    execFunction(readCall);
 }
 
 TEST_CASE("Test python chaining", "[faaslet]")

--- a/tests/test/faaslet/test_python.cpp
+++ b/tests/test/faaslet/test_python.cpp
@@ -1,4 +1,6 @@
+#include <boost/algorithm/string.hpp>
 #include <catch2/catch.hpp>
+#include <dirent.h>
 
 #include "utils.h"
 
@@ -19,17 +21,59 @@ void checkPythonFunction(const std::string& funcName)
     execFunction(call);
 }
 
-TEST_CASE("Test python conformance", "[faaslet]")
+TEST_CASE("Test Python listdir", "[python]")
+{
+    // We need to list a big enough directory here to catch issues with long
+    // file listings and the underlying syscalls
+    std::string realDir = "/usr/local/faasm/runtime_root/lib/python3.8";
+    std::string wasmDir = "/lib/python3.8";
+
+    cleanSystem();
+
+    // Build the call, passing in the path as input
+    faabric::Message call =
+      faabric::util::messageFactory(PYTHON_USER, PYTHON_FUNC);
+    call.set_pythonuser("python");
+    call.set_pythonfunction("dir_test");
+    call.set_ispython(true);
+    call.set_inputdata(wasmDir);
+
+    // Execute the function
+    execFunction(call);
+    std::string actualOutput = call.outputdata();
+
+    // Split the output into a list
+    std::vector<std::string> wasmList;
+    boost::split(wasmList, actualOutput, [](char c) { return c == ','; });
+
+    // Get the directory listing using stdlib
+    DIR* dir = opendir(realDir.c_str());
+    REQUIRE(dir != nullptr);
+
+    std::vector<std::string> nativeList;
+    struct dirent* ent;
+    while ((ent = readdir(dir)) != nullptr) {
+        nativeList.push_back(ent->d_name);
+    }
+
+    closedir(dir);
+
+    // Check the two listings match
+    REQUIRE(wasmList.size() == nativeList.size());
+    REQUIRE(wasmList == nativeList);
+}
+
+TEST_CASE("Test python conformance", "[python]")
 {
     checkPythonFunction("lang_test");
 }
 
-TEST_CASE("Test numpy conformance", "[faaslet][!mayfail]")
+TEST_CASE("Test numpy conformance", "[python][!mayfail]")
 {
     checkPythonFunction("numpy_test");
 }
 
-TEST_CASE("Test repeated numpy execution", "[faaslet][!mayfail]")
+TEST_CASE("Test repeated numpy execution", "[python][!mayfail]")
 {
     cleanSystem();
 
@@ -42,7 +86,7 @@ TEST_CASE("Test repeated numpy execution", "[faaslet][!mayfail]")
     checkMultipleExecutions(call, 3);
 }
 
-TEST_CASE("Test python echo", "[faaslet]")
+TEST_CASE("Test python echo", "[python]")
 {
     cleanSystem();
 
@@ -58,7 +102,7 @@ TEST_CASE("Test python echo", "[faaslet]")
     REQUIRE(result == input);
 }
 
-TEST_CASE("Test python state write/ read", "[faaslet]")
+TEST_CASE("Test python state write/ read", "[python]")
 {
     cleanSystem();
 
@@ -79,7 +123,7 @@ TEST_CASE("Test python state write/ read", "[faaslet]")
     execFunction(readCall);
 }
 
-TEST_CASE("Test python chaining", "[faaslet]")
+TEST_CASE("Test python chaining", "[python]")
 {
     faabric::Message call =
       faabric::util::messageFactory(PYTHON_USER, PYTHON_FUNC);
@@ -90,7 +134,7 @@ TEST_CASE("Test python chaining", "[faaslet]")
     // execFuncWithPool(call, true, 1);
 }
 
-TEST_CASE("Test python sharing dict", "[faaslet]")
+TEST_CASE("Test python sharing dict", "[python]")
 {
     faabric::Message call =
       faabric::util::messageFactory(PYTHON_USER, PYTHON_FUNC);

--- a/tests/test/faaslet/test_python.cpp
+++ b/tests/test/faaslet/test_python.cpp
@@ -53,9 +53,18 @@ TEST_CASE("Test Python listdir", "[python]")
     std::vector<std::string> nativeList;
     struct dirent* ent;
     while ((ent = readdir(dir)) != nullptr) {
+        std::string dirName(ent->d_name);
+
+        // Python listdir excludes . and ..
+        if (dirName == ".." || dirName == ".") {
+            continue;
+        }
+
         nativeList.push_back(ent->d_name);
     }
 
+    // Sort the native list
+    std::sort(nativeList.begin(), nativeList.end());
     closedir(dir);
 
     // Check the two listings match

--- a/tests/test/module_cache/test_module_cache.cpp
+++ b/tests/test/module_cache/test_module_cache.cpp
@@ -34,8 +34,12 @@ TEST_CASE("Test creating zygotes", "[zygote]")
     REQUIRE(moduleA.isBound());
 
     // Execute the function normally and make sure zygote is not used directly
-    faaslet::Faaslet faaslet = execFunction(msgA);
-    REQUIRE(faaslet.isBound());
+    faaslet::Faaslet faaslet(0);
+    faaslet.bindToFunction(msgA);
+    std::string errorMessage = faaslet.executeCall(msgA);
+    REQUIRE(errorMessage.empty());
+    REQUIRE(msgA.returnvalue() == 0);
+
     REQUIRE(std::addressof(moduleA) != std::addressof(*faaslet.module));
 }
 }

--- a/tests/test/storage/test_file_descriptor.cpp
+++ b/tests/test/storage/test_file_descriptor.cpp
@@ -323,13 +323,12 @@ TEST_CASE("Test readdir iterator and buffer", "[storage]")
         fileDesc.iterReset();
 
         // Make a buffer slightly too small for all of them
-        size_t bufferSize = sizeA + sizeB + sizeC - 10;
-        std::vector<uint8_t> buffer(bufferSize);
+        std::vector<uint8_t> buffer(sizeA + sizeB + sizeC - 10);
 
         // Copy into this buffer
         size_t bytesCopied =
           fileDesc.copyDirentsToWasiBuffer(buffer.data(), buffer.size());
-        REQUIRE(bytesCopied == bufferSize);
+        REQUIRE(bytesCopied == buffer.size());
 
         // Check contents
         checkWasiDirentInBuffer(buffer.data(), entA);

--- a/tests/test/storage/test_file_descriptor.cpp
+++ b/tests/test/storage/test_file_descriptor.cpp
@@ -266,6 +266,7 @@ TEST_CASE("Check directory iterator", "[storage]")
     int step = 3;
     for (int i = 0; i < step; i++) {
         storage::DirEnt ent = fileDesc.iterNext();
+        REQUIRE(ent.next == i + 1);
         REQUIRE(ent.path == expectedList.at(i));
     }
 

--- a/tests/test/wasm/test_cloning.cpp
+++ b/tests/test/wasm/test_cloning.cpp
@@ -231,7 +231,7 @@ TEST_CASE("Test cloned execution on simple module", "[wasm]")
     }
 }
 
-TEST_CASE("Test cloned execution on complex module", "[wasm][!mayfail]")
+TEST_CASE("Test cloned execution on complex module", "[wasm]")
 {
     cleanSystem();
 

--- a/tests/utils/utils.h
+++ b/tests/utils/utils.h
@@ -6,8 +6,8 @@
 namespace tests {
 void cleanSystem();
 
-faaslet::Faaslet execFunction(faabric::Message& msg,
-                              const std::string& expectedOutput = "");
+void execFunction(faabric::Message& msg,
+                  const std::string& expectedOutput = "");
 
 std::string execFunctionWithStringResult(faabric::Message& msg);
 


### PR DESCRIPTION
This addresses a hard-to-diagnose issue which was causing certain Python functions to fail. The bug manifested itself as Python being unable to import `weakref` on some platforms but not others. It came down to an issue where the `__wasi_fd_readdir` implementation would drop one or two directory entries on larger directory listings. Which directories got dropped depended on the ordering of the native `readdir` syscall, hence the bug was platform dependent.

On certain platforms, the `weakref.py` file was dropped from the listing of the `lib/python3.8` dir, hence Python was claiming that the `weakref` module didn't exist. On other platforms, non-essential entries for this dir were dropped, hence Python executed successfully.

This PR restructures the `__wasi_fd_readdir` call to:

- Prefetch the full directory listing behind the scenes (this avoids having two iterators going at once)
- Completely encapsulate the logic for `__wasi_fd_readdir` in the `FileDescriptor` class rather than have it split across two files
- Add more tests for the directory iterator and buffer handling