### PR TITLE
Temporary fix for missing intrinsics

### DIFF
--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -548,4 +548,40 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
         return 0;
     }
 }
+
+// 02/12/20 - unfortunately some old Python wasm still needs this
+// Emulator API, should not be called from wasm but needs to be present for
+// linking
+WAVM_DEFINE_INTRINSIC_FUNCTION(env,
+                               "setEmulatedMessageFromJson",
+                               I32,
+                               setEmulatedMessageFromJson,
+                               I32 msgPtr)
+{
+    faabric::util::getLogger()->debug("S - setEmulatedMessageFromJson - {}",
+                                      msgPtr);
+    throw std::runtime_error(
+      "Should not be calling emulator functions from wasm");
+}
+
+WAVM_DEFINE_INTRINSIC_FUNCTION(env,
+                               "emulatorGetAsyncResponse",
+                               I32,
+                               emulatorGetAsyncResponse)
+{
+    faabric::util::getLogger()->debug("S - emulatorGetAsyncResponse");
+    throw std::runtime_error(
+      "Should not be calling emulator functions from wasm");
+}
+
+WAVM_DEFINE_INTRINSIC_FUNCTION(env,
+                               "emulatorSetCallStatus",
+                               void,
+                               emulatorSetCallStatus,
+                               I32 success)
+{
+    faabric::util::getLogger()->debug("S - emulatorSetCallStatus {}", success);
+    throw std::runtime_error(
+      "Should not be calling emulator functions from wasm");
+}
 }


### PR DESCRIPTION
Apparently some Python libraries still reference the emulator intrinsics removed in #370 