### PR TITLE
Move in Faasm-specific config from Faabric

### DIFF
--- a/include/conf/FaasmConfig.h
+++ b/include/conf/FaasmConfig.h
@@ -6,11 +6,28 @@ namespace conf {
 class FaasmConfig
 {
   public:
-    // Threading
-    int moduleThreadPoolSize;
+    std::string hostType;
+    std::string functionStorage;
+    std::string fileserverUrl;
+
+    std::string cgroupMode;
+    std::string netNsMode;
+
+    std::string pythonPreload;
+    std::string captureStdout;
+
+    int chainedCallTimeout;
+
+    std::string wasmVm;
+
+    // Filesystem storage
+    std::string functionDir;
+    std::string objectFileDir;
+    std::string runtimeFilesDir;
+    std::string sharedFilesDir;
+    std::string sharedFilesStorageDir;
 
     FaasmConfig();
-
     void reset();
 
   private:

--- a/include/conf/FaasmConfig.h
+++ b/include/conf/FaasmConfig.h
@@ -20,7 +20,6 @@ class FaasmConfig
 
     std::string wasmVm;
 
-    // Filesystem storage
     std::string functionDir;
     std::string objectFileDir;
     std::string runtimeFilesDir;

--- a/include/conf/function_utils.h
+++ b/include/conf/function_utils.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <faabric/proto/faabric.pb.h>
+#include <faabric/util/exception.h>
+#include <string>
+#include <vector>
+
+#define SHARED_FILE_PREFIX "faasm://"
+
+#define SHARED_OBJ_EXT ".o"
+
+#define PYTHON_USER "python"
+#define PYTHON_FUNC "py_func"
+#define PYTHON_FUNC_DIR "pyfuncs"
+
+namespace conf {
+std::string getFunctionKey(const faabric::Message& msg);
+
+std::string getFunctionObjectKey(const faabric::Message& msg);
+
+std::string getFunctionUrl(const faabric::Message& msg);
+
+std::string getFunctionObjectUrl(const faabric::Message& msg);
+
+std::string getPythonFunctionUrl(const faabric::Message& msg);
+
+std::string getSharedObjectUrl();
+
+std::string getSharedObjectObjectUrl();
+
+std::string getSharedFileUrl();
+
+std::string getFunctionFile(const faabric::Message& msg);
+
+std::string getEncryptedFunctionFile(const faabric::Message& msg);
+
+std::string getPythonFunctionFile(const faabric::Message& msg);
+
+std::string getPythonFunctionFileSharedPath(const faabric::Message& msg);
+
+std::string getPythonRuntimeFunctionFile(const faabric::Message& msg);
+
+std::string getFunctionSymbolsFile(const faabric::Message& msg);
+
+std::string getFunctionObjectFile(const faabric::Message& msg);
+
+std::string getFunctionAotFile(const faabric::Message& msg);
+
+std::string getSharedObjectObjectFile(const std::string& realPath);
+
+std::string getSharedFileFile(const std::string& path);
+
+bool isValidFunction(const faabric::Message& msg);
+
+void convertMessageToPython(faabric::Message& msg);
+
+class InvalidFunctionException : public faabric::util::FaabricException
+{
+  public:
+    explicit InvalidFunctionException(std::string message)
+      : FaabricException(std::move(message))
+    {}
+};
+}

--- a/include/storage/LocalFileLoader.h
+++ b/include/storage/LocalFileLoader.h
@@ -74,4 +74,4 @@ class LocalFileLoader : public FileLoader
     void writeHashForFile(const std::string& path,
                           const std::vector<uint8_t>& hash);
 };
-};
+}

