### PR TITLE
Remove barrier in MPI Init

### DIFF
--- a/src/wavm/mpi.cpp
+++ b/src/wavm/mpi.cpp
@@ -148,11 +148,6 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env, "MPI_Init", I32, MPI_Init, I32 a, I32 b)
         executingContext.joinWorld(*call);
     }
 
-    // We want to synchronise everyone here on a barrier
-    int thisRank = executingContext.getRank();
-    faabric::scheduler::MpiWorld& world = getExecutingWorld();
-    world.barrier(thisRank);
-
     return 0;
 }
 


### PR DESCRIPTION
As discussed offline, after removing the state dependency for bootstrapping an MPI world, there should be no need to syncrhonize at the end of an `MPI_Init` call.