### PR TITLE
Adding ld_library_path for upload pod in k8s deployment

### DIFF
--- a/deploy/k8s/bare-metal/upload-pod.yml
+++ b/deploy/k8s/bare-metal/upload-pod.yml
@@ -28,3 +28,5 @@ spec:
           value: "off"
         - name: STATE_MODE
           value: "redis"
+        - name: LD_LIBRARY_PATH
+          value: "/build/faasm/third-party/lib:/usr/local/lib"


### PR DESCRIPTION
I had this change in my local copy of the `deploy` files, but the merge process in faasm/experiment-base#5 makes it necessary to push them upstream.