### PR TITLE
Faabric update: per-host flushing, dirty pages integration

### DIFF
--- a/include/faaslet/Faaslet.h
+++ b/include/faaslet/Faaslet.h
@@ -18,8 +18,6 @@ class Faaslet final : public faabric::scheduler::Executor
 
     std::unique_ptr<wasm::WasmModule> module;
 
-    void flush() override;
-
     void reset(faabric::Message& msg) override;
 
     int32_t executeTask(
@@ -27,12 +25,16 @@ class Faaslet final : public faabric::scheduler::Executor
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req) override;
 
+     faabric::util::SnapshotData snapshot() override;
+
   protected:
     void postFinish() override;
 
     void restore(faabric::Message& call) override;
 
   private:
+    bool isIsolated = false;
+
     std::shared_ptr<isolation::NetworkNamespace> ns;
 };
 
@@ -43,7 +45,9 @@ class FaasletFactory final : public faabric::scheduler::ExecutorFactory
 
   protected:
     std::shared_ptr<faabric::scheduler::Executor> createExecutor(
-      faabric::Message& msg);
+      faabric::Message& msg) override;
+
+    void flushHost() override;
 };
 
 void preloadPythonRuntime();

--- a/include/faaslet/Faaslet.h
+++ b/include/faaslet/Faaslet.h
@@ -25,7 +25,7 @@ class Faaslet final : public faabric::scheduler::Executor
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req) override;
 
-     faabric::util::SnapshotData snapshot() override;
+    faabric::util::SnapshotData snapshot() override;
 
   protected:
     void postFinish() override;

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -140,6 +140,8 @@ class WasmModule
     virtual size_t getMemorySizeBytes();
 
     // ----- Snapshot/ restore -----
+    faabric::util::SnapshotData getSnapshotData();
+
     std::string snapshot(bool locallyRestorable = true);
 
     void restore(const std::string& snapshotKey);

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -33,12 +33,12 @@ class WAVMWasmModule final
 
     ~WAVMWasmModule();
 
+    static void clearCaches();
+
     // ----- Module lifecycle -----
     void doBindToFunction(faabric::Message& msg, bool cache) override;
 
     void bindToFunctionNoZygote(faabric::Message& msg);
-
-    void flush() override;
 
     void reset(faabric::Message& msg) override;
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -65,6 +65,12 @@ static void instantiateBaseModules()
     PROF_END(BaseWasiModule)
 }
 
+void WAVMWasmModule::clearCaches()
+{
+    getIRModuleCache().clear();
+    getWAVMModuleCache().clear();
+}
+
 void WAVMWasmModule::reset(faabric::Message& msg)
 {
     if (!_isBound) {
@@ -75,17 +81,11 @@ void WAVMWasmModule::reset(faabric::Message& msg)
     assert(msg.function() == boundFunction);
 
     std::string funcStr = faabric::util::funcToString(msg, true);
-    SPDLOG_DEBUG("{} Resetting after {}", gettid(), funcStr);
+    SPDLOG_DEBUG("Resetting after {}", funcStr);
     wasm::WAVMWasmModule& cachedModule =
       wasm::getWAVMModuleCache().getCachedModule(msg);
 
     clone(cachedModule);
-}
-
-void WAVMWasmModule::flush()
-{
-    getIRModuleCache().clear();
-    getWAVMModuleCache().clear();
 }
 
 Runtime::Instance* WAVMWasmModule::getEnvModule()

--- a/tests/test/faaslet/test_flushing.cpp
+++ b/tests/test/faaslet/test_flushing.cpp
@@ -38,9 +38,7 @@ TEST_CASE("Test flushing clears shared files", "[flush]")
     REQUIRE(boost::filesystem::exists(sharedPath));
 
     // Flush and check file is gone
-    faabric::Message msg = faabric::util::messageFactory("demo", "echo");
-    faaslet::Faaslet f(msg);
-    f.flush();
+    faabric::scheduler::getExecutorFactory()->flushHost();
     REQUIRE(!boost::filesystem::exists(sharedPath));
 }
 
@@ -69,8 +67,7 @@ TEST_CASE("Test flushing clears cached modules", "[flush]")
     wasm::WAVMModuleCache& cache = wasm::getWAVMModuleCache();
     REQUIRE(cache.getTotalCachedModuleCount() == 2);
 
-    faaslet::Faaslet f(msgA);
-    f.flush();
+    faabric::scheduler::getExecutorFactory()->flushHost();
     REQUIRE(cache.getTotalCachedModuleCount() == 0);
 }
 
@@ -90,7 +87,7 @@ TEST_CASE("Test flushing clears IR module cache", "[flush]")
     REQUIRE(cache.isModuleCached("demo", "echo", ""));
 
     // Flush and check it's gone
-    f.flush();
+    faabric::scheduler::getExecutorFactory()->flushHost();
     REQUIRE(!cache.isModuleCached("demo", "echo", ""));
 }
 


### PR DESCRIPTION
Change to `FaasletFactory::flushHost` from `Faaslet::flush` for host-wise flushing: https://github.com/faasm/faabric/pull/112

Add Faaslet `snapshot()` method to hook into Faabric dirty page checking: https://github.com/faasm/faabric/pull/96 

