### PR TITLE
Fix formatting checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,8 +17,11 @@ jobs:
       run:
         working-directory: /usr/local/code/faasm
     steps:
-      - name: "Build the targets to update compile commands and dependencies"
-        run: inv -r faasmcli/faasmcli dev.tools --build Release
+      # --- Get the code ---
+      - name: "Fetch ref"
+        run: git fetch origin ${GITHUB_REF}:ci-branch
+      - name: "Check out branch"
+        run: git checkout --force ci-branch
       # --- Formatting checks ---
       - name: "Ensure all Python deps up-to-date"
         run: pip3 install -r faasmcli/requirements.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ jobs:
         run: git fetch origin ${GITHUB_REF}:ci-branch
       - name: "Check out branch"
         run: git checkout --force ci-branch
+      - name: "Update submodules"
+        run: git submodule update 
       # --- Formatting checks ---
       - name: "Ensure all Python deps up-to-date"
         run: pip3 install -r faasmcli/requirements.txt

--- a/faasmcli/faasmcli/tasks/flame.py
+++ b/faasmcli/faasmcli/tasks/flame.py
@@ -16,9 +16,7 @@ def general(ctx, user, func, cmd=None, data=None, reverse=False):
     """
     Generates a flame graph for the given function
     """
-    print(
-        "Generating flame graph for {}/{}".format(user, func)
-    )
+    print("Generating flame graph for {}/{}".format(user, func))
 
     if not exists(FLAME_GRAPH_DIR):
         print("Cloning FlameGraph")
@@ -32,9 +30,7 @@ def general(ctx, user, func, cmd=None, data=None, reverse=False):
     # Set up the command to be perf'd
     if not cmd:
         func_runner_bin = find_command("func_runner")
-        cmd = " ".join(
-            [func_runner_bin, user, func, data if data else ""]
-        )
+        cmd = " ".join([func_runner_bin, user, func, data if data else ""])
 
     # Set up main perf command
     perf_cmd = ["perf", "record", "-k 1", "-F 99", "-g", cmd]


### PR DESCRIPTION
Solving two problems in the current formatting checks:
1. After #419 we no longer run `clang-tidy` as part of the CI pipeline. Thus, there is no need to update the compilation database.
2. We were not checking out the latest version of the code, hence not really doing any formatting checks on the newly added code.

I also format a file that wasn't formatted and was making the tests fail.