### PR TITLE
Encapsulate wasm execution context

### DIFF
--- a/include/sgx/SGXWAMRWasmModule.h
+++ b/include/sgx/SGXWAMRWasmModule.h
@@ -55,7 +55,7 @@ class SGXWAMRWasmModule final : public WasmModule
 
     ~SGXWAMRWasmModule() override;
 
-    void doBindToFunction(const faabric::Message& msg, bool cache) override;
+    void doBindToFunction(faabric::Message& msg, bool cache) override;
 
     bool unbindFunction();
 

--- a/include/threads/ThreadState.h
+++ b/include/threads/ThreadState.h
@@ -69,11 +69,11 @@ class Level
 
     void unlockCritical();
 
-    int getLocalThreadNum(const faabric::Message* msg);
+    int getLocalThreadNum(faabric::Message* msg);
 
     int getGlobalThreadNum(int localThreadNum);
 
-    int getGlobalThreadNum(const faabric::Message* msg);
+    int getGlobalThreadNum(faabric::Message* msg);
 };
 
 class PthreadTask

--- a/include/threads/ThreadState.h
+++ b/include/threads/ThreadState.h
@@ -69,11 +69,11 @@ class Level
 
     void unlockCritical();
 
-    int getLocalThreadNum(faabric::Message* msg);
+    int getLocalThreadNum(const faabric::Message* msg);
 
     int getGlobalThreadNum(int localThreadNum);
 
-    int getGlobalThreadNum(faabric::Message* msg);
+    int getGlobalThreadNum(const faabric::Message* msg);
 };
 
 class PthreadTask

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -60,6 +60,4 @@ class WAMRWasmModule final : public WasmModule
 };
 
 void tearDownWAMRGlobally();
-
-WAMRWasmModule* getExecutingWAMRModule();
 }

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -27,7 +27,7 @@ class WAMRWasmModule final : public WasmModule
     ~WAMRWasmModule();
 
     // ----- Module lifecycle -----
-    void doBindToFunction(const faabric::Message& msg, bool cache) override;
+    void doBindToFunction(faabric::Message& msg, bool cache) override;
 
     int32_t executeFunction(faabric::Message& msg) override;
 

--- a/include/wasm/WasmExecutionContext.h
+++ b/include/wasm/WasmExecutionContext.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <wasm/WasmModule.h>
+
+namespace wasm {
+
+class WasmExecutionContext;
+
+WasmExecutionContext* getCurrentWasmExecutionContext();
+
+class WasmExecutionContext
+{
+  public:
+    WasmModule* executingModule = nullptr;
+    faabric::Message* executingCall = nullptr;
+
+    WasmModule* previousModule = nullptr;
+    faabric::Message* previousCall = nullptr;
+
+    WasmExecutionContext(WasmModule* module, faabric::Message* call);
+
+    ~WasmExecutionContext();
+};
+
+WasmModule* getExecutingModule();
+
+faabric::Message* getExecutingCall();
+}

--- a/include/wasm/WasmExecutionContext.h
+++ b/include/wasm/WasmExecutionContext.h
@@ -17,6 +17,9 @@ class WasmExecutionContext
     WasmExecutionContext(WasmModule* module, faabric::Message* call);
 
     ~WasmExecutionContext();
+
+    WasmExecutionContext(const WasmExecutionContext&) = delete;
+    WasmExecutionContext& operator=(const WasmExecutionContext&) = delete;
 };
 
 WasmModule* getExecutingModule();

--- a/include/wasm/WasmExecutionContext.h
+++ b/include/wasm/WasmExecutionContext.h
@@ -14,9 +14,6 @@ class WasmExecutionContext
     WasmModule* executingModule = nullptr;
     faabric::Message* executingCall = nullptr;
 
-    WasmModule* previousModule = nullptr;
-    faabric::Message* previousCall = nullptr;
-
     WasmExecutionContext(WasmModule* module, faabric::Message* call);
 
     ~WasmExecutionContext();

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -64,9 +64,9 @@ class WasmModule
     virtual ~WasmModule();
 
     // ----- Module lifecycle -----
