### PR TITLE
Update kubernetes and knative logic

### DIFF
--- a/bin/knative_route.sh
+++ b/bin/knative_route.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-FUNC_HEADER=$(kn service describe faasm-worker -o url -n faasm | cut -c 8-)
 
 set -e
+
+KNATIVE_HOST=$(kn service describe faasm-worker -o url -n faasm | cut -c 8-)
 
 function service_ip {
     local svc_ns=$1
@@ -44,5 +45,6 @@ echo "invoke_host = ${ISTIO_IP}"
 echo "invoke_port = ${ISTIO_PORT}"
 echo "upload_host = ${UPLOAD_IP}"
 echo "upload_port = ${UPLOAD_PORT}"
+echo "knative_host = ${KNATIVE_HOST}"
 echo ""
 

--- a/bin/knative_route.sh
+++ b/bin/knative_route.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-FUNC_HEADER=faasm-worker.faasm.example.com
+FUNC_HEADER=$(kn service describe faasm-worker -o url -n faasm | cut -c 8-)
 
 set -e
 

--- a/bin/knative_route.sh
+++ b/bin/knative_route.sh
@@ -30,7 +30,7 @@ UPLOAD_PORT=8002
 echo ""
 echo "-----        Invoke        -----"
 echo ""
-echo "curl -H 'Host: ${FUNC_HEADER}' http://${ISTIO_IP}"
+echo "curl -H 'Host: ${KNATIVE_HOST}' http://${ISTIO_IP}"
 
 echo ""
 echo "-----        Upload        -----"

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -30,21 +30,10 @@ To set up Faasm on [GKE](https://console.cloud.google.com/kubernetes) you can do
 To set up Faasm on AKS, you can do the following:
 - Set up an account and install the [`az`](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) client.
 - Create a resource group with sufficient quota.
-- Run:
-```bash
-az aks create \
-    --resource-group <YOUR_RESOURCE_GROUP> \
-    --name <CLUSTER_NAME> \
-    --node-count <CLUSTER_NODE_COUNT> \
-    --node-vm-size <VM_SIZE> \
-    --generate-ssh-keys
-```
-- Lastly, to update your local config run:
-```bash
-az aks get-credentials \
-    --resource-group <YOUR_RESOURCE_GROUP> \
-    --name <CLUSTER_NAME>
-```
+- Create an AKS cluster under said resource group.
+- Aim for >=4 nodes with more than one vCPU
+- Set up the local `kubectl` via the `get credentials` command
+- Install Knative as described below
 
 ### Bare metal
 
@@ -72,7 +61,7 @@ If you are running a local cluster or one on AKS, you will have to update the `e
 field in the `upload-service.yml`.
 You can query it with:
 ```bash
-kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+./bin/knative_route.sh
 ```
 
 ### Faasm

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -59,10 +59,7 @@ kubectl get pods -n knative-serving
 
 If you are running a local cluster or one on AKS, you will have to update the `externalIPs`
 field in the `upload-service.yml`.
-You can query it with:
-```bash
-./bin/knative_route.sh
-```
+You can query it with `./bin/knative_route.sh` (it corresponds to `invoke_host`)
 
 ### Faasm
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -25,6 +25,27 @@ To set up Faasm on [GKE](https://console.cloud.google.com/kubernetes) you can do
 - Check things are working by running `kubectl get nodes`
 - Install Knative serving as described below
 
+### Azure Kubernetes Service
+
+To set up Faasm on AKS, you can do the following:
+- Set up an account and install the [`az`](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) client.
+- Create a resource group with sufficient quota.
+- Run:
+```bash
+az aks create \
+    --resource-group <YOUR_RESOURCE_GROUP> \
+    --name <CLUSTER_NAME> \
+    --node-count <CLUSTER_NODE_COUNT> \
+    --node-vm-size <VM_SIZE> \
+    --generate-ssh-keys
+```
+- Lastly, to update your local config run:
+```bash
+az aks get-credentials \
+    --resource-group <YOUR_RESOURCE_GROUP> \
+    --name <CLUSTER_NAME>
+```
+
 ### Bare metal
 
 If you're deploying on a bare-metal cluster then you need to update the `externalIPs` 
@@ -45,7 +66,14 @@ inv knative.install
 
 # Check
 kubectl get pods -n knative-serving
-```  
+```
+
+If you are running a local cluster or one on AKS, you will have to update the `externalIPs`
+field in the `upload-service.yml`.
+You can query it with:
+```bash
+kubectl get svc istio-ingressgateway -n istio-system -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
 
 ### Faasm
 

--- a/faasmcli/faasmcli/tasks/knative.py
+++ b/faasmcli/faasmcli/tasks/knative.py
@@ -13,7 +13,7 @@ BARE_METAL_REMOTE_CONF = join(K8S_DIR, "bare-metal-remote")
 LOCAL_CONF = join(K8S_DIR, "local")
 COMMON_CONF = join(K8S_DIR, "common")
 
-KNATIVE_VERSION = "0.13.0"
+KNATIVE_VERSION = "0.21.0"
 
 # Number of replicas in the Faasm worker pod
 DEFAULT_REPLICAS = 4
@@ -238,15 +238,40 @@ def _deploy_knative_fn(
 
 @task
 def install(ctx):
+    """
+    Install knative on an existing k8s cluster
+    """
     specs = [
-        "serving-crds.yaml",
-        "serving-core.yaml",
-        "serving-istio.yaml",
+        ["knative/serving", "serving-crds.yaml"],
+        ["knative/serving", "serving-core.yaml"],
+        ["knative/net-istio", "istio.yaml"],
+        ["knative/net-istio", "net-istio.yaml"],
+        ["knative/serving", "serving-default-domain.yaml"],
     ]
 
     for s in specs:
         _kubectl_apply(
-            "https://github.com/knative/serving/releases/download/v{}/{}".format(
-                KNATIVE_VERSION, s
+            "https://github.com/{}/releases/download/v{}/{}".format(
+                s[0], KNATIVE_VERSION, s[1]
+            )
+        )
+
+
+@task
+def uninstall(ctx):
+    """
+    Uninstall knative from an existing k8s cluster
+    """
+    specs = [
+        ["knative/net-istio", "net-istio.yaml"],
+        ["knative/net-istio", "istio.yaml"],
+        ["knative/serving", "serving-core.yaml"],
+        ["knative/serving", "serving-crds.yaml"],
+    ]
+
+    for s in specs:
+        _kubectl_delete(
+            "https://github.com/{}/releases/download/v{}/{}".format(
+                s[0], KNATIVE_VERSION, s[1]
             )
         )

--- a/faasmcli/faasmcli/tasks/knative.py
+++ b/faasmcli/faasmcli/tasks/knative.py
@@ -14,6 +14,14 @@ LOCAL_CONF = join(K8S_DIR, "local")
 COMMON_CONF = join(K8S_DIR, "common")
 
 KNATIVE_VERSION = "0.21.0"
+KNATIVE_SPECS = [
+    ["knative/serving", "serving-crds.yaml"],
+    ["knative/serving", "serving-core.yaml"],
+    ["knative/net-istio", "istio.yaml"],
+    ["knative/net-istio", "net-istio.yaml"],
+    ["knative/serving", "serving-default-domain.yaml"],
+]
+
 
 # Number of replicas in the Faasm worker pod
 DEFAULT_REPLICAS = 4
@@ -241,15 +249,7 @@ def install(ctx):
     """
     Install knative on an existing k8s cluster
     """
-    specs = [
-        ["knative/serving", "serving-crds.yaml"],
-        ["knative/serving", "serving-core.yaml"],
-        ["knative/net-istio", "istio.yaml"],
-        ["knative/net-istio", "net-istio.yaml"],
-        ["knative/serving", "serving-default-domain.yaml"],
-    ]
-
-    for s in specs:
+    for s in KNATIVE_SPECS:
         _kubectl_apply(
             "https://github.com/{}/releases/download/v{}/{}".format(
                 s[0], KNATIVE_VERSION, s[1]
@@ -262,14 +262,9 @@ def uninstall(ctx):
     """
     Uninstall knative from an existing k8s cluster
     """
-    specs = [
-        ["knative/net-istio", "net-istio.yaml"],
-        ["knative/net-istio", "istio.yaml"],
-        ["knative/serving", "serving-core.yaml"],
-        ["knative/serving", "serving-crds.yaml"],
-    ]
-
-    for s in specs:
+    # We delete in the reverse order we apply, and the last component
+    # needs not to be deleted.
+    for s in reversed(KNATIVE_SPECS[:-1]):
         _kubectl_delete(
             "https://github.com/{}/releases/download/v{}/{}".format(
                 s[0], KNATIVE_VERSION, s[1]

--- a/faasmcli/faasmcli/util/call.py
+++ b/faasmcli/faasmcli/util/call.py
@@ -2,21 +2,13 @@ from time import sleep
 
 from faasmcli.util.env import PYTHON_USER, PYTHON_FUNC, FAABRIC_MSG_TYPE_FLUSH
 from faasmcli.util.http import do_post
-from faasmcli.util.endpoints import get_invoke_host_port
+from faasmcli.util.endpoints import get_invoke_host_port, get_knative_headers
 
 STATUS_SUCCESS = "SUCCESS"
 STATUS_FAILED = "FAILED"
 STATUS_RUNNING = "RUNNING"
 
 POLL_INTERVAL_MS = 1000
-
-
-def _get_knative_headers(func_name):
-    func_name = func_name.replace("_", "-")
-    cmd = "kn service describe faasm-{} -o url -n faasm".format(func_name)
-    url = check_output(cmd, shell=True).decode("utf-8").strip()[7:]
-
-    return {"Host": "{}".format(url)}
 
 
 def _do_invoke(user, func, host, port, func_type, input=None):
@@ -124,7 +116,7 @@ def invoke_impl(
 
     # Knative must pass custom headers
     if knative:
-        headers = _get_knative_headers("worker")
+        headers = get_knative_headers()
     else:
         headers = {}
 
@@ -181,6 +173,6 @@ def _do_single_call(host, port, msg, quiet):
         url += ":{}/".format(port)
 
     # If wasm, can always use the faasm worker for getting status
-    headers = _get_knative_headers("worker")
+    headers = get_knative_headers()
 
     return do_post(url, msg, headers=headers, quiet=quiet, json=True)

--- a/faasmcli/faasmcli/util/call.py
+++ b/faasmcli/faasmcli/util/call.py
@@ -13,8 +13,10 @@ POLL_INTERVAL_MS = 1000
 
 def _get_knative_headers(func_name):
     func_name = func_name.replace("_", "-")
+    cmd = "kn service describe faasm-{} -o url -n faasm".format(func_name)
+    url = check_output(cmd, shell=True).decode("utf-8").strip()[7:]
 
-    return {"Host": "faasm-{}.faasm.example.com".format(func_name)}
+    return {"Host": "{}".format(url)}
 
 
 def _do_invoke(user, func, host, port, func_type, input=None):

--- a/faasmcli/faasmcli/util/endpoints.py
+++ b/faasmcli/faasmcli/util/endpoints.py
@@ -37,4 +37,3 @@ def get_knative_headers():
     host = _get_config_value("KNATIVE_HOST", "knative_host", "example.com")
 
     return {"Host": "{}".format(host)}
-

--- a/faasmcli/faasmcli/util/endpoints.py
+++ b/faasmcli/faasmcli/util/endpoints.py
@@ -31,3 +31,10 @@ def get_invoke_host_port():
     port = _get_config_value("INVOKE_PORT", "invoke_port", 8080)
 
     return host, port
+
+
+def get_knative_headers():
+    host = _get_config_value("KNATIVE_HOST", "knative_host", "example.com")
+
+    return {"Host": "{}".format(host)}
+

--- a/faasmcli/faasmcli/util/env.py
+++ b/faasmcli/faasmcli/util/env.py
@@ -30,7 +30,7 @@ FAASM_INSTALL_DIR = "/usr/local"
 
 FAASM_BUILD_DIR = _get_dir("FAASM_BUILD_DIR", "/build/faasm")
 
-FAASM_CONFIG_FILE = join(FAASM_HOME, "faasm.ini")
+FAASM_CONFIG_FILE = join(PROJ_ROOT, "faasm.ini")
 
 BENCHMARK_BUILD = join(HOME_DIR, "faasm", "bench")
 RESULT_DIR = join(FAASM_HOME, "results")


### PR DESCRIPTION
This PR now contains the necessary changes to move from `knative` `0.13.0` to `0.21.0`. This was needed as the original installation scripts weren't working.

I also include an extra file in the `faasm.ini` to contain the `host` file which may change depending on the underlying hardware.

Afer merging, updating the `faasm.ini` and running:
```
inv upload demo hello
inv invoke demo hello
```
should run as expected.