--- a/src/conf/CMakeLists.txt
+++ b/src/conf/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories(
 set(LIB_FILES
         "${FAASM_INCLUDE_DIR}/conf/FaasmConfig.h"
         FaasmConfig.cpp
+        function_utils.cpp
         )
 
 faasm_private_lib(conf "${LIB_FILES}")

--- a/src/conf/FaasmConfig.cpp
+++ b/src/conf/FaasmConfig.cpp
@@ -31,7 +31,6 @@ void FaasmConfig::initialise()
     wasmVm = getEnvVar("WASM_VM", "wavm");
     chainedCallTimeout = this->getIntParam("CHAINED_CALL_TIMEOUT", "300000");
 
-    // Filesystem storage
     std::string faasmLocalDir =
       getEnvVar("FAASM_LOCAL_DIR", "/usr/local/faasm");
     functionDir = fmt::format("{}/{}", faasmLocalDir, "wasm");

--- a/src/conf/FaasmConfig.cpp
+++ b/src/conf/FaasmConfig.cpp
@@ -1,5 +1,8 @@
 #include <conf/FaasmConfig.h>
 #include <faabric/util/environment.h>
+#include <faabric/util/logging.h>
+
+using namespace faabric::util;
 
 namespace conf {
 FaasmConfig& getFaasmConfig()
@@ -15,14 +18,27 @@ FaasmConfig::FaasmConfig()
 
 void FaasmConfig::initialise()
 {
-    // Threads
-    moduleThreadPoolSize = this->getIntParam("FAASM_THREAD_POOL_SIZE", "0");
-    if (moduleThreadPoolSize == 0) {
-        // Thread pool should be one less than number of cores as main thread
-        // executes as well. Always need at least 1
-        moduleThreadPoolSize =
-          std::max<int>(faabric::util::getUsableCores() - 1, 1);
-    }
+    hostType = getEnvVar("HOST_TYPE", "default");
+    functionStorage = getEnvVar("FUNCTION_STORAGE", "local");
+    fileserverUrl = getEnvVar("FILESERVER_URL", "");
+
+    cgroupMode = getEnvVar("CGROUP_MODE", "on");
+    netNsMode = getEnvVar("NETNS_MODE", "off");
+
+    pythonPreload = getEnvVar("PYTHON_PRELOAD", "off");
+    captureStdout = getEnvVar("CAPTURE_STDOUT", "off");
+
+    wasmVm = getEnvVar("WASM_VM", "wavm");
+    chainedCallTimeout = this->getIntParam("CHAINED_CALL_TIMEOUT", "300000");
+
+    // Filesystem storage
+    std::string faasmLocalDir =
+      getEnvVar("FAASM_LOCAL_DIR", "/usr/local/faasm");
+    functionDir = fmt::format("{}/{}", faasmLocalDir, "wasm");
+    objectFileDir = fmt::format("{}/{}", faasmLocalDir, "object");
+    runtimeFilesDir = fmt::format("{}/{}", faasmLocalDir, "runtime_root");
+    sharedFilesDir = fmt::format("{}/{}", faasmLocalDir, "shared");
+    sharedFilesStorageDir = fmt::format("{}/{}", faasmLocalDir, "shared_store");
 }
 
 int FaasmConfig::getIntParam(const char* name, const char* defaultValue)

--- a/src/conf/function_utils.cpp
+++ b/src/conf/function_utils.cpp
@@ -1,0 +1,288 @@
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
+
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
+
+#include <faabric/proto/faabric.pb.h>
+#include <faabric/util/clock.h>
+#include <faabric/util/config.h>
+#include <faabric/util/environment.h>
+#include <faabric/util/func.h>
+#include <faabric/util/gids.h>
+#include <faabric/util/logging.h>
+#include <faabric/util/random.h>
+
+using namespace faabric::util;
+
+namespace conf {
+
+const static std::string pyFile = "function.py";
+const static std::string funcFile = "function.wasm";
+const static std::string encryptedFuncFile = "function.wasm.enc";
+const static std::string symFile = "function.symbols";
+const static std::string objFile = "function.wasm.o";
+const static std::string wamrAotFile = "function.aot";
+
+std::string getRootUrl()
+{
+    std::string rootUrl = getEnvVar("FILESERVER_URL", "");
+    if (rootUrl.empty()) {
+        throw std::runtime_error("Fileserver URL not set");
+    }
+
+    return rootUrl;
+}
+
+std::string getUrl(const faabric::Message& msg, const std::string& urlPart)
+{
+    std::string rootUrl = getRootUrl();
+
+    std::string funcUrl =
+      rootUrl + "/" + urlPart + "/" + msg.user() + "/" + msg.function();
+
+    return funcUrl;
+}
+
+std::string getSharedObjectUrl()
+{
+    std::string rootUrl = getRootUrl();
+    return rootUrl + "/sobjwasm";
+}
+
+std::string getSharedObjectObjectUrl()
+{
+    std::string rootUrl = getRootUrl();
+    return rootUrl + "/sobjobj";
+}
+
+std::string getSharedFileUrl()
+{
+    std::string rootUrl = getRootUrl();
+    return rootUrl + "/file";
+}
+
+std::string getFunctionUrl(const faabric::Message& msg)
+{
+    return getUrl(msg, "f");
+}
+
+std::string getFunctionObjectUrl(const faabric::Message& msg)
+{
+    return getUrl(msg, "fo");
+}
+
+std::string getPythonFunctionUrl(const faabric::Message& msg)
+{
+    return getUrl(msg, "p");
+}
+
+std::string _doGetPythonFunctionFile(const faabric::Message& msg,
+                                     const std::string& parentDir,
+                                     bool createDirs)
+{
+    if (!msg.ispython()) {
+        throw std::runtime_error(
+          "Getting python function file for non-Python function " +
+          funcToString(msg, false));
+    }
+
+    if (msg.pythonuser().empty() || msg.pythonfunction().empty()) {
+        throw std::runtime_error(
+          "Invalid Python call: user=" + msg.pythonuser() +
+          " func=" + msg.pythonfunction());
+    }
+    boost::filesystem::path path(parentDir);
+
+    path.append(PYTHON_FUNC_DIR);
+    path.append(msg.pythonuser());
+    path.append(msg.pythonfunction());
+
+    if (createDirs) {
+        boost::filesystem::create_directories(path);
+    }
+
+    path.append(pyFile);
+    return path.string();
+}
+
+boost::filesystem::path _doGetDir(std::string baseDir,
+                                  const faabric::Message& msg,
+                                  bool create)
+{
+    boost::filesystem::path path(baseDir);
+    path.append(msg.user());
+    path.append(msg.function());
+
+    // Create directory if doesn't exist
+    if (create) {
+        boost::filesystem::create_directories(path);
+    }
+
+    return path;
+}
+
+boost::filesystem::path getFunctionDir(const faabric::Message& msg,
+                                       bool create = true)
+{
+    FaasmConfig& conf = getFaasmConfig();
+    return _doGetDir(conf.functionDir, msg, create);
+}
+
+boost::filesystem::path getObjectDir(const faabric::Message& msg,
+                                     bool create = true)
+{
+    FaasmConfig& conf = getFaasmConfig();
+    return _doGetDir(conf.objectFileDir, msg, create);
+}
+
+bool isValidFunction(const faabric::Message& msg)
+{
+    if (msg.user().empty() || msg.function().empty()) {
+        return false;
+    }
+
+    auto path = getFunctionDir(msg, false);
+    path.append("function.wasm");
+
+    bool isValid = boost::filesystem::exists(path);
+    return isValid;
+}
+
+std::string getFunctionKey(const faabric::Message& msg)
+{
+    std::string key = "wasm";
+
+    key += "/";
+    key += msg.user();
+    key += "/";
+    key += msg.function();
+    key += "/";
+    key += funcFile;
+
+    return key;
+}
+
+std::string getFunctionObjectKey(const faabric::Message& msg)
+{
+    std::string key = "wasm";
+
+    key += "/";
+    key += msg.user();
+    key += "/";
+    key += msg.function();
+    key += "/";
+    key += objFile;
+
+    return key;
+}
+
+std::string getPythonFunctionFile(const faabric::Message& msg)
+{
+    // Python functions are stored as shared files to make it easier to
+    // share them through the system
+    return _doGetPythonFunctionFile(
+      msg, getFaasmConfig().sharedFilesStorageDir, true);
+}
+
+std::string getPythonFunctionFileSharedPath(const faabric::Message& msg)
+{
+    // This is the shared path of the form faasm:// used to access the Python
+    // file
+    return _doGetPythonFunctionFile(msg, SHARED_FILE_PREFIX, false);
+}
+
+std::string getPythonRuntimeFunctionFile(const faabric::Message& msg)
+{
+    // This is the path where the file is placed at runtime to be
+    // accessible to the function
+    return _doGetPythonFunctionFile(
+      msg, getFaasmConfig().runtimeFilesDir, true);
+}
+
+std::string getFunctionFile(const faabric::Message& msg)
+{
+    auto path = getFunctionDir(msg);
+    path.append(funcFile);
+
+    return path.string();
+}
+
+std::string getEncryptedFunctionFile(const faabric::Message& msg)
+{
+    auto path = getFunctionDir(msg);
+    path.append(encryptedFuncFile);
+
+    return path.string();
+}
+
+std::string getFunctionSymbolsFile(const faabric::Message& msg)
+{
+    auto path = getFunctionDir(msg);
+    path.append(symFile);
+
+    return path.string();
+}
+
+std::string getFunctionObjectFile(const faabric::Message& msg)
+{
+    auto path = getObjectDir(msg);
+    path.append(objFile);
+
+    return path.string();
+}
+
+std::string getFunctionAotFile(const faabric::Message& msg)
+{
+    auto path = getObjectDir(msg);
+    path.append(wamrAotFile);
+
+    return path.string();
+}
+
+std::string getSharedObjectObjectFile(const std::string& realPath)
+{
+    boost::filesystem::directory_entry f(realPath);
+    const std::string directory = f.path().parent_path().string();
+    const std::string fileName = f.path().filename().string();
+
+    // Work out the final destination for the object file. This will be the
+    // object path with the directory of the original file appended
+    FaasmConfig& conf = getFaasmConfig();
+    boost::filesystem::path objPath(conf.objectFileDir);
+    objPath.append(directory);
+
+    // Create directory (if necessary)
+    create_directories(objPath);
+
+    // Add the filename
+    std::string outputFile = objPath.append(fileName).string();
+    outputFile += SHARED_OBJ_EXT;
+
+    return outputFile;
+}
+
+std::string getSharedFileFile(const std::string& path)
+{
+    FaasmConfig& conf = getFaasmConfig();
+
+    boost::filesystem::path p(conf.sharedFilesStorageDir);
+    p.append(path);
+
+    if (!boost::filesystem::exists(p.parent_path())) {
+        boost::filesystem::create_directories(p.parent_path());
+    }
+
+    return p.string();
+}
+
+void convertMessageToPython(faabric::Message& msg)
+{
+    msg.set_ispython(true);
+    msg.set_pythonfunction(msg.function());
+    msg.set_pythonuser(msg.user());
+
+    msg.set_user(PYTHON_USER);
+    msg.set_function(PYTHON_FUNC);
+}
+}

--- a/src/faaslet/Faaslet.cpp
+++ b/src/faaslet/Faaslet.cpp
@@ -1,5 +1,7 @@
 #include <faaslet/Faaslet.h>
 
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <system/CGroup.h>
 #include <system/NetworkNamespace.h>
 #include <threads/ThreadState.h>
@@ -32,7 +34,7 @@ void preloadPythonRuntime()
 {
     auto logger = faabric::util::getLogger();
 
-    auto& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.pythonPreload != "on") {
         logger->info("Not preloading python runtime");
         return;
@@ -76,7 +78,7 @@ void Faaslet::flush()
 Faaslet::Faaslet(const faabric::Message& msg)
   : Executor(msg)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     // Instantiate the right wasm module for the chosen runtime
     if (conf.wasmVm == "wamr") {
@@ -141,7 +143,7 @@ void Faaslet::restore(const faabric::Message& msg)
 {
     auto logger = faabric::util::getLogger();
 
-    auto& conf = faabric::util::getSystemConfig();
+    auto& conf = conf::getFaasmConfig();
     const std::string snapshotKey = msg.snapshotkey();
 
     // Restore from snapshot if necessary

--- a/src/faaslet/Faaslet.cpp
+++ b/src/faaslet/Faaslet.cpp
@@ -143,7 +143,7 @@ void Faaslet::restore(const faabric::Message& msg)
 {
     auto logger = faabric::util::getLogger();
 
-    auto& conf = conf::getFaasmConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     const std::string snapshotKey = msg.snapshotkey();
 
     // Restore from snapshot if necessary

--- a/src/runner/codegen_func.cpp
+++ b/src/runner/codegen_func.cpp
@@ -4,6 +4,9 @@
 #include <faabric/util/func.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <storage/FileLoader.h>
 
 using namespace boost::filesystem;
@@ -13,7 +16,7 @@ void codegenForFunc(const std::string& user, const std::string& func)
     const std::shared_ptr<spdlog::logger> logger = faabric::util::getLogger();
 
     faabric::Message msg = faabric::util::messageFactory(user, func);
-    if (!faabric::util::isValidFunction(msg)) {
+    if (!conf::isValidFunction(msg)) {
         logger->warn("Invalid function: {}/{}", user, func);
         return;
     }
@@ -36,7 +39,7 @@ int main(int argc, char* argv[])
     } else if (argc == 2) {
         std::string user = argv[1];
 
-        faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+        conf::FaasmConfig& conf = conf::getFaasmConfig();
         logger->info(
           "Running codegen for user {} on dir {}", user, conf.functionDir);
 

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -1,3 +1,5 @@
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <faaslet/Faaslet.h>
 #include <wasm/WasmModule.h>
 
@@ -30,11 +32,12 @@ int main(int argc, char* argv[])
     faabric::Message& msg = req->mutable_messages()->at(0);
 
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
 
     // Set short timeouts to die quickly
     conf.boundTimeout = 60000;
     conf.globalMessageTimeout = 60000;
-    conf.chainedCallTimeout = 60000;
+    faasmConf.chainedCallTimeout = 60000;
 
     // Make sure we have enough space for chained calls
     int nThreads = 10;
@@ -50,7 +53,7 @@ int main(int argc, char* argv[])
     redis.flushAll();
 
     if (user == "python") {
-        faabric::util::convertMessageToPython(msg);
+        conf::convertMessageToPython(msg);
         logger->info("Running Python function {}/{}",
                      msg.pythonuser(),
                      msg.pythonfunction());

--- a/src/runner/func_sym.cpp
+++ b/src/runner/func_sym.cpp
@@ -1,11 +1,13 @@
-#include <wasm/WasmModule.h>
-
 #include <fstream>
+#include <iomanip>
 
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
 #include <faabric/util/logging.h>
-#include <iomanip>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
+#include <wasm/WasmModule.h>
 #include <wavm/WAVMWasmModule.h>
 
 int main(int argc, char* argv[])
@@ -31,7 +33,7 @@ int main(int argc, char* argv[])
 
     std::map<std::string, std::string> disasMap = module.buildDisassemblyMap();
 
-    std::string outPath = faabric::util::getFunctionSymbolsFile(call);
+    std::string outPath = conf::getFunctionSymbolsFile(call);
     std::ofstream outfile;
     outfile.open(outPath, std::ios::out);
 

--- a/src/storage/FileDescriptor.cpp
+++ b/src/storage/FileDescriptor.cpp
@@ -1,15 +1,17 @@
 #include "FileDescriptor.h"
-#include "SharedFiles.h"
 
 #include <faabric/util/bytes.h>
+#include <faabric/util/config.h>
+#include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
 #include <faabric/util/timing.h>
+
+#include <conf/FaasmConfig.h>
+#include <storage/SharedFiles.h>
 
 #include <WAVM/WASI/WASIABI.h>
 #include <boost/filesystem.hpp>
 #include <dirent.h>
-#include <faabric/util/config.h>
-#include <faabric/util/logging.h>
 #include <fcntl.h>
 #include <stdexcept>
 #include <sys/stat.h>
@@ -21,7 +23,7 @@
 namespace storage {
 std::string prependRuntimeRoot(const std::string& originalPath)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     boost::filesystem::path p(conf.runtimeFilesDir);
     p.append(originalPath);
     return p.string();

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -1,8 +1,6 @@
 #include "FileLoader.h"
-#include <boost/filesystem/operations.hpp>
-#include <stdexcept>
 
-#include <openssl/md5.h>
+#include <stdexcept>
 
 #if (WAMR_EXECUTION_MODE_INTERP)
 // Import for codegen not needed as it's not supported
@@ -10,6 +8,7 @@
 #include <wamr/WAMRWasmModule.h>
 #endif
 
+#include <conf/FaasmConfig.h>
 #include <wavm/WAVMWasmModule.h>
 
 #include <faabric/util/config.h>
@@ -18,6 +17,8 @@
 #include <faabric/util/logging.h>
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <openssl/md5.h>
 
 namespace storage {
 
@@ -39,7 +40,7 @@ std::string FileLoader::getHashFilePath(const std::string& path)
 std::vector<uint8_t> FileLoader::doCodegen(std::vector<uint8_t>& bytes,
                                            const std::string& fileName)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    auto& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
 #if (WAMR_EXECTION_MODE_INTERP)
         throw std::runtime_error(
@@ -66,7 +67,7 @@ void FileLoader::codegenForFunction(faabric::Message& msg)
     // Compare hashes
     std::vector<uint8_t> newHash = hashBytes(bytes);
     std::vector<uint8_t> oldHash;
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    auto& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
         oldHash = loadFunctionWamrAotHash(msg);
     } else {
@@ -121,7 +122,7 @@ void FileLoader::codegenForSharedObject(const std::string& inputPath)
     std::vector<uint8_t> objBytes = doCodegen(bytes, inputPath);
 
     // Do the upload
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    auto& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
         uploadSharedObjectAotFile(inputPath, objBytes);
         uploadSharedObjectAotHash(inputPath, newHash);

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -40,7 +40,7 @@ std::string FileLoader::getHashFilePath(const std::string& path)
 std::vector<uint8_t> FileLoader::doCodegen(std::vector<uint8_t>& bytes,
                                            const std::string& fileName)
 {
-    auto& conf = conf::getFaasmConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
 #if (WAMR_EXECTION_MODE_INTERP)
         throw std::runtime_error(
@@ -67,7 +67,7 @@ void FileLoader::codegenForFunction(faabric::Message& msg)
     // Compare hashes
     std::vector<uint8_t> newHash = hashBytes(bytes);
     std::vector<uint8_t> oldHash;
-    auto& conf = conf::getFaasmConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
         oldHash = loadFunctionWamrAotHash(msg);
     } else {
@@ -122,7 +122,7 @@ void FileLoader::codegenForSharedObject(const std::string& inputPath)
     std::vector<uint8_t> objBytes = doCodegen(bytes, inputPath);
 
     // Do the upload
-    auto& conf = conf::getFaasmConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.wasmVm == "wamr") {
         uploadSharedObjectAotFile(inputPath, objBytes);
         uploadSharedObjectAotHash(inputPath, newHash);

--- a/src/storage/FileSystem.cpp
+++ b/src/storage/FileSystem.cpp
@@ -1,8 +1,11 @@
 #include "FileSystem.h"
 #include "SharedFiles.h"
 
+#include <conf/FaasmConfig.h>
+
 #include <WASI/WASIPrivate.h>
 #include <boost/filesystem.hpp>
+
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
@@ -156,7 +159,7 @@ void FileSystem::clearSharedFiles()
 
     // Just nuke the whole shared directory
     // Note that we're not deleting the master copies in the shared store
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     boost::filesystem::remove_all(conf.sharedFilesDir);
 }
 

--- a/src/storage/FileserverFileLoader.cpp
+++ b/src/storage/FileserverFileLoader.cpp
@@ -53,7 +53,7 @@ std::vector<uint8_t> FileserverFileLoader::doLoad(
         }
     }
 
-    auto& conf = conf::getFaasmConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string host = conf.fileserverUrl;
 
     logger->debug("Creating client at {}", host);

--- a/src/storage/FileserverFileLoader.cpp
+++ b/src/storage/FileserverFileLoader.cpp
@@ -1,20 +1,23 @@
 #include "FileserverFileLoader.h"
 
-#include <cpprest/astreambuf.h>
-#include <cpprest/containerstream.h>
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
+
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
 #include <faabric/util/logging.h>
 
+#include <boost/filesystem.hpp>
+#include <cpprest/astreambuf.h>
+#include <cpprest/containerstream.h>
 #include <cpprest/filestream.h>
 #include <cpprest/http_client.h>
 #include <cpprest/json.h>
 #include <cpprest/uri.h>
-#include <iostream>
 
-#include <boost/filesystem.hpp>
+#include <iostream>
 
 using namespace utility;
 using namespace web;
@@ -30,7 +33,7 @@ FileserverFileLoader::FileserverFileLoader(bool useFilesystemCacheIn)
 
 std::string FileserverFileLoader::getFileserverUrl()
 {
-    return faabric::util::getSystemConfig().fileserverUrl;
+    return conf::getFaasmConfig().fileserverUrl;
 }
 
 std::vector<uint8_t> FileserverFileLoader::doLoad(
@@ -50,7 +53,7 @@ std::vector<uint8_t> FileserverFileLoader::doLoad(
         }
     }
 
-    auto& conf = faabric::util::getSystemConfig();
+    auto& conf = conf::getFaasmConfig();
     std::string host = conf.fileserverUrl;
 
     logger->debug("Creating client at {}", host);
@@ -86,7 +89,7 @@ std::vector<uint8_t> FileserverFileLoader::doLoad(
               std::string errMsg =
                 "Empty response for file at " + host + "/" + urlPath;
               logger->error(errMsg);
-              throw faabric::util::InvalidFunctionException(errMsg);
+              throw conf::InvalidFunctionException(errMsg);
           }
 
           // Check whether it's a directory
@@ -117,7 +120,7 @@ std::vector<uint8_t> FileserverFileLoader::loadFunctionWasm(
   const faabric::Message& msg)
 {
     std::string urlPath = fmt::format("f/{}/{}", msg.user(), msg.function());
-    std::string filePath = faabric::util::getFunctionFile(msg);
+    std::string filePath = conf::getFunctionFile(msg);
     return doLoad(urlPath, "", filePath);
 }
 
@@ -125,7 +128,7 @@ std::vector<uint8_t> FileserverFileLoader::loadFunctionObjectFile(
   const faabric::Message& msg)
 {
     std::string urlPath = fmt::format("fo/{}/{}", msg.user(), msg.function());
-    std::string objectFilePath = faabric::util::getFunctionObjectFile(msg);
+    std::string objectFilePath = conf::getFunctionObjectFile(msg);
     return doLoad(urlPath, "", objectFilePath);
 }
 
@@ -140,7 +143,7 @@ std::vector<uint8_t> FileserverFileLoader::loadSharedObjectObjectFile(
   const std::string& path)
 {
     std::string urlPath = "sobjobj";
-    std::string objFilePath = faabric::util::getSharedObjectObjectFile(path);
+    std::string objFilePath = conf::getSharedObjectObjectFile(path);
     return doLoad(urlPath, path, objFilePath);
 }
 
@@ -155,7 +158,7 @@ std::vector<uint8_t> FileserverFileLoader::loadSharedFile(
   const std::string& path)
 {
     std::string urlPath = "file";
-    const std::string fullPath = faabric::util::getSharedFileFile(path);
+    const std::string fullPath = conf::getSharedFileFile(path);
     return doLoad(urlPath, path, fullPath);
 }
 
@@ -164,7 +167,7 @@ void FileserverFileLoader::flushFunctionFiles()
     // Note that because we're loading files from a file server, we can safely
     // delete the function and object files on this host as they are not the
     // master copies.
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     // Nuke the function directory
     boost::filesystem::remove_all(conf.functionDir);

--- a/src/storage/LocalFileLoader.cpp
+++ b/src/storage/LocalFileLoader.cpp
@@ -1,5 +1,7 @@
 #include "storage/LocalFileLoader.h"
 
+#include <conf/function_utils.h>
+
 #include <iostream>
 
 #include <faabric/util/bytes.h>
@@ -13,28 +15,28 @@ namespace storage {
 std::vector<uint8_t> LocalFileLoader::loadFunctionWasm(
   const faabric::Message& msg)
 {
-    std::string filePath = faabric::util::getFunctionFile(msg);
+    std::string filePath = conf::getFunctionFile(msg);
     return loadFileBytes(filePath);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadFunctionObjectFile(
   const faabric::Message& msg)
 {
-    std::string objectFilePath = faabric::util::getFunctionObjectFile(msg);
+    std::string objectFilePath = conf::getFunctionObjectFile(msg);
     return loadFileBytes(objectFilePath);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadFunctionWamrAotFile(
   const faabric::Message& msg)
 {
-    std::string objectFilePath = faabric::util::getFunctionAotFile(msg);
+    std::string objectFilePath = conf::getFunctionAotFile(msg);
     return loadFileBytes(objectFilePath);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadSharedObjectObjectFile(
   const std::string& path)
 {
-    std::string objFilePath = faabric::util::getSharedObjectObjectFile(path);
+    std::string objFilePath = conf::getSharedObjectObjectFile(path);
     return loadFileBytes(objFilePath);
 }
 
@@ -58,31 +60,30 @@ std::vector<uint8_t> LocalFileLoader::loadHashForPath(const std::string& path)
 std::vector<uint8_t> LocalFileLoader::loadFunctionObjectHash(
   const faabric::Message& msg)
 {
-    std::string outputFile = faabric::util::getFunctionObjectFile(msg);
+    std::string outputFile = conf::getFunctionObjectFile(msg);
     return loadHashForPath(outputFile);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadFunctionWamrAotHash(
   const faabric::Message& msg)
 {
-    std::string outputFile = faabric::util::getFunctionAotFile(msg);
+    std::string outputFile = conf::getFunctionAotFile(msg);
     return loadHashForPath(outputFile);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadSharedObjectObjectHash(
   const std::string& path)
 {
-    std::string outputFile = faabric::util::getSharedObjectObjectFile(path);
+    std::string outputFile = conf::getSharedObjectObjectFile(path);
     return loadHashForPath(outputFile);
 }
 
 std::vector<uint8_t> LocalFileLoader::loadSharedFile(const std::string& path)
 {
-    const std::string fullPath = faabric::util::getSharedFileFile(path);
+    const std::string fullPath = conf::getSharedFileFile(path);
 
     if (!boost::filesystem::exists(fullPath)) {
-        const std::shared_ptr<spdlog::logger>& logger =
-          faabric::util::getLogger();
+        const auto& logger = faabric::util::getLogger();
         logger->debug("Local file loader could not find file at {}", fullPath);
         std::vector<uint8_t> empty;
         return empty;
@@ -97,7 +98,7 @@ std::vector<uint8_t> LocalFileLoader::loadSharedFile(const std::string& path)
 
 void LocalFileLoader::uploadFunction(faabric::Message& msg)
 {
-    const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
+    const auto& logger = faabric::util::getLogger();
     const std::string funcStr = faabric::util::funcToString(msg, false);
 
     // Here the msg input data is actually the file
@@ -108,7 +109,7 @@ void LocalFileLoader::uploadFunction(faabric::Message& msg)
     }
 
     logger->debug("Uploading wasm file {}", funcStr);
-    std::string outputFile = faabric::util::getFunctionFile(msg);
+    std::string outputFile = conf::getFunctionFile(msg);
     std::ofstream out(outputFile);
     out.write(fileBody.c_str(), fileBody.size());
     out.flush();
@@ -122,12 +123,12 @@ void LocalFileLoader::uploadFunction(faabric::Message& msg)
 void LocalFileLoader::uploadPythonFunction(faabric::Message& msg)
 {
     const std::string& fileBody = msg.inputdata();
-    const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
+    const auto& logger = faabric::util::getLogger();
 
     // Message will have user/ function set as python user and python function
-    faabric::util::convertMessageToPython(msg);
+    conf::convertMessageToPython(msg);
 
-    std::string outputFile = faabric::util::getPythonFunctionFile(msg);
+    std::string outputFile = conf::getPythonFunctionFile(msg);
     logger->debug("Uploading python file {}/{} to {}",
                   msg.pythonuser(),
                   msg.pythonfunction(),
@@ -144,7 +145,7 @@ void LocalFileLoader::uploadFunctionObjectFile(
   const std::vector<uint8_t>& objBytes)
 {
     // Write the file
-    std::string objFilePath = faabric::util::getFunctionObjectFile(msg);
+    std::string objFilePath = conf::getFunctionObjectFile(msg);
     faabric::util::writeBytesToFile(objFilePath, objBytes);
 }
 
@@ -152,7 +153,7 @@ void LocalFileLoader::uploadFunctionAotFile(
   const faabric::Message& msg,
   const std::vector<uint8_t>& objBytes)
 {
-    std::string objFilePath = faabric::util::getFunctionAotFile(msg);
+    std::string objFilePath = conf::getFunctionAotFile(msg);
     faabric::util::writeBytesToFile(objFilePath, objBytes);
 }
 
@@ -160,7 +161,7 @@ void LocalFileLoader::uploadSharedObjectObjectFile(
   const std::string& path,
   const std::vector<uint8_t>& objBytes)
 {
-    std::string outputPath = faabric::util::getSharedObjectObjectFile(path);
+    std::string outputPath = conf::getSharedObjectObjectFile(path);
     faabric::util::writeBytesToFile(outputPath, objBytes);
 }
 
@@ -174,7 +175,7 @@ void LocalFileLoader::uploadSharedObjectAotFile(
 void LocalFileLoader::uploadSharedFile(const std::string& path,
                                        const std::vector<uint8_t>& objBytes)
 {
-    const std::string fullPath = faabric::util::getSharedFileFile(path);
+    const std::string fullPath = conf::getSharedFileFile(path);
     faabric::util::writeBytesToFile(fullPath, objBytes);
 }
 
@@ -195,7 +196,7 @@ void LocalFileLoader::writeHashForFile(const std::string& path,
 void LocalFileLoader::uploadFunctionObjectHash(const faabric::Message& msg,
                                                const std::vector<uint8_t>& hash)
 {
-    std::string objFilePath = faabric::util::getFunctionObjectFile(msg);
+    std::string objFilePath = conf::getFunctionObjectFile(msg);
     writeHashForFile(objFilePath, hash);
 }
 
@@ -203,7 +204,7 @@ void LocalFileLoader::uploadFunctionWamrAotHash(
   const faabric::Message& msg,
   const std::vector<uint8_t>& hash)
 {
-    std::string objFilePath = faabric::util::getFunctionAotFile(msg);
+    std::string objFilePath = conf::getFunctionAotFile(msg);
     writeHashForFile(objFilePath, hash);
 }
 
@@ -211,7 +212,7 @@ void LocalFileLoader::uploadSharedObjectObjectHash(
   const std::string& path,
   const std::vector<uint8_t>& hash)
 {
-    std::string outputPath = faabric::util::getSharedObjectObjectFile(path);
+    std::string outputPath = conf::getSharedObjectObjectFile(path);
     writeHashForFile(outputPath, hash);
 }
 

--- a/src/storage/SharedFiles.cpp
+++ b/src/storage/SharedFiles.cpp
@@ -1,11 +1,15 @@
 #include "SharedFiles.h"
 
 #include <boost/filesystem.hpp>
+
 #include <faabric/util/config.h>
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/string_tools.h>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <storage/FileLoader.h>
 
 namespace storage {
@@ -22,7 +26,7 @@ static std::unordered_map<std::string, FileState> sharedFileMap;
 
 std::string SharedFiles::prependSharedRoot(const std::string& originalPath)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     boost::filesystem::path p(conf.sharedFilesDir);
     p.append(originalPath);
     return p.string();
@@ -143,10 +147,8 @@ void SharedFiles::syncPythonFunctionFile(const faabric::Message& msg)
         return;
     }
 
-    std::string sharedPath =
-      faabric::util::getPythonFunctionFileSharedPath(msg);
-    std::string runtimeFilePath =
-      faabric::util::getPythonRuntimeFunctionFile(msg);
+    std::string sharedPath = conf::getPythonFunctionFileSharedPath(msg);
+    std::string runtimeFilePath = conf::getPythonRuntimeFunctionFile(msg);
 
     syncSharedFile(sharedPath, runtimeFilePath);
 }

--- a/src/storage/instance.cpp
+++ b/src/storage/instance.cpp
@@ -1,12 +1,13 @@
 #include <faabric/util/config.h>
 
-#include "FileserverFileLoader.h"
-#include "LocalFileLoader.h"
+#include <conf/FaasmConfig.h>
+#include <storage/FileserverFileLoader.h>
+#include <storage/LocalFileLoader.h>
 
 namespace storage {
 FileLoader& getFileLoader()
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     if (conf.functionStorage == "local") {
         static thread_local LocalFileLoader fl;

--- a/src/system/CGroup.cpp
+++ b/src/system/CGroup.cpp
@@ -1,13 +1,15 @@
 #include "CGroup.h"
 
+#include <conf/FaasmConfig.h>
+
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
 #include <mutex>
+#include <syscall.h>
 
 #include <boost/filesystem.hpp>
-#include <syscall.h>
 
 using namespace boost::filesystem;
 
@@ -22,7 +24,7 @@ static std::mutex groupMutex;
 CGroup::CGroup(const std::string& name)
   : name(name)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     if (conf.cgroupMode == "on") {
         mode = CgroupMode::cg_on;

--- a/src/system/NetworkNamespace.cpp
+++ b/src/system/NetworkNamespace.cpp
@@ -8,6 +8,8 @@
 #include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
+#include <conf/FaasmConfig.h>
+
 #include <errno.h>
 #include <fcntl.h>
 
@@ -57,7 +59,7 @@ NetworkNamespace::NetworkNamespace(const std::string& name)
   : name(name)
 {
     // Get which mode we're operating in
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     if (conf.netNsMode == "on") {
         mode = NetworkIsolationMode::ns_on;

--- a/src/upload/UploadServer.cpp
+++ b/src/upload/UploadServer.cpp
@@ -7,6 +7,7 @@
 #include <faabric/util/func.h>
 #include <faabric/util/logging.h>
 
+#include <conf/FaasmConfig.h>
 #include <storage/FileLoader.h>
 
 namespace edge {
@@ -34,7 +35,7 @@ UploadServer::UploadServer()
 {
     const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.functionStorage == "fileserver") {
         logger->info("Overriding fileserver storage on upload server (as this "
                      "is the fileserver)");

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -1,6 +1,8 @@
 #include "wasm/WasmModule.h"
 
 #include <conf/FaasmConfig.h>
+#include <threads/ThreadState.h>
+
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/bytes.h>
@@ -11,7 +13,6 @@
 #include <faabric/util/locks.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/timing.h>
-#include <threads/ThreadState.h>
 
 #include <boost/filesystem.hpp>
 #include <sstream>
@@ -408,7 +409,7 @@ int32_t WasmModule::executeTask(
     }
 
     // Add captured stdout if necessary
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.captureStdout == "on") {
         std::string moduleStdout = getCapturedStdout();
         if (!moduleStdout.empty()) {

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -6,10 +6,13 @@
 
 #include <wasm/chaining.h>
 
+#include <conf/FaasmConfig.h>
+#include <wasm/chaining.h>
+
 namespace wasm {
 int awaitChainedCall(unsigned int messageId)
 {
-    int callTimeoutMs = faabric::util::getSystemConfig().chainedCallTimeout;
+    int callTimeoutMs = conf::getFaasmConfig().chainedCallTimeout;
 
     int returnCode = 1;
     try {
@@ -102,7 +105,7 @@ int awaitChainedCallOutput(unsigned int messageId,
                            int bufferLen)
 {
     const std::shared_ptr<spdlog::logger>& logger = faabric::util::getLogger();
-    int callTimeoutMs = faabric::util::getSystemConfig().chainedCallTimeout;
+    int callTimeoutMs = conf::getFaasmConfig().chainedCallTimeout;
 
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
     const faabric::Message result =

--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -9,6 +9,8 @@
 #include <faabric/util/files.h>
 #include <faabric/util/state.h>
 
+#include <conf/FaasmConfig.h>
+
 using namespace WAVM;
 
 namespace wasm {
@@ -538,8 +540,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
     const std::string key = getStringFromWasm(keyPtr);
     logger->debug("S - conf_flag - {}", key);
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (key == "PYTHON_PRELOAD") {
         int res = conf.pythonPreload == "on" ? 1 : 0;
         return res;

--- a/src/wavm/io.cpp
+++ b/src/wavm/io.cpp
@@ -5,6 +5,8 @@
 #include <faabric/util/config.h>
 #include <faabric/util/macros.h>
 #include <faabric/util/timing.h>
+
+#include <conf/FaasmConfig.h>
 #include <storage/FileDescriptor.h>
 #include <storage/FileLoader.h>
 
@@ -352,7 +354,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(wasi,
     }
 
     // Catpure stdout if necessary, otherwise write as normal
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (isStd && conf.captureStdout == "on") {
         getExecutingWAVMModule()->captureStdout(nativeIovecs, iovecCount);
     }
@@ -744,7 +746,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env, "puts", I32, puts, I32 strPtr)
     char* hostStr = &Runtime::memoryRef<char>(memoryPtr, (Uptr)strPtr);
 
     // Capture stdout if necessary
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (conf.captureStdout == "on") {
         module->captureStdout(hostStr);
     }

--- a/tests/test/conf/test_conf.cpp
+++ b/tests/test/conf/test_conf.cpp
@@ -1,0 +1,76 @@
+#include <catch2/catch.hpp>
+
+#include <conf/FaasmConfig.h>
+
+#include <faabric/util/config.h>
+#include <faabric/util/environment.h>
+
+using namespace faabric::util;
+using namespace conf;
+
+namespace tests {
+TEST_CASE("Test default faasm config initialisation", "[conf]")
+{
+    FaasmConfig conf;
+    conf.reset();
+
+    REQUIRE(conf.cgroupMode == "on");
+    REQUIRE(conf.functionStorage == "local");
+    REQUIRE(conf.fileserverUrl == "");
+    REQUIRE(conf.netNsMode == "off");
+    REQUIRE(conf.pythonPreload == "off");
+    REQUIRE(conf.captureStdout == "off");
+    REQUIRE(conf.wasmVm == "wavm");
+
+    REQUIRE(conf.chainedCallTimeout == 300000);
+}
+
+TEST_CASE("Test overriding faasm config initialisation", "[conf]")
+{
+    std::string originalHostType = getFaasmConfig().hostType;
+
+    std::string hostType = setEnvVar("HOST_TYPE", "magic");
+    std::string funcStorage = setEnvVar("FUNCTION_STORAGE", "foobar");
+    std::string fileserver = setEnvVar("FILESERVER_URL", "www.foo.com");
+    std::string cgMode = setEnvVar("CGROUP_MODE", "off");
+    std::string nsMode = setEnvVar("NETNS_MODE", "on");
+    std::string pythonPre = setEnvVar("PYTHON_PRELOAD", "on");
+    std::string captureStdout = setEnvVar("CAPTURE_STDOUT", "on");
+
+    std::string chainedTimeout = setEnvVar("CHAINED_CALL_TIMEOUT", "9999");
+
+    std::string faasmLocalDir = setEnvVar("FAASM_LOCAL_DIR", "/tmp/blah");
+
+    // Create new conf for test
+    FaasmConfig conf;
+
+    REQUIRE(conf.hostType == "magic");
+    REQUIRE(conf.functionStorage == "foobar");
+    REQUIRE(conf.fileserverUrl == "www.foo.com");
+    REQUIRE(conf.cgroupMode == "off");
+    REQUIRE(conf.netNsMode == "on");
+    REQUIRE(conf.pythonPreload == "on");
+    REQUIRE(conf.captureStdout == "on");
+    REQUIRE(conf.wasmVm == "blah");
+    REQUIRE(conf.chainedCallTimeout == 9999);
+    REQUIRE(conf.functionDir == "/tmp/blah/wasm");
+    REQUIRE(conf.objectFileDir == "/tmp/blah/object");
+    REQUIRE(conf.runtimeFilesDir == "/tmp/blah/runtime_root");
+    REQUIRE(conf.sharedFilesDir == "/tmp/blah/shared");
+    REQUIRE(conf.sharedFilesStorageDir == "/tmp/blah/shared_store");
+
+    // Be careful with host type as it must remain consistent for tests
+    setEnvVar("HOST_TYPE", originalHostType);
+
+    setEnvVar("FUNCTION_STORAGE", funcStorage);
+    setEnvVar("FILESERVER_URL", fileserver);
+    setEnvVar("CGROUP_MODE", cgMode);
+    setEnvVar("NETNS_MODE", nsMode);
+    setEnvVar("PYTHON_PRELOAD", pythonPre);
+    setEnvVar("CAPTURE_STDOUT", captureStdout);
+
+    setEnvVar("CHAINED_CALL_TIMEOUT", chainedTimeout);
+
+    setEnvVar("FAASM_LOCAL_DIR", faasmLocalDir);
+}
+}

--- a/tests/test/conf/test_conf.cpp
+++ b/tests/test/conf/test_conf.cpp
@@ -36,6 +36,7 @@ TEST_CASE("Test overriding faasm config initialisation", "[conf]")
     std::string nsMode = setEnvVar("NETNS_MODE", "on");
     std::string pythonPre = setEnvVar("PYTHON_PRELOAD", "on");
     std::string captureStdout = setEnvVar("CAPTURE_STDOUT", "on");
+    std::string wasmVm = setEnvVar("WASM_VM", "blah");
 
     std::string chainedTimeout = setEnvVar("CHAINED_CALL_TIMEOUT", "9999");
 
@@ -68,6 +69,7 @@ TEST_CASE("Test overriding faasm config initialisation", "[conf]")
     setEnvVar("NETNS_MODE", nsMode);
     setEnvVar("PYTHON_PRELOAD", pythonPre);
     setEnvVar("CAPTURE_STDOUT", captureStdout);
+    setEnvVar("WASM_VM", wasmVm);
 
     setEnvVar("CHAINED_CALL_TIMEOUT", chainedTimeout);
 

--- a/tests/test/conf/test_conf.cpp
+++ b/tests/test/conf/test_conf.cpp
@@ -14,7 +14,12 @@ TEST_CASE("Test default faasm config initialisation", "[conf]")
     FaasmConfig conf;
     conf.reset();
 
-    REQUIRE(conf.cgroupMode == "on");
+    std::string cgroupExpected = "on";
+    if (conf.hostType == "ci") {
+        cgroupExpected = "off";
+    }
+    REQUIRE(conf.cgroupMode == cgroupExpected);
+
     REQUIRE(conf.functionStorage == "local");
     REQUIRE(conf.fileserverUrl == "");
     REQUIRE(conf.netNsMode == "off");

--- a/tests/test/faaslet/test_flushing.cpp
+++ b/tests/test/faaslet/test_flushing.cpp
@@ -10,6 +10,7 @@
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
 
+#include <conf/FaasmConfig.h>
 #include <storage/FileLoader.h>
 #include <wavm/IRModuleCache.h>
 #include <wavm/WAVMWasmModule.h>
@@ -20,7 +21,7 @@ TEST_CASE("Test flushing clears shared files", "[flush]")
 {
     cleanSystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     std::string relativePath = "flush-test.txt";
     boost::filesystem::path sharedPath(conf.sharedFilesDir);
@@ -102,6 +103,8 @@ TEST_CASE("Test flushing picks up new version of function", "[flush]")
     int origBoundTimeout = conf.boundTimeout;
     conf.boundTimeout = 1000;
 
+    conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
+
     // Load the wasm for two real functions
     faabric::Message origMsgA = faabric::util::messageFactory("demo", "hello");
     faabric::Message origMsgB = faabric::util::messageFactory("demo", "echo");
@@ -124,10 +127,10 @@ TEST_CASE("Test flushing picks up new version of function", "[flush]")
     uploadMsgB.set_inputdata(wasmB.data(), wasmB.size());
 
     // Set up dummy directories for storage
-    conf.functionDir = "/tmp/faasm/funcs";
-    conf.objectFileDir = "/tmp/faasm/objs";
-    std::string origFunctionDir = conf.functionDir;
-    std::string origObjDir = conf.objectFileDir;
+    faasmConf.functionDir = "/tmp/faasm/funcs";
+    faasmConf.objectFileDir = "/tmp/faasm/objs";
+    std::string origFunctionDir = faasmConf.functionDir;
+    std::string origObjDir = faasmConf.objectFileDir;
 
     // Upload the first version
     fileLoader.uploadFunction(uploadMsgA);
@@ -170,8 +173,8 @@ TEST_CASE("Test flushing picks up new version of function", "[flush]")
     REQUIRE(resultB.outputdata() == inputB);
 
     conf.boundTimeout = origBoundTimeout;
-    conf.functionDir = origFunctionDir;
-    conf.objectFileDir = origObjDir;
+    faasmConf.functionDir = origFunctionDir;
+    faasmConf.objectFileDir = origObjDir;
 
     m.shutdown();
 }

--- a/tests/test/faaslet/test_io.cpp
+++ b/tests/test/faaslet/test_io.cpp
@@ -3,6 +3,8 @@
 
 #include <faabric/util/config.h>
 
+#include <conf/FaasmConfig.h>
+
 using namespace faaslet;
 
 namespace tests {
@@ -31,7 +33,7 @@ TEST_CASE("Test capturing stdout", "[faaslet]")
 {
     cleanSystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     faabric::Message call = faabric::util::messageFactory("demo", "stdout");
 
     std::string expected;
@@ -63,7 +65,7 @@ TEST_CASE("Test capturing stderr", "[faaslet]")
 {
     cleanSystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     faabric::Message call = faabric::util::messageFactory("demo", "stderr");
 
     std::string expected;

--- a/tests/test/faaslet/test_python.cpp
+++ b/tests/test/faaslet/test_python.cpp
@@ -4,6 +4,8 @@
 #include <boost/algorithm/string.hpp>
 #include <dirent.h>
 
+#include <conf/function_utils.h>
+
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 

--- a/tests/test/faaslet/test_shared_files.cpp
+++ b/tests/test/faaslet/test_shared_files.cpp
@@ -2,12 +2,14 @@
 
 #include "utils.h"
 
+#include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
+#include <faabric/util/files.h>
 #include <faabric/util/func.h>
 
+#include <conf/function_utils.h>
+
 #include <boost/filesystem.hpp>
-#include <faabric/util/bytes.h>
-#include <faabric/util/files.h>
 
 namespace tests {
 TEST_CASE("Test accessing shared files from wasm", "[faaslet]")
@@ -16,7 +18,7 @@ TEST_CASE("Test accessing shared files from wasm", "[faaslet]")
 
     // Set up a dummy file
     std::string relativePath = "test/shared-wasm.txt";
-    std::string fullPath = faabric::util::getSharedFileFile(relativePath);
+    std::string fullPath = conf::getSharedFileFile(relativePath);
     if (boost::filesystem::exists(fullPath)) {
         boost::filesystem::remove(fullPath);
     }

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -11,9 +11,9 @@ struct LogListener : Catch::TestEventListenerBase
     void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
     {
         auto logger = faabric::util::getLogger();
-        logger->debug("---------------------------------------------");
-        logger->debug("TEST: {}", testInfo.name);
-        logger->debug("---------------------------------------------");
+        logger->info("---------------------------------------------");
+        logger->info("TEST: {}", testInfo.name);
+        logger->info("---------------------------------------------");
     }
 };
 

--- a/tests/test/storage/test_file_descriptor.cpp
+++ b/tests/test/storage/test_file_descriptor.cpp
@@ -1,11 +1,14 @@
 #include <catch2/catch.hpp>
 
-#include "storage/FileDescriptor.h"
 #include "utils.h"
 
 #include <WAVM/WASI/WASIABI.h>
 #include <boost/filesystem.hpp>
 #include <faabric/util/files.h>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
+#include <storage/FileDescriptor.h>
 #include <storage/SharedFiles.h>
 
 using namespace storage;
@@ -81,7 +84,7 @@ TEST_CASE("Test stat and mkdir", "[storage]")
 
     std::string dummyDir = "fs_test_dir";
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string realDir = conf.runtimeFilesDir + "/" + dummyDir;
     if (boost::filesystem::exists(realDir)) {
         boost::filesystem::remove_all(realDir);
@@ -116,7 +119,7 @@ TEST_CASE("Test creating, renaming and deleting a file", "[storage]")
     std::string dummyPath = dummyDir + "/dummy_file.txt";
 
     // Set up the directory
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string realDir = conf.runtimeFilesDir + "/" + dummyDir;
     if (!boost::filesystem::exists(realDir)) {
         boost::filesystem::create_directories(realDir);
@@ -179,7 +182,7 @@ TEST_CASE("Test seek", "[storage]")
     FileSystem fs;
     fs.prepareFilesystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string dummyPath;
     std::string realPath;
     std::string contentPath;
@@ -197,7 +200,7 @@ TEST_CASE("Test seek", "[storage]")
     SECTION("Shared file")
     {
         dummyPath = "faasm://dummy_test_file.txt";
-        contentPath = faabric::util::getSharedFileFile("dummy_test_file.txt");
+        contentPath = conf::getSharedFileFile("dummy_test_file.txt");
 
         // This is the path where the file should end up after being synced
         realPath = SharedFiles::realPathForSharedFile(dummyPath);
@@ -257,7 +260,7 @@ TEST_CASE("Test stat and read shared file", "[storage]")
 
     // Set up the shared file
     std::string relativePath = "test/shared-file-stat.txt";
-    std::string fullPath = faabric::util::getSharedFileFile(relativePath);
+    std::string fullPath = conf::getSharedFileFile(relativePath);
     if (boost::filesystem::exists(fullPath)) {
         boost::filesystem::remove(fullPath);
     }

--- a/tests/test/storage/test_fileserver_file_loader.cpp
+++ b/tests/test/storage/test_fileserver_file_loader.cpp
@@ -1,25 +1,28 @@
-#include "faabric/util/bytes.h"
-#include "faabric/util/config.h"
-#include "faabric/util/func.h"
-
-#include "storage/FileserverFileLoader.h"
 #include "utils.h"
-
-#include <boost/filesystem/operations.hpp>
 #include <catch2/catch.hpp>
 
-#include <boost/filesystem.hpp>
+#include <faabric/util/bytes.h>
+#include <faabric/util/config.h>
 #include <faabric/util/files.h>
-#include <stdlib.h>
+#include <faabric/util/func.h>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
+#include <storage/FileserverFileLoader.h>
 #include <storage/LocalFileLoader.h>
 #include <upload/UploadServer.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
+
+#include <stdlib.h>
 
 using namespace storage;
 
 namespace tests {
 TEST_CASE("Test fileserver file loader pulling files over HTTP", "[storage]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     std::string origFunctionStorage = conf.functionStorage;
     std::string origUrl = conf.fileserverUrl;
@@ -29,7 +32,7 @@ TEST_CASE("Test fileserver file loader pulling files over HTTP", "[storage]")
 
     // Load the expected bytes from the function file
     faabric::Message msg = faabric::util::messageFactory("demo", "echo");
-    std::string expectedPath = faabric::util::getFunctionFile(msg);
+    std::string expectedPath = conf::getFunctionFile(msg);
     std::vector<uint8_t> expectedBytes =
       faabric::util::readFileToBytes(expectedPath);
 
@@ -70,7 +73,7 @@ TEST_CASE("Test flushing function files deletes them", "[storage]")
 {
     cleanSystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string origStorage = conf.functionStorage;
     std::string origUrl = conf.fileserverUrl;
     std::string origFunctionDir = conf.functionDir;

--- a/tests/test/storage/test_local_file_loader.cpp
+++ b/tests/test/storage/test_local_file_loader.cpp
@@ -1,11 +1,15 @@
-#include "faabric/util/bytes.h"
-#include "faabric/util/func.h"
-#include <boost/filesystem/operations.hpp>
 #include <catch2/catch.hpp>
 
-#include <boost/filesystem.hpp>
+#include <faabric/util/bytes.h>
 #include <faabric/util/files.h>
+#include <faabric/util/func.h>
+
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <stdlib.h>
+
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <storage/LocalFileLoader.h>
 
 #define SHARED_OBJ                                                             \
@@ -14,6 +18,7 @@
 using namespace storage;
 
 namespace tests {
+
 TEST_CASE("Check uploading and loading shared files", "[storage]")
 {
     std::string relativePath = "test/local_file_loader.txt";
@@ -27,7 +32,7 @@ TEST_CASE("Check uploading and loading shared files", "[storage]")
     REQUIRE(actual == expected);
 
     // Check it's written where we expect it to be too
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     boost::filesystem::path fullPath(conf.sharedFilesStorageDir);
     fullPath.append(relativePath);
 
@@ -43,8 +48,8 @@ TEST_CASE("Check function codegen hashing", "[storage]")
     faabric::Message msgB = faabric::util::messageFactory("demo", "x2");
 
     // Load the existing wasm
-    std::string pathA = faabric::util::getFunctionFile(msgA);
-    std::string pathB = faabric::util::getFunctionFile(msgB);
+    std::string pathA = conf::getFunctionFile(msgA);
+    std::string pathB = conf::getFunctionFile(msgB);
     std::vector<uint8_t> wasmA = faabric::util::readFileToBytes(pathA);
     std::vector<uint8_t> wasmB = faabric::util::readFileToBytes(pathB);
 
@@ -52,7 +57,7 @@ TEST_CASE("Check function codegen hashing", "[storage]")
     msgB.set_inputdata(faabric::util::bytesToString(wasmB));
 
     // Override the storage directories
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string origFuncDir = conf.functionDir;
     std::string origObjDir = conf.objectFileDir;
     conf.functionDir = "/tmp/func";
@@ -161,7 +166,7 @@ TEST_CASE("Check function codegen hashing", "[storage]")
 
 TEST_CASE("Check shared object codegen hashing", "[storage]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string origObjDir = conf.objectFileDir;
     conf.objectFileDir = "/tmp/obj";
 
@@ -214,7 +219,7 @@ TEST_CASE("Check shared object codegen hashing", "[storage]")
 
 TEST_CASE("Test flushing function files does nothing", "[storage]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string origFunctionDir = conf.functionDir;
     std::string origObjDir = conf.objectFileDir;
 

--- a/tests/test/storage/test_shared_files.cpp
+++ b/tests/test/storage/test_shared_files.cpp
@@ -4,6 +4,8 @@
 
 #include <boost/filesystem.hpp>
 
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <faabric/util/files.h>
 #include <storage/SharedFiles.h>
 
@@ -14,10 +16,10 @@ TEST_CASE("Check sync shared file", "[storage]")
 {
     SharedFiles::clear();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string relPath = "shared_test_dir/dummy_file.txt";
     std::string sharedPath = "faasm://" + relPath;
-    std::string realPath = faabric::util::getSharedFileFile(relPath);
+    std::string realPath = conf::getSharedFileFile(relPath);
 
     std::string syncedPath;
     std::string overridePath;

--- a/tests/test/system/test_cgroup.cpp
+++ b/tests/test/system/test_cgroup.cpp
@@ -5,6 +5,7 @@
 #include <faabric/util/files.h>
 #include <faabric/util/string_tools.h>
 
+#include <conf/FaasmConfig.h>
 #include <system/CGroup.h>
 
 #include <boost/algorithm/string.hpp>
@@ -20,7 +21,7 @@ static int cgroupCheckSuccessful = 0;
 
 TEST_CASE("Test cgroup on/ off", "[faaslet]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string original = conf.cgroupMode;
 
     // Ignore this test in CI, not able to run privileged hence can't create
@@ -88,7 +89,7 @@ void checkCgroupAddition()
 
 TEST_CASE("Test adding thread to cpu controller", "[faaslet]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
 
     // Ignore this test in CI, not able to run privileged hence can't create
     // cgroups

--- a/tests/test/system/test_network.cpp
+++ b/tests/test/system/test_network.cpp
@@ -3,6 +3,7 @@
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>
 
+#include <conf/FaasmConfig.h>
 #include <system/NetworkNamespace.h>
 
 using namespace isolation;
@@ -11,7 +12,7 @@ namespace tests {
 
 TEST_CASE("Test basic network properties", "[faaslet]")
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string original = conf.netNsMode;
 
     std::string envValue;

--- a/tests/test/wasm/test_cloning.cpp
+++ b/tests/test/wasm/test_cloning.cpp
@@ -6,6 +6,8 @@
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 
+#include <conf/FaasmConfig.h>
+#include <conf/function_utils.h>
 #include <wavm/WAVMWasmModule.h>
 
 using namespace wasm;
@@ -211,7 +213,7 @@ TEST_CASE("Test cloned execution on complex module", "[wasm]")
 {
     cleanSystem();
 
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string preloadVal = conf.pythonPreload;
     conf.pythonPreload = "off";
 

--- a/tests/test/wasm/test_io.cpp
+++ b/tests/test/wasm/test_io.cpp
@@ -1,5 +1,6 @@
 #include "utils.h"
 #include <catch2/catch.hpp>
+
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>

--- a/tests/test/wavm/test_ir_registry.cpp
+++ b/tests/test/wavm/test_ir_registry.cpp
@@ -4,6 +4,7 @@
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
 
+#include <conf/function_utils.h>
 #include <storage/FileLoader.h>
 #include <wavm/IRModuleCache.h>
 
@@ -68,8 +69,8 @@ TEST_CASE("Test main module caching", "[wasm]")
     REQUIRE(std::addressof(moduleRefA1) != std::addressof(moduleRefB1));
     REQUIRE(objRefA1 != objRefB1);
 
-    const std::string objPathA = faabric::util::getFunctionObjectFile(msgA);
-    const std::string objPathB = faabric::util::getFunctionObjectFile(msgB);
+    const std::string objPathA = conf::getFunctionObjectFile(msgA);
+    const std::string objPathB = conf::getFunctionObjectFile(msgB);
 
     checkObjCode(objRefA1, objPathA);
     checkObjCode(objRefB1, objPathB);
@@ -130,8 +131,8 @@ TEST_CASE("Test shared library caching", "[wasm]")
     REQUIRE(objRefA1 != objRefB1);
 
     // Check object code loaded matches file
-    std::string objPathA = faabric::util::getSharedObjectObjectFile(pathA);
-    std::string objPathB = faabric::util::getSharedObjectObjectFile(pathB);
+    std::string objPathA = conf::getSharedObjectObjectFile(pathA);
+    std::string objPathB = conf::getSharedObjectObjectFile(pathB);
 
     checkObjCode(objRefA1, objPathA);
     checkObjCode(objRefB1, objPathB);

--- a/tests/utils/system_utils.cpp
+++ b/tests/utils/system_utils.cpp
@@ -4,6 +4,7 @@
 
 #include "utils.h"
 
+#include <conf/FaasmConfig.h>
 #include <threads/ThreadState.h>
 #include <wavm/WAVMWasmModule.h>
 
@@ -12,6 +13,9 @@ void cleanSystem()
 {
     // Faabric stuff
     cleanFaabric();
+
+    // Reset config
+    conf::getFaasmConfig().reset();
 
     // Clear thread state
     threads::clearThreadState();

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -12,6 +12,7 @@
 #include <faabric/util/testing.h>
 #include <faaslet/Faaslet.h>
 
+#include <conf/FaasmConfig.h>
 #include <wavm/WAVMWasmModule.h>
 
 using namespace faaslet;
@@ -94,8 +95,9 @@ void execBatchWithPool(std::shared_ptr<faabric::BatchExecuteRequest> req,
     }
 
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
     conf.boundTimeout = 1000;
-    conf.chainedCallTimeout = 10000;
+    faasmConf.chainedCallTimeout = 10000;
 
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
 
@@ -135,9 +137,10 @@ void execFuncWithPool(faabric::Message& call, bool clean, int timeout)
 
     // Modify system config (network ns requires root)
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-    std::string originalNsMode = conf.netNsMode;
+    conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
+    std::string originalNsMode = faasmConf.netNsMode;
     conf.boundTimeout = timeout;
-    conf.netNsMode = "off";
+    faasmConf.netNsMode = "off";
 
     // Set up the system
     auto fac = std::make_shared<faaslet::FaasletFactory>();
@@ -156,14 +159,14 @@ void execFuncWithPool(faabric::Message& call, bool clean, int timeout)
     // Shut down the pool
     m.shutdown();
 
-    conf.netNsMode = originalNsMode;
+    faasmConf.netNsMode = originalNsMode;
 
     cleanSystem();
 }
 
 void doWamrPoolExecution(faabric::Message& msg)
 {
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     const std::string originalVm = conf.wasmVm;
     conf.wasmVm = "wamr";
 

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -10,8 +10,8 @@
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>
 #include <faabric/util/testing.h>
-
 #include <faaslet/Faaslet.h>
+
 #include <wavm/WAVMWasmModule.h>
 
 using namespace faaslet;
@@ -21,7 +21,7 @@ namespace tests {
 void execFunction(faabric::Message& call, const std::string& expectedOutput)
 {
     // Turn off python preloading
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string originalPreload = conf.pythonPreload;
     conf.pythonPreload = "off";
 
@@ -43,7 +43,7 @@ void execFunction(faabric::Message& call, const std::string& expectedOutput)
 std::string execFunctionWithStringResult(faabric::Message& call)
 {
     // Turn off python preloading
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     std::string originalPreload = conf.pythonPreload;
     conf.pythonPreload = "off";
 


### PR DESCRIPTION
Updates to fit with [Faabric PR](https://github.com/faasm/faabric/pull/89).

- Moved config into `FaasmConfig` object
- Added `function_utils.cpp` to hold what was taken from Faabric's function utils
- Changed use of Faabric config to Faasm config where necessary
- Removed use of `auto` on configs to make it clear which one is being used