### PR TITLE
Add CPP toolchain to initial set-up

### DIFF
--- a/bin/refresh_local.sh
+++ b/bin/refresh_local.sh
@@ -10,7 +10,9 @@ PROJ_ROOT=${THIS_DIR}/..
 pushd ${PROJ_ROOT} >> /dev/null
 
 FAASM_VERSION=$(cat VERSION)
+CPP_VERSION=$(cat clients/cpp/VERSION)
 IMAGE_TAG=faasm/cli:${FAASM_VERSION}
+CPP_IMAGE_TAG=faasm/cpp-sysroot:${CPP_VERSION}
 
 # This path needs to be absolute with no ..s
 TARGET_DIR=$(pwd)/dev/faasm-local
@@ -24,11 +26,19 @@ docker run -i\
     /bin/bash -c "rm -rf /tmp/localcp/*"
 
 # This command mounts the faasm-local dir from this repo to a temp location,
-# then copies in the contents of /usr/local/faasm
+# then copies in the contents of /usr/local/faasm from the relevant containers
 echo "Populating ${TARGET_DIR} from ${SOURCE_DIR} in ${IMAGE_TAG}"
 docker run -i\
     -v ${TARGET_DIR}:/tmp/localcp \
     ${IMAGE_TAG} \
+    /bin/bash -c "cp -r /usr/local/faasm/* /tmp/localcp/"
+    
+# This command mounts the faasm-local dir from this repo to a temp location,
+# then copies in the contents of /usr/local/faasm
+echo "Populating ${TARGET_DIR} from ${SOURCE_DIR} in ${CPP_IMAGE_TAG}"
+docker run -i\
+    -v ${TARGET_DIR}:/tmp/localcp \
+    ${CPP_IMAGE_TAG} \
     /bin/bash -c "cp -r /usr/local/faasm/* /tmp/localcp/"
 
 popd >> /dev/null

--- a/bin/refresh_local.sh
+++ b/bin/refresh_local.sh
@@ -19,8 +19,11 @@ pushd ${PROJ_ROOT} >> /dev/null
 
 FAASM_VERSION=$(cat VERSION)
 CPP_VERSION=$(cat clients/cpp/VERSION)
+PY_VERSION=$(cat clients/python/VERSION)
+
 IMAGE_TAG=faasm/cli:${FAASM_VERSION}
 CPP_IMAGE_TAG=faasm/cpp-sysroot:${CPP_VERSION}
+PY_IMAGE_TAG=faasm/cpython:${PY_VERSION}
 
 # This path needs to be absolute with no ..s
 TARGET_DIR=$(pwd)/dev/faasm-local
@@ -37,20 +40,18 @@ else
         /bin/bash -c "rm -rf /tmp/localcp/*"
 fi
 
-# This command mounts the faasm-local dir from this repo to a temp location,
-# then copies in the contents of /usr/local/faasm from the relevant containers
-echo "Populating ${TARGET_DIR} from ${SOURCE_DIR} in ${IMAGE_TAG}"
-docker run -i\
-    -v ${TARGET_DIR}:/tmp/localcp \
-    ${IMAGE_TAG} \
-    /bin/bash -c "cp -r /usr/local/faasm/* /tmp/localcp/"
-    
-# This command mounts the faasm-local dir from this repo to a temp location,
-# then copies in the contents of /usr/local/faasm
-echo "Populating ${TARGET_DIR} from ${SOURCE_DIR} in ${CPP_IMAGE_TAG}"
-docker run -i\
-    -v ${TARGET_DIR}:/tmp/localcp \
-    ${CPP_IMAGE_TAG} \
-    /bin/bash -c "cp -r /usr/local/faasm/* /tmp/localcp/"
+# This function mounts the faasm-local dir from this repo to a temp location,
+# then copies in the contents of /usr/local/faasm from the relevant container
+function pop_local {
+    echo "Populating ${TARGET_DIR} from ${SOURCE_DIR} in $1"
+    docker run -i\
+        -v ${TARGET_DIR}:/tmp/localcp \
+        $1 \
+        /bin/bash -c "cp -r /usr/local/faasm/* /tmp/localcp/"
+}
+
+pop_local ${IMAGE_TAG}
+pop_local ${CPP_IMAGE_TAG}
+pop_local ${PY_IMAGE_TAG}
 
 popd >> /dev/null

--- a/bin/refresh_local.sh
+++ b/bin/refresh_local.sh
@@ -7,6 +7,14 @@ PROJ_ROOT=${THIS_DIR}/..
 # Pulls the /usr/local/faasm directory from the current Faasm CLI
 # -----------------------------------------
 
+while getopts :d option
+do
+case "${option}"
+in
+d) CLEAN="ON";;
+esac
+done
+
 pushd ${PROJ_ROOT} >> /dev/null
 
 FAASM_VERSION=$(cat VERSION)
@@ -18,12 +26,16 @@ CPP_IMAGE_TAG=faasm/cpp-sysroot:${CPP_VERSION}
 TARGET_DIR=$(pwd)/dev/faasm-local
 SOURCE_DIR=/usr/local/faasm
 
-# We use docker to clear out the existing dir so that it has the right perms
-echo "Nuking existing dir"
-docker run -i\
-    -v ${TARGET_DIR}:/tmp/localcp \
-    ${IMAGE_TAG} \
-    /bin/bash -c "rm -rf /tmp/localcp/*"
+if [ -z $CLEAN ]; then
+    echo "Not cleaning existing dir"
+else
+    # We use docker to clear out the existing dir so that it has the right perms
+    echo "Cleaning existing dir"
+    docker run -i\
+        -v ${TARGET_DIR}:/tmp/localcp \
+        ${IMAGE_TAG} \
+        /bin/bash -c "rm -rf /tmp/localcp/*"
+fi
 
 # This command mounts the faasm-local dir from this repo to a temp location,
 # then copies in the contents of /usr/local/faasm from the relevant containers

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,6 +34,12 @@ can initialise with:
 ./bin/refresh_local.sh
 ```
 
+If you want to nuke your existing `dev/faasm-local` in the process:
+
+```
+./bin/refresh_local.sh -d
+```
+
 It may also be useful to run Python scripts outside the containerised 
 environments, for which you can set up a suitable Python virtual envrionment 
 with:


### PR DESCRIPTION
Rather than nuking the directory before running, the script now gives you the option to do so (default off). It also copies in the useful stuff from CPP and python containers.