### PR TITLE
Fine-grained trigger control for running the tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,14 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    types: 
+      - assigned
+      - opened
+      - edited
+      - syncrhonize
+      - reopened
+      - ready_for_review
+      - review_requested
 
 jobs:
   formatting:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,13 +6,10 @@ on:
   pull_request:
     branches: [master]
     types: 
-      - assigned
       - opened
-      - edited
       - syncrhonize
       - reopened
       - ready_for_review
-      - review_requested
 
 jobs:
   formatting:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
     branches: [master]
     types: 
       - opened
+      - edited
       - syncrhonize
       - reopened
       - ready_for_review

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    types: 
-      - opened
-      - edited
-      - syncrhonize
-      - reopened
-      - ready_for_review
+    types: [opened, syncrhonize, reopened, ready_for_review]
 
 jobs:
   formatting:


### PR DESCRIPTION
This PR updates the workflow files, so that we have a greater control on when the tests are triggered. Before, moving a PR from `Draft` to `Ready for review` did not tirgger the tests, what was causing some of them to be skipped, and could potentially lead to a broken `master`.

The complete list of triggers can be found [here](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request). For the moment I've included those that sounded more reasonable to me. If they are too coarse or trigger too often, we can modify the list. Note that after the event is triggered, the PR needs not to be `draft` as otherwise the `if` condition will fail and hence the tests skipped.

According to [this](https://github.community/t/trigger-workflow-for-a-pull-request-and-for-all-subsequent-commits-in-it/17996), the default behaviour for the `pull_request` trigger is `[opened, synchronize, reopened]` so just adding `ready_for_review` might be just about it for our current needs.