### PR TITLE
Fix MPI Async test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,8 +166,11 @@ jobs:
       - name: "Clear existing pyc files"
         run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
+      - name: "Run one test"
+        run: LOG_LEVEL=trace /build/faasm/bin/tests "Test MPI"
+      # --- Test run ---
       - name: "Run the tests"
-        run: /build/faasm/bin/tests
+        run: LOG_LEVEL=trace /build/faasm/bin/tests
 
   dist-tests:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,7 +167,7 @@ jobs:
         run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
       - name: "Run one test"
-        run: LOG_LEVEL=trace /build/faasm/bin/tests "Test MPI"
+        run: LOG_LEVEL=trace /build/faasm/bin/tests "Test MPI async"
       # --- Test run ---
       - name: "Run the tests"
         run: LOG_LEVEL=trace /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,11 +166,8 @@ jobs:
       - name: "Clear existing pyc files"
         run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
       # --- Test run ---
-      - name: "Run one test"
-        run: LOG_LEVEL=trace /build/faasm/bin/tests "Test MPI async"
-      # --- Test run ---
       - name: "Run the tests"
-        run: LOG_LEVEL=trace /build/faasm/bin/tests
+        run: /build/faasm/bin/tests
 
   dist-tests:
     if: github.event.pull_request.draft == false

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -81,7 +81,6 @@ int spawnChainedThread(const std::string& snapshotKey,
 
     // Snapshot details
     call.set_snapshotkey(snapshotKey);
-    call.set_snapshotsize(snapshotSize);
 
     // Function pointer and args
     // NOTE - with a pthread interface we only ever pass the function a single

--- a/tests/test/faaslet/test_mpi.cpp
+++ b/tests/test/faaslet/test_mpi.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 
 #include <faabric/scheduler/Scheduler.h>
+#include <faabric/util/environment.h>
 #include <faabric/util/func.h>
 
 namespace tests {

--- a/tests/test/faaslet/test_mpi.cpp
+++ b/tests/test/faaslet/test_mpi.cpp
@@ -130,8 +130,8 @@ TEST_CASE("Test MPI window creation", "[mpi]")
     checkMpiFunc("mpi_wincreate");
 }
 
-// TEST_CASE("Test MPI async", "[mpi]")
-//{
-//    checkMpiFunc("mpi_isendrecv");
-//}
+TEST_CASE("Test MPI async", "[mpi]")
+{
+    checkMpiFunc("mpi_isendrecv");
+}
 }


### PR DESCRIPTION
This PR fixes the MPI Async test that was before commented out. The underpinning motive was a bit involved, and the solution involves changes upstream in faabric (faasm/faabric#101) and cpp (faasm/cpp#46).

In short, we were blocking all threads in our async thead pool with non-blocking receives, that were matched by non-blocking sends. The reasonable solution, after discussing offline, was to have always at least one more thread than ranks. Unless, we are in an over-provisioned setting, where we run more ranks than actual cores in the machine, like GHA (note that MPI would also block in this setting). 

To fix the case for the over-provisioned setting, we just need to first do non-blocking sends, then non-blocking receives, as introduced in the PR for cpp.