-    virtual void reset(const faabric::Message& msg);
+    virtual void reset(faabric::Message& msg);
 
-    void bindToFunction(const faabric::Message& msg, bool cache = true);
+    void bindToFunction(faabric::Message& msg, bool cache = true);
 
     int32_t executeTask(int threadPoolIdx,
                         int msgIdx,
@@ -186,20 +186,11 @@ class WasmModule
     virtual uint8_t* getMemoryBase();
 
     // Module-specific binding
-    virtual void doBindToFunction(const faabric::Message& msg, bool cache);
+    virtual void doBindToFunction(faabric::Message& msg, bool cache);
 
     // Threads
     void createThreadStacks();
 };
-
-// ----- Global functions -----
-void setExecutingCall(faabric::Message* call);
-
-faabric::Message* getExecutingCall();
-
-void setExecutingModule(wasm::WasmModule* module);
-
-wasm::WasmModule* getExecutingModule();
 
 // Convenience functions
 size_t getNumberOfWasmPagesForBytes(uint32_t nBytes);

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <threads/ThreadState.h>
+#include <wasm/WasmExecutionContext.h>
 #include <wasm/WasmModule.h>
 #include <wavm/LoadedDynamicModule.h>
 
@@ -33,13 +34,13 @@ class WAVMWasmModule final
     ~WAVMWasmModule();
 
     // ----- Module lifecycle -----
-    void doBindToFunction(const faabric::Message& msg, bool cache) override;
+    void doBindToFunction(faabric::Message& msg, bool cache) override;
 
-    void bindToFunctionNoZygote(const faabric::Message& msg);
+    void bindToFunctionNoZygote(faabric::Message& msg);
 
     void flush() override;
 
-    void reset(const faabric::Message& msg) override;
+    void reset(faabric::Message& msg) override;
 
     // ----- Memory management -----
     uint32_t growMemory(uint32_t nBytes) override;
@@ -175,7 +176,7 @@ class WAVMWasmModule final
 
     static WAVM::Runtime::Instance* getWasiModule();
 
