### PR TITLE
Adding ld_library_path for pool runner

### DIFF
--- a/docker/worker.dockerfile
+++ b/docker/worker.dockerfile
@@ -19,5 +19,5 @@ RUN groupadd -g 1000 faasm
 RUN useradd -u 1000 -g 1000 faasm
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD "/build/faasm/bin/pool_runner"
+CMD "LD_LIBRARY_PATH=/usr/local/lib /build/faasm/bin/pool_runner"
 


### PR DESCRIPTION
Right now the worker container fails to start as it can't find `libpistache.so.0` which is in `/usr/local/lib`.

I realized when trying to run faasm in `knative`.

Note how we can't catch this in `docker-compose` as we update the `LD_LIBRARY_PATH` in the config file.