### PR TITLE
CMake Versioning Hot-Fix

### DIFF
--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -6,6 +6,7 @@ include (FetchContent)
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
 
 # Tightly-coupled dependencies
+set(FETCHCONTENT_QUIET OFF)
 FetchContent_Declare(wavm_ext
     GIT_REPOSITORY "https://github.com/faasm/WAVM.git"
     GIT_TAG "faasm"
@@ -21,8 +22,7 @@ FetchContent_Declare(wamr_ext
 
 FetchContent_Declare(faabric_ext
     GIT_REPOSITORY "https://github.com/faasm/faabric.git"
-    GIT_TAG "v0.0.13"
-    UPDATE_COMMAND ""
+    GIT_TAG "3e8886281dca4c020bf943fa39fc3ebbd30607f6"
     CMAKE_ARGS "-DFAABRIC_BUILD_TESTS=OFF"
 )
 

--- a/libs/faasmpi/CMakeLists.txt
+++ b/libs/faasmpi/CMakeLists.txt
@@ -30,8 +30,7 @@ if (FAASM_BUILD_TYPE STREQUAL "wasm")
     # TODO - split Faabric MPI library out into a separate repo 
     FetchContent_Declare(faabric_ext
         GIT_REPOSITORY "https://github.com/faasm/faabric.git"
-        GIT_TAG "v0.0.13"
-        UPDATE_COMMAND ""
+        GIT_TAG "3e8886281dca4c020bf943fa39fc3ebbd30607f6"
         CMAKE_ARGS "-DFAABRIC_BUILD_TESTS=OFF"
     )
 


### PR DESCRIPTION
Disabling the update command as suggested in #360 , doesn't error out when fetching bexause it simply does nothing at all. This was my mistake as, when the tests passed, I completely overlooked what was going under the hood.

In essence, the update command `fetch + checkout` to a specific tag. If we skip the `UPDATE` step, we do nothing at all and hence use the version that's already in place. I just encountered this issue when trying to merge #351 and setting the `FETCHCONTENT_QUIET OFF` in `CMake`.

In the end I've decided to go with commit hashes. I mentioned before that this won't work, but that's because I was trying with hashes corresponding to tags, which were not fetched at all. Changing to a different hash (current `origin/master`) makes it work.

This time I'll do things properly and, prior to merging this branch, will rebase the one from #351 on top of this one and make sure tests pass.