-    void doBindToFunctionInternal(const faabric::Message& msg,
+    void doBindToFunctionInternal(faabric::Message& msg,
                                   bool executeZygote,
                                   bool useCache);
 
@@ -210,9 +211,9 @@ class WAVMWasmModule final
 class WAVMModuleCache
 {
   public:
-    wasm::WAVMWasmModule& getCachedModule(const faabric::Message& msg);
+    wasm::WAVMWasmModule& getCachedModule(faabric::Message& msg);
 
-    void initialiseCachedModule(const faabric::Message& msg);
+    void initialiseCachedModule(faabric::Message& msg);
 
     void clear();
 

--- a/src/faaslet/Faaslet.cpp
+++ b/src/faaslet/Faaslet.cpp
@@ -106,7 +106,7 @@ int32_t Faaslet::executeTask(int threadPoolIdx,
                              int msgIdx,
                              std::shared_ptr<faabric::BatchExecuteRequest> req)
 {
-    const faabric::Message& msg = req->mutable_messages()->at(msgIdx);
+    faabric::Message& msg = req->mutable_messages()->at(msgIdx);
 
     // Lazily bind to function and isolate
     // Note that this has to be done within the executeTask function to be in
@@ -130,7 +130,9 @@ int32_t Faaslet::executeTask(int threadPoolIdx,
 
 void Faaslet::reset(const faabric::Message& msg)
 {
-    module->reset(msg);
+    // TODO - avoid this copy, need to remove the const
+    faabric::Message msgCopy = msg;
+    module->reset(msgCopy);
 }
 
 void Faaslet::postFinish()

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -127,7 +127,7 @@ int32_t SGXWAMRWasmModule::executeFunction(faabric::Message& msg)
       "Entering enclave {} to execute {}", globalEnclaveId, funcStr);
 
     // Set execution context
-    wasm::WasmExecutionContext(this, &msg);
+    wasm::WasmExecutionContext ctx(this, &msg);
 
     // Enter enclave and call function
     faasm_sgx_status_t returnValue;

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -4,6 +4,7 @@
 #include <sgx/SGXWAMRWasmModule.h>
 #include <sgx/faasm_sgx_attestation.h>
 #include <sgx/faasm_sgx_system.h>
+#include <wasm/WasmExecutionContext.h>
 
 extern "C"
 {
@@ -46,7 +47,7 @@ SGXWAMRWasmModule::~SGXWAMRWasmModule()
     }
 }
 
-void SGXWAMRWasmModule::doBindToFunction(const faabric::Message& msg,
+void SGXWAMRWasmModule::doBindToFunction(faabric::Message& msg,
                                          bool cache)
 {
     auto logger = faabric::util::getLogger();
@@ -126,8 +127,8 @@ int32_t SGXWAMRWasmModule::executeFunction(faabric::Message& msg)
     logger->debug(
       "Entering enclave {} to execute {}", globalEnclaveId, funcStr);
 
-    // Set executing module
-    setExecutingModule(this);
+    // Set execution context
+    wasm::WasmExecutionContext((WasmModule*)this, &msg);
 
     // Enter enclave and call function
     faasm_sgx_status_t returnValue;

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -47,8 +47,7 @@ SGXWAMRWasmModule::~SGXWAMRWasmModule()
     }
 }
 
-void SGXWAMRWasmModule::doBindToFunction(faabric::Message& msg,
-                                         bool cache)
+void SGXWAMRWasmModule::doBindToFunction(faabric::Message& msg, bool cache)
 {
     auto logger = faabric::util::getLogger();
 
@@ -128,7 +127,7 @@ int32_t SGXWAMRWasmModule::executeFunction(faabric::Message& msg)
       "Entering enclave {} to execute {}", globalEnclaveId, funcStr);
 
     // Set execution context
-    wasm::WasmExecutionContext((WasmModule*)this, &msg);
+    wasm::WasmExecutionContext(this, &msg);
 
     // Enter enclave and call function
     faasm_sgx_status_t returnValue;

--- a/src/threads/ThreadState.cpp
+++ b/src/threads/ThreadState.cpp
@@ -226,7 +226,7 @@ void Level::unlockCritical()
 // local thread number must fit with that expected by OpenMP within the team/
 // level. We use Faabric messages to hold the global thread number and can
 // translated back and forth.
-int Level::getLocalThreadNum(const faabric::Message* msg)
+int Level::getLocalThreadNum(faabric::Message* msg)
 {
     if (depth == 0) {
         return msg->appindex();
@@ -256,7 +256,7 @@ int Level::getGlobalThreadNum(int localThreadNum)
     return localThreadNum + globalTidOffset;
 }
 
-int Level::getGlobalThreadNum(const faabric::Message* msg)
+int Level::getGlobalThreadNum(faabric::Message* msg)
 {
     return msg->appindex();
 }

--- a/src/threads/ThreadState.cpp
+++ b/src/threads/ThreadState.cpp
@@ -226,7 +226,7 @@ void Level::unlockCritical()
 // local thread number must fit with that expected by OpenMP within the team/
 // level. We use Faabric messages to hold the global thread number and can
 // translated back and forth.
-int Level::getLocalThreadNum(faabric::Message* msg)
+int Level::getLocalThreadNum(const faabric::Message* msg)
 {
     if (depth == 0) {
         return msg->appindex();
@@ -256,7 +256,7 @@ int Level::getGlobalThreadNum(int localThreadNum)
     return localThreadNum + globalTidOffset;
 }
 
-int Level::getGlobalThreadNum(faabric::Message* msg)
+int Level::getGlobalThreadNum(const faabric::Message* msg)
 {
     return msg->appindex();
 }

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -120,7 +120,7 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
     logger->debug("WAMR executing message {}", msg.id());
 
     // Make sure context is set
-    WasmExecutionContext(this, &msg);
+    WasmExecutionContext ctx(this, &msg);
 
     // Run wasm initialisers
     executeWasmFunction(WASM_CTORS_FUNC_NAME);

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -124,8 +124,10 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
     const auto& logger = faabric::util::getLogger();
     logger->debug("WAMR executing message {}", msg.id());
 
+    // Make sure context is set
+    WasmExecutionContext(this, &msg);
+
     // Run wasm initialisers
-    wasm::WasmExecutionContext(this, &msg);
     executeWasmFunction(WASM_CTORS_FUNC_NAME);
 
     if (msg.funcptr() > 0) {

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -1,14 +1,14 @@
 #include "WAMRWasmModule.h"
 #include "aot_runtime.h"
-#include "faabric/util/logging.h"
 #include "platform_common.h"
-#include "wasm/WasmModule.h"
 #include "wasm_exec_env.h"
 #include "wasm_runtime.h"
 
 #include <faabric/util/locks.h>
+#include <faabric/util/logging.h>
 #include <wamr/native.h>
 #include <wasm/WasmExecutionContext.h>
+#include <wasm/WasmModule.h>
 
 #include <cstdint>
 #include <stdexcept>
@@ -52,11 +52,6 @@ void WAMRWasmModule::initialiseWAMRGlobally()
 void tearDownWAMRGlobally()
 {
     wasm_runtime_destroy();
-}
-
-WAMRWasmModule* getExecutingWAMRModule()
-{
-    return reinterpret_cast<WAMRWasmModule*>(getExecutingModule());
 }
 
 WAMRWasmModule::WAMRWasmModule()

--- a/src/wamr/funcs.cpp
+++ b/src/wamr/funcs.cpp
@@ -2,8 +2,8 @@
 #include <faabric/util/bytes.h>
 #include <faabric/util/macros.h>
 #include <wamr/native.h>
-#include <wasm/WasmModule.h>
 #include <wasm/WasmExecutionContext.h>
+#include <wasm/WasmModule.h>
 #include <wasm/chaining.h>
 #include <wasm_export.h>
 

--- a/src/wamr/funcs.cpp
+++ b/src/wamr/funcs.cpp
@@ -3,6 +3,7 @@
 #include <faabric/util/macros.h>
 #include <wamr/native.h>
 #include <wasm/WasmModule.h>
+#include <wasm/WasmExecutionContext.h>
 #include <wasm/chaining.h>
 #include <wasm_export.h>
 

--- a/src/wamr/memory.cpp
+++ b/src/wamr/memory.cpp
@@ -1,6 +1,7 @@
 #include <faabric/proto/faabric.pb.h>
 #include <wamr/WAMRWasmModule.h>
 #include <wamr/native.h>
+#include <wasm/WasmExecutionContext.h>
 #include <wasm/WasmModule.h>
 #include <wasm_export.h>
 
@@ -9,7 +10,7 @@ static int32_t __sbrk_wrapper(wasm_exec_env_t exec_env, int32_t increment)
 {
     // Note trace logging here as this is called a lot
     faabric::util::getLogger()->trace("S - __sbrk - {}", increment);
-    WAMRWasmModule* module = getExecutingWAMRModule();
+    WasmModule* module = getExecutingModule();
     uint32_t oldBrk = module->getCurrentBrk();
 
     if (increment == 0) {

--- a/src/wamr/state.cpp
+++ b/src/wamr/state.cpp
@@ -1,6 +1,7 @@
 #include <faabric/proto/faabric.pb.h>
 #include <wamr/WAMRWasmModule.h>
 #include <wamr/native.h>
+#include <wasm/WasmExecutionContext.h>
 #include <wasm/WasmModule.h>
 #include <wasm_export.h>
 

--- a/src/wamr/state.cpp
+++ b/src/wamr/state.cpp
@@ -51,7 +51,7 @@ static int32_t __faasm_read_state_ptr_wrapper(wasm_exec_env_t exec_env,
       "S - faasm_read_state_ptr - {} {}", kv->key, bufferLen);
 
     // Map shared memory
-    WAMRWasmModule* module = getExecutingWAMRModule();
+    WasmModule* module = getExecutingModule();
     uint32_t wasmPtr = module->mapSharedStateMemory(kv, 0, bufferLen);
 
     // Call get to make sure the value is pulled

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS
 
 set(LIB_FILES
         WasmEnvironment.cpp
+        WasmExecutionContext.cpp
         WasmModule.cpp
         chaining_util.cpp
         ${HEADERS}

--- a/src/wasm/WasmExecutionContext.cpp
+++ b/src/wasm/WasmExecutionContext.cpp
@@ -5,7 +5,7 @@
 namespace wasm {
 
 // Using global TLS here to isolate between executing functions and support the
-// globally accessible accessor methods to access the current context
+// global accessor methods for the current context
 static thread_local std::stack<WasmExecutionContext*> contexts;
 
 WasmExecutionContext::WasmExecutionContext(WasmModule* module,

--- a/src/wasm/WasmExecutionContext.cpp
+++ b/src/wasm/WasmExecutionContext.cpp
@@ -1,0 +1,47 @@
+#include <wasm/WasmExecutionContext.h>
+
+namespace wasm {
+
+// Using TLS here to isolate between executing functions
+// Note that with threads, multiple messages can be executing on the same
+// module, hence we must track them independently.
+static thread_local WasmExecutionContext* currentExecutionContext = nullptr;
+
+WasmExecutionContext::WasmExecutionContext(WasmModule* module,
+                                           faabric::Message* call)
+{
+    if (currentExecutionContext != nullptr) {
+        previousModule = currentExecutionContext->executingModule;
+        previousCall = currentExecutionContext->executingCall;
+    }
+
+    executingModule = module;
+    executingCall = call;
+
+    currentExecutionContext = this;
+}
+
+WasmExecutionContext::~WasmExecutionContext()
+{
+    executingModule = previousModule;
+    executingCall = previousCall;
+}
+
+WasmModule* getExecutingModule()
+{
+    if (currentExecutionContext == nullptr) {
+        return nullptr;
+    }
+
+    return currentExecutionContext->executingModule;
+}
+
+faabric::Message* getExecutingCall()
+{
+    if (currentExecutionContext == nullptr) {
+        return nullptr;
+    }
+
+    return currentExecutionContext->executingCall;
+}
+}

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -2,6 +2,7 @@
 
 #include <conf/FaasmConfig.h>
 #include <threads/ThreadState.h>
+#include <wasm/WasmExecutionContext.h>
 
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
@@ -20,12 +21,6 @@
 #include <sys/uio.h>
 
 namespace wasm {
-// Using TLS here to isolate between executing functions
-// Note that with threads, multiple messages can be executing on the same
-// module, hence we must track them independently.
-static thread_local wasm::WasmModule* executingModule = nullptr;
-
-static thread_local faabric::Message* executingCall = nullptr;
 
 bool isWasmPageAligned(int32_t offset)
 {
@@ -34,53 +29,6 @@ bool isWasmPageAligned(int32_t offset)
     } else {
         return true;
     }
-}
-
-// This function remains for compatibility
-faabric::Message* getExecutingCall()
-{
-    assert(executingCall != nullptr);
-    return executingCall;
-}
-
-void setExecutingCall(faabric::Message* msg)
-{
-    // Although the executing msg can be overridden, we only want to do so
-    // with another message for the same function (e.g. when executing
-    // threads).
-    if (msg != nullptr) {
-        assert(!msg->user().empty());
-        assert(!msg->function().empty());
-
-        assert(executingModule->getBoundUser().empty() ||
-               executingModule->getBoundUser() == msg->user());
-        assert(executingModule->getBoundFunction().empty() ||
-               executingModule->getBoundFunction() == msg->function());
-    }
-
-    executingCall = msg;
-}
-
-wasm::WasmModule* getExecutingModule()
-{
-    assert(executingModule != nullptr);
-    return executingModule;
-}
-
-void setExecutingModule(wasm::WasmModule* module)
-{
-    // We should not be changing the executing module associated with this
-    // thread, only setting it for the first time, unsetting it, or harmlessly
-    // resetting the same value
-    if (executingModule != nullptr && module != nullptr &&
-        executingModule != module) {
-
-        assert(executingModule->getBoundFunction() ==
-               module->getBoundFunction());
-        assert(executingModule->getBoundUser() == module->getBoundUser());
-    }
-
-    executingModule = module;
 }
 
 size_t getNumberOfWasmPagesForBytes(uint32_t nBytes)
@@ -275,7 +223,7 @@ uint32_t WasmModule::getArgvBufferSize()
     return argvBufferSize;
 }
 
-void WasmModule::bindToFunction(const faabric::Message& msg, bool cache)
+void WasmModule::bindToFunction(faabric::Message& msg, bool cache)
 {
     if (_isBound) {
         throw std::runtime_error("Cannot bind a module twice");
@@ -285,7 +233,8 @@ void WasmModule::bindToFunction(const faabric::Message& msg, bool cache)
     boundUser = msg.user();
     boundFunction = msg.function();
 
-    // Call module-specific steps
+    // Set up context and call subclass hook
+    WasmExecutionContext(this, &msg);
     doBindToFunction(msg, cache);
 }
 
@@ -379,8 +328,7 @@ int32_t WasmModule::executeTask(
     assert(boundFunction == msg.function());
 
     // Set up context for this task
-    setExecutingModule(this);
-    setExecutingCall(&msg);
+    WasmExecutionContext ctx(this, &msg);
 
     // Modules must have provisioned their own thread stacks
     assert(!threadStacks.empty());
@@ -482,12 +430,12 @@ bool WasmModule::isBound()
 // Functions to be implemented by subclasses
 // ------------------------------------------
 
-void WasmModule::reset(const faabric::Message& msg)
+void WasmModule::reset(faabric::Message& msg)
 {
     faabric::util::getLogger()->warn("Using default reset of wasm module");
 }
 
-void WasmModule::doBindToFunction(const faabric::Message& msg, bool cache)
+void WasmModule::doBindToFunction(faabric::Message& msg, bool cache)
 {
     throw std::runtime_error("doBindToFunction not implemented");
 }

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -233,8 +233,8 @@ void WasmModule::bindToFunction(faabric::Message& msg, bool cache)
     boundUser = msg.user();
     boundFunction = msg.function();
 
-    // Set up context and call subclass hook
-    WasmExecutionContext(this, &msg);
+    // Call into subclass hook, setting the context beforehand
+    WasmExecutionContext ctx(this, &msg);
     doBindToFunction(msg, cache);
 }
 

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -4,9 +4,8 @@
 #include <faabric/util/bytes.h>
 #include <faabric/util/func.h>
 
-#include <wasm/chaining.h>
-
 #include <conf/FaasmConfig.h>
+#include <wasm/WasmExecutionContext.h>
 #include <wasm/chaining.h>
 
 namespace wasm {

--- a/src/wavm/WAVMModuleCache.cpp
+++ b/src/wavm/WAVMModuleCache.cpp
@@ -25,8 +25,7 @@ int WAVMModuleCache::getCachedModuleCount(const std::string& key)
     return count;
 }
 
-wasm::WAVMWasmModule& WAVMModuleCache::getCachedModule(
-  const faabric::Message& msg)
+wasm::WAVMWasmModule& WAVMModuleCache::getCachedModule(faabric::Message& msg)
 {
     std::string key = faabric::util::funcToString(msg, false);
     if (cachedModuleMap.count(key) == 0) {
@@ -42,7 +41,7 @@ wasm::WAVMWasmModule& WAVMModuleCache::getCachedModule(
     return cachedModuleMap[key];
 }
 
-void WAVMModuleCache::initialiseCachedModule(const faabric::Message& msg)
+void WAVMModuleCache::initialiseCachedModule(faabric::Message& msg)
 {
     std::string key = faabric::util::funcToString(msg, false);
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -15,8 +15,8 @@
 
 #include <storage/SharedFiles.h>
 #include <threads/ThreadState.h>
-#include <wasm/WasmModule.h>
 #include <wasm/WasmExecutionContext.h>
+#include <wasm/WasmModule.h>
 #include <wavm/IRModuleCache.h>
 #include <wavm/WAVMWasmModule.h>
 
@@ -824,9 +824,6 @@ int32_t WAVMWasmModule::executeFunction(faabric::Message& msg)
 
     const auto& logger = faabric::util::getLogger();
 
-    // Set execution context
-    wasm::WasmExecutionContext ctx(this, &msg);
-
     // Ensure Python function file in place (if necessary)
     storage::SharedFiles::syncPythonFunctionFile(msg);
 
@@ -879,6 +876,7 @@ int32_t WAVMWasmModule::executeFunction(faabric::Message& msg)
     }
 
     // Call the function
+    WasmExecutionContext ctx(this, &msg);
     int returnValue = 0;
     try {
         Runtime::catchRuntimeExceptions(

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -26,7 +26,7 @@ namespace wasm {
 
 #define OMP_FUNC(str)                                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    faabric::Message* msg = getExecutingCall();                                \
+    const faabric::Message* msg = getExecutingCall();                                \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \
@@ -34,7 +34,7 @@ namespace wasm {
 
 #define OMP_FUNC_ARGS(formatStr, ...)                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    faabric::Message* msg = getExecutingCall();                                \
+    const faabric::Message* msg = getExecutingCall();                                \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \
@@ -458,7 +458,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
         // Set up the context for the next level
         threads::setCurrentOpenMPLevel(nextLevel);
-        setExecutingCall(&masterMsg);
+        wasm::WasmExecutionContext(parentModule, &masterMsg);
 
         // Execute the task
         logger->debug("OpenMP 0: executing OMP thread 0 (master)");
@@ -469,7 +469,6 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
         // Reset the context
         threads::setCurrentOpenMPLevel(parentLevel);
-        setExecutingCall(parentCall);
 
         if (masterThreadResult.i32 > 0) {
             throw std::runtime_error("Master OpenMP thread failed");

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -26,7 +26,7 @@ namespace wasm {
 
 #define OMP_FUNC(str)                                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    const faabric::Message* msg = getExecutingCall();                          \
+    faabric::Message* msg = getExecutingCall();                                \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \
@@ -34,7 +34,7 @@ namespace wasm {
 
 #define OMP_FUNC_ARGS(formatStr, ...)                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    const faabric::Message* msg = getExecutingCall();                          \
+    faabric::Message* msg = getExecutingCall();                                \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -26,7 +26,7 @@ namespace wasm {
 
 #define OMP_FUNC(str)                                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    const faabric::Message* msg = getExecutingCall();                                \
+    const faabric::Message* msg = getExecutingCall();                          \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \
@@ -34,7 +34,7 @@ namespace wasm {
 
 #define OMP_FUNC_ARGS(formatStr, ...)                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    const faabric::Message* msg = getExecutingCall();                                \
+    const faabric::Message* msg = getExecutingCall();                          \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     auto logger = faabric::util::getLogger();                                  \

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -458,14 +458,17 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
         // Set up the context for the next level
         threads::setCurrentOpenMPLevel(nextLevel);
-        wasm::WasmExecutionContext(parentModule, &masterMsg);
 
-        // Execute the task
-        logger->debug("OpenMP 0: executing OMP thread 0 (master)");
-        WAVM::Runtime::Function* microtaskFunc =
-          parentModule->getFunctionFromPtr(microtaskPtr);
-        parentModule->executeWasmFunction(
-          microtaskFunc, mainArguments, masterThreadResult);
+        {
+            wasm::WasmExecutionContext ctx(parentModule, &masterMsg);
+
+            // Execute the task
+            logger->debug("OpenMP 0: executing OMP thread 0 (master)");
+            WAVM::Runtime::Function* microtaskFunc =
+              parentModule->getFunctionFromPtr(microtaskPtr);
+            parentModule->executeWasmFunction(
+              microtaskFunc, mainArguments, masterThreadResult);
+        }
 
         // Reset the context
         threads::setCurrentOpenMPLevel(parentLevel);

--- a/tests/test/faaslet/test_flushing.cpp
+++ b/tests/test/faaslet/test_flushing.cpp
@@ -48,9 +48,8 @@ TEST_CASE("Test flushing clears cached modules", "[flush]")
 {
     cleanSystem();
 
-    const faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
-    const faabric::Message msgB =
-      faabric::util::messageFactory("demo", "dummy");
+    faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
+    faabric::Message msgB = faabric::util::messageFactory("demo", "dummy");
 
     // Note, these have to be executed in a separate thread to fit with the
     // module's isolation expectation

--- a/tests/test/wasm/test_execution_context.cpp
+++ b/tests/test/wasm/test_execution_context.cpp
@@ -1,0 +1,39 @@
+#include "utils.h"
+#include <catch2/catch.hpp>
+
+#include <faabric/util/func.h>
+#include <wasm/WasmExecutionContext.h>
+#include <wavm/WAVMWasmModule.h>
+
+namespace tests {
+
+TEST_CASE("Test nesting wasm execution contexts", "[wasm]")
+{
+    wasm::WAVMWasmModule moduleA;
+    wasm::WAVMWasmModule moduleB;
+
+    faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
+    faabric::Message msgB = faabric::util::messageFactory("demo", "hello");
+
+    REQUIRE(wasm::getExecutingCall() == nullptr);
+    REQUIRE(wasm::getExecutingModule() == nullptr);
+
+    {
+        wasm::WasmExecutionContext ctxA(&moduleA, &msgA);
+        REQUIRE(wasm::getExecutingModule() == &moduleA);
+        REQUIRE(wasm::getExecutingCall() == &msgA);
+
+        {
+            wasm::WasmExecutionContext ctxB(&moduleB, &msgB);
+            REQUIRE(wasm::getExecutingModule() == &moduleB);
+            REQUIRE(wasm::getExecutingCall() == &msgB);
+        }
+
+        REQUIRE(wasm::getExecutingModule() == &moduleA);
+        REQUIRE(wasm::getExecutingCall() == &msgA);
+    }
+
+    REQUIRE(wasm::getExecutingCall() == nullptr);
+    REQUIRE(wasm::getExecutingModule() == nullptr);
+}
+}

--- a/tests/test/wasm/test_wasm_state.cpp
+++ b/tests/test/wasm/test_wasm_state.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Test loading state into wasm module", "[wasm]")
     wasm::WAVMWasmModule moduleA;
     wasm::WAVMWasmModule moduleB;
 
-    const faabric::Message call = faabric::util::messageFactory("demo", "echo");
+    faabric::Message call = faabric::util::messageFactory("demo", "echo");
     moduleA.bindToFunction(call);
     moduleB.bindToFunction(call);
 
@@ -121,7 +121,7 @@ TEST_CASE("Test mapping state chunk from remote state", "[state]")
 
     // Create a wasm module
     wasm::WAVMWasmModule module;
-    const faabric::Message call = faabric::util::messageFactory("demo", "echo");
+    faabric::Message call = faabric::util::messageFactory("demo", "echo");
     module.bindToFunction(call);
 
     // Map the chunk locally

--- a/tests/utils/system_utils.cpp
+++ b/tests/utils/system_utils.cpp
@@ -26,9 +26,6 @@ void cleanSystem()
     // Clear cached modules
     wasm::getWAVMModuleCache().clear();
 
-    // Make sure execution state doesn't bleed across
-    wasm::setExecutingModule(nullptr);
-
     // Set Faaslets as the executors
     std::shared_ptr<faabric::scheduler::ExecutorFactory> fac =
       std::make_shared<faaslet::FaasletFactory>();


### PR DESCRIPTION
To give intrinsic functions access to the executing module and call, we set them as global thread-local variables with global accessor methods. 

Currently the logic for this is spread around the place and because it's handled with global variables, can end up affecting subsequent executions if not cleared up properly. It's also wrapped in a load of assertions because it's so fragile, and these assertions enforce needless restrictions (e.g. each thread can only ever set one executing call and not be changed).

In an attempt to tidy things up I've encapsulated this context into a class which hides the use of the local variables and uses RAII-like scoping, i.e. I can do something like:

```
// No execution context set

{
    WasmExecutionContext ctxA(moduleA, callA);
    // Execution context set to moduleA and callA
    
    { 
        WasmExecutionContext ctxB(moduleB, callB);
        // Execution context set to moduleB and callB
    }

    // Execution context set to moduleA and callA
}

// No execution context set
```

Unfortunately things rely on having access to a non-const `Message` object, so there's a bit of a cascade of non-const-ifying and I've had to add one unnecessary copy when resetting the context.