### PR TITLE
Update clang-tidy to run on single file

### DIFF
--- a/bin/run_clang_tidy.sh
+++ b/bin/run_clang_tidy.sh
@@ -4,27 +4,51 @@ set -e
 
 BUILD_PATH=/build/faasm/
 CONFIG=${FAASM_ROOT}/.clang-tidy
+DUMP_OUTPUT=true
 
-FILES=$(git ls-files {func,libs,src,tests}/{"*.h","*.cpp","*.c"})
+# Function to actually run clang-tidy
+function do_tidy {
+    FILES="($@)"
+    echo "Running on $FILES"
+    run-clang-tidy-10.py \
+        -config '' \
+        -j `nproc` \
+        -fix \
+        -format \
+        -style 'file' \
+        -p ${BUILD_PATH} \
+        -quiet \
+        ${FILES}
+}
 
-if [ -z "$1" ]; then
-    :
-else
+# Support passing a file, directory or nothing
+if [ -f "$1" ]; then
+    echo "Running on file $1"
+    FILES=($1)
+
+    # Assume we want to see output if running on a single file
+    unset DUMP_OUTPUT
+
+elif [ -d "$1" ]; then
     pushd $1 >> /dev/null
+    echo "Running on directory $1"
     FILES=$(git ls-files {"*.h","*.cpp","*.c"})
+
+elif [ -z "$1" ]; then
+    echo "Running on cwd at $(pwd)"
+    FILES=$(git ls-files {func,libs,src,tests}/{"*.h","*.cpp","*.c"})
+
+else
+    echo "First argument must be a file or directory"
+    exit 1
 fi
 
-# Run clang-tidy on a set of files
-run-clang-tidy-10.py \
-    -config '' \
-    -j `nproc` \
-    -fix \
-    -format \
-    -style 'file' \
-    -p ${BUILD_PATH} \
-    -extra-arg-before='-I/usr/local/faasm/native/include' \
-    -quiet \
-    ${FILES} > /dev/null
+# Dump output or not
+if [ -z "$DUMP_OUTPUT" ]; then
+    do_tidy ${FILES[@]}
+else
+    do_tidy ${FILES[@]} > /dev/null
+fi
 
 popd >> /dev/null || true
 

--- a/bin/run_clang_tidy.sh
+++ b/bin/run_clang_tidy.sh
@@ -9,7 +9,6 @@ DUMP_OUTPUT=true
 # Function to actually run clang-tidy
 function do_tidy {
     FILES="($@)"
-    echo "Running on $FILES"
     run-clang-tidy-10.py \
         -config '' \
         -j `nproc` \


### PR DESCRIPTION
I had a problem with a clang-tidy file in the build that wasn't showing up in my local env, so I needed to run clang-tidy from the actual build container on a single file, and have it report the issues (rather than pipe the output to `/dev/null`). 

To do this, I modified the script to support accepting a single file, in which case it won't pipe the `clang-tidy` output to `/dev/null` (but it will continue to do so for directories or no argument).

Unfortunately I couldn't find a nice way to do the condition "if this then pipe", so I had to put the `clang-tidy` bit in a function that accepts an array input.