### PR TITLE
Add codegen for SGX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(FAASM_SGX_SIM_MODE "Turn on SGX sim mode" ON)
 option(FAASM_SGX_ATTESTATION "Turn on attestation" OFF)
 option(FAASM_SGX_XRA "Turn on support for XRA" OFF)
 option(FAASM_SGX_WAMR_AOT_MODE "Turn on AoT mode in SGX" OFF)
-set (FAASM_SGX_WAMR_AOT_MODE OFF)
+set (FAASM_SGX_WAMR_AOT_MODE ON)
 
 # Note - whitelisting currently not working in WAMR AoT mode
 option(FAASM_SGX_WHITELISTING "Add support for whitelisting" OFF)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ the distributed messaging and state layer.
 
 The underlying WebAssembly execution and code generation is built using
 [WAVM](https://github.com/WAVM/WAVM). 
+Support for running functions inside SGX enclaves is achieved using
+[WAMR](https://github.com/bytecodealliance/wasm-micro-runtime).
 
 Faasm defines a custom [host interface](docs/host_interface.md) which extends
 [WASI](https://wasi.dev/) to include function inputs and outputs, chaining

--- a/docs/sgx.md
+++ b/docs/sgx.md
@@ -4,12 +4,28 @@ Faasm provides
 [SGX](https://software.intel.com/content/www/us/en/develop/topics/software-guard-extensions.html)
 support using [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime).
 
-You can read the latest SGX Linux developer instructions 
-[here](https://download.01.org/intel-sgx/latest/linux-latest/docs/Intel_SGX_Developer_Guide.pdf).
+## Quick start
 
-[@J-Heinemann](https://github.com/J-Heinemann) is responsible for a lot of the
-SGX work in Faasm, but some messy merges have mixed up ownership of a couple of
-commits.
+SGX support is currently only available for development clusters.
+Note that the following will run in simulation mode.
+
+```bash
+# Start development cluster, and log into the cpp container
+./bin/cli.sh cpp
+
+# Compile the demo function
+(cpp) inv func demo hello
+
+# Exit the cpp container, and log into the CLI one
+(cpp) exit
+./bin/cli.sh faasm
+
+# Generate machine code for SGX
+inv codegen demo hello --wamr --sgx
+
+# Run the code
+inv run demo hello --wamr --sgx
+```
 
 ## SGX Set-up
 
@@ -55,19 +71,3 @@ Low-level SGX-related customisation is found in [the SGX-specific
   only available if `FAASM_SGX_WAMR_AOT_MODE=OFF`.  Default is off.
 - `FAASM_SGX_XRA` - Enables the eXtended Remote Attestation mechanism. Default 
   is off.
-
-### Low-Level Options
-
-- `FAASM_SGX_DEBUG`- Prints debug information messages.  Useful for development
-  but slows down the execution.  Default is 1
-- `FAASM_SGX_INIT_TCS_SLOTS` - Specifies the amount of Faasm-SGX TCS slots after
-  initialization.  Its recommended (but not necessary) to use the same number as
-  available SGX TCS.  Default is 2.
-- `FAASM_SGX_WAMR_BUILDIN_LIBC` - This option enables the WAMR built-in libc.
-  Default is 1 (enabled).
-- `FAASM_SGX_WAMR_WASI_LIBC` - This option enables WASI support. If this option 
-  is enabled, please set `#define FAASM_SGX_WAMR_WASI_LIBC 1` in 
-  [faasm_sgx_enclave.edl](../src/sgx/faasm_sgx_enclave.edl). Default is 0 
-  (disabled).
-- `SGX_DEBUG_MODE` - This option enables or disables the SGX debug mode. 
-  Default is 1 (enabled).

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -28,7 +28,7 @@ def codegen(ctx, user, function, wamr=False, sgx=False):
         }
     )
 
-    if ((not wamr) and sgx):
+    if (not wamr) and sgx:
         print("Can't run SGX codegen with WAVM. Add --wamr flag.")
         exit(1)
 
@@ -42,21 +42,21 @@ def codegen(ctx, user, function, wamr=False, sgx=False):
 
 
 @task
-def user(ctx, user, wamr=False):
+def user(ctx, user):
     """
     Generates machine for all the functions belonging to the given user
     """
-    _do_codegen_user(user, wamr=wamr)
+    _do_codegen_user(user)
 
 
-def _do_codegen_user(user, wamr=False):
-    print("Running codegen for user {}".format(user))
+def _do_codegen_user(user):
+    print("Running WAVM codegen for user {}".format(user))
 
     binary = find_codegen_func()
     env = copy(environ)
     env.update(
         {
-            "WASM_VM": "wamr" if wamr else "wavm",
+            "WASM_VM": "wavm",
             "LD_LIBRARY_PATH": "/usr/local/lib/",
         }
     )
@@ -77,15 +77,15 @@ def _do_codegen_file(path):
 
 
 @task
-def local(ctx, wamr=False):
+def local(ctx):
     """
     Runs codegen on functions used in tests
     """
-    _do_codegen_user("demo", wamr=wamr)
-    _do_codegen_user("errors", wamr=wamr)
-    _do_codegen_user("mpi", wamr=wamr)
-    _do_codegen_user("omp", wamr=wamr)
-    _do_codegen_user("python", wamr=wamr)
+    _do_codegen_user("demo")
+    _do_codegen_user("errors")
+    _do_codegen_user("mpi")
+    _do_codegen_user("omp")
+    _do_codegen_user("python")
 
     # Do codegen for libfake
     for so in LIB_FAKE_FILES:
@@ -94,3 +94,6 @@ def local(ctx, wamr=False):
     # Run the WAMR codegen required by the tests
     codegen(ctx, "demo", "echo", wamr=True)
     codegen(ctx, "demo", "chain", wamr=True)
+
+    # Run the SGX codegen required by the tests
+    codegen(ctx, "demo", "hello", wamr=True, sgx=True)

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -4,6 +4,7 @@ from invoke import task
 from copy import copy
 from os import environ
 from os.path import join
+from sys import exit
 
 from faasmcli.util.codegen import find_codegen_func, find_codegen_shared_lib
 from faasmcli.util.env import FAASM_RUNTIME_ROOT
@@ -15,7 +16,7 @@ LIB_FAKE_FILES = [
 
 
 @task(default=True)
-def codegen(ctx, user, function, wamr=False):
+def codegen(ctx, user, function, wamr=False, sgx=False):
     """
     Generates machine code for the given function
     """
@@ -27,9 +28,13 @@ def codegen(ctx, user, function, wamr=False):
         }
     )
 
+    if ((not wamr) and sgx):
+        print("Can't run SGX codegen with WAVM. Add --wamr flag.")
+        exit(1)
+
     binary = find_codegen_func()
     run(
-        "{} {} {}".format(binary, user, function),
+        "{} {} {} {}".format(binary, user, function, "--sgx" if sgx else ""),
         shell=True,
         env=env,
         check=True,

--- a/faasmcli/faasmcli/tasks/run.py
+++ b/faasmcli/faasmcli/tasks/run.py
@@ -4,13 +4,15 @@ from faasmcli.util.shell import run_command
 
 
 @task(default=True)
-def run(ctx, user, function, wamr=False, data=None):
+def run(ctx, user, function, wamr=False, data=None, sgx=False):
     """
     Execute a specific function
     """
     args = [user, function]
     if data:
         args.append(data)
+    if sgx:
+        args.append("--sgx")
 
     wasm_vm = "wamr" if wamr else "wavm"
     extra_env = {"WASM_VM": wasm_vm}

--- a/faasmcli/faasmcli/tasks/run.py
+++ b/faasmcli/faasmcli/tasks/run.py
@@ -1,4 +1,5 @@
 from invoke import task
+from sys import exit
 
 from faasmcli.util.shell import run_command
 
@@ -16,5 +17,9 @@ def run(ctx, user, function, wamr=False, data=None, sgx=False):
 
     wasm_vm = "wamr" if wamr else "wavm"
     extra_env = {"WASM_VM": wasm_vm}
+
+    if (wasm_vm != "wamr") and sgx:
+        print("Can't run SGX functions with WAVM. Add --wamr flag.")
+        exit(1)
 
     run_command("func_runner", args, extra_env=extra_env)

--- a/faasmcli/faasmcli/util/codegen.py
+++ b/faasmcli/faasmcli/util/codegen.py
@@ -5,8 +5,5 @@ def find_codegen_shared_lib():
     return find_command("codegen_shared_obj")
 
 
-def find_codegen_func(wamr=False):
-    if wamr:
-        return find_command("wamrc")
-    else:
-        return find_command("codegen_func")
+def find_codegen_func():
+    return find_command("codegen_func")

--- a/include/sgx/faasm_sgx_native_symbols_wrapper.h
+++ b/include/sgx/faasm_sgx_native_symbols_wrapper.h
@@ -6,7 +6,7 @@
 
 // Length of used native symbols
 #define FAASM_SGX_NATIVE_SYMBOLS_LEN 33
-#define FAASM_SGX_WASI_SYMBOLS_LEN 6
+#define FAASM_SGX_WASI_SYMBOLS_LEN 7
 
 // Define symbols that need to be available for functions inside enclaves
 extern "C"
@@ -282,6 +282,8 @@ extern "C"
     static int args_sizes_get_wrapper(wasm_exec_env_t exec_env, int a, int b);
 
     static int fd_close_wrapper(wasm_exec_env_t exec_env, int a);
+
+    static int fd_fdstat_get_wrapper(wasm_exec_env_t, int a, int b);
 
     static int fd_seek_wrapper(wasm_exec_env_t exec_env,
                                int a,

--- a/include/sgx/faasm_sgx_native_symbols_wrapper.h
+++ b/include/sgx/faasm_sgx_native_symbols_wrapper.h
@@ -6,7 +6,7 @@
 
 // Length of used native symbols
 #define FAASM_SGX_NATIVE_SYMBOLS_LEN 33
-#define FAASM_SGX_WASI_SYMBOLS_LEN 7
+#define FAASM_SGX_WASI_SYMBOLS_LEN 6
 
 // Define symbols that need to be available for functions inside enclaves
 extern "C"
@@ -282,8 +282,6 @@ extern "C"
     static int args_sizes_get_wrapper(wasm_exec_env_t exec_env, int a, int b);
 
     static int fd_close_wrapper(wasm_exec_env_t exec_env, int a);
-
-    static int fd_fdstat_get_wrapper(wasm_exec_env_t, int a, int b);
 
     static int fd_seek_wrapper(wasm_exec_env_t exec_env,
                                int a,

--- a/include/storage/FileLoader.h
+++ b/include/storage/FileLoader.h
@@ -88,7 +88,8 @@ class FileLoader
 
   protected:
     std::vector<uint8_t> doCodegen(std::vector<uint8_t>& bytes,
-                                   const std::string& fileName);
+                                   const std::string& fileName,
+                                   bool isSgx = false);
 
     std::vector<uint8_t> hashBytes(const std::vector<uint8_t>& bytes);
 

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -12,7 +12,7 @@ namespace wasm {
 #if (WAMR_EXECUTION_MODE_INTERP)
 // We can't support WAMR codegen in interpreter mode
 #else
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes);
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx);
 #endif
 
 class WAMRWasmModule final : public WasmModule

--- a/src/conf/function_utils.cpp
+++ b/src/conf/function_utils.cpp
@@ -23,6 +23,7 @@ const static std::string encryptedFuncFile = "function.wasm.enc";
 const static std::string symFile = "function.symbols";
 const static std::string objFile = "function.wasm.o";
 const static std::string wamrAotFile = "function.aot";
+const static std::string sgxWamrAotFile = "function.aot.sgx";
 
 std::string getRootUrl()
 {
@@ -235,7 +236,11 @@ std::string getFunctionObjectFile(const faabric::Message& msg)
 std::string getFunctionAotFile(const faabric::Message& msg)
 {
     auto path = getObjectDir(msg);
-    path.append(wamrAotFile);
+    if (msg.issgx()) {
+        path.append(sgxWamrAotFile);
+    } else {
+        path.append(wamrAotFile);
+    }
 
     return path.string();
 }

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -24,8 +24,22 @@ int main(int argc, char* argv[])
     std::string function = argv[2];
 
     std::string inputData;
-    if (argc >= 4) {
+    bool isSgx = false;
+    bool hasInput = false;
+    if (argc == 4) {
+        if (std::string(argv[3]) == "--sgx") {
+            isSgx = true;
+        } else {
+            inputData = argv[3];
+            hasInput = true;
+        }
+    } else if (argc == 5 && std::string(argv[4]) == "--sgx") {
         inputData = argv[3];
+        hasInput = true;
+        isSgx = true;
+    } else {
+        SPDLOG_ERROR("Unrecognized argument list for func_runner");
+        return 1;
     }
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =
@@ -62,11 +76,16 @@ int main(int argc, char* argv[])
         SPDLOG_INFO("Running function {}/{}", user, function);
     }
 
-    if (argc > 3) {
+    if (hasInput) {
         std::string inputData = argv[3];
         msg.set_inputdata(inputData);
 
         SPDLOG_INFO("Adding input data: {}", inputData);
+    }
+
+    if (isSgx) {
+        msg.set_issgx(true);
+        SPDLOG_INFO("Running function in SGX");
     }
 
     // Set up the system

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -37,9 +37,6 @@ int main(int argc, char* argv[])
         inputData = argv[3];
         hasInput = true;
         isSgx = true;
-    } else {
-        SPDLOG_ERROR("Unrecognized argument list for func_runner");
-        return 1;
     }
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -10,7 +10,7 @@
 #include <boost/filesystem.hpp>
 
 namespace wasm {
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes)
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
 {
 
     // Make sure WAMR is initialised
@@ -41,6 +41,11 @@ std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes)
     option.size_level = 3;
     option.output_format = AOT_FORMAT_FILE;
     option.bounds_checks = 2;
+
+    if (isSgx) {
+        option.size_level = 1;
+        option.is_sgx_platform = true;
+    }
 
     aot_comp_context_t compileContext =
       aot_create_comp_context(compileData, &option);


### PR DESCRIPTION
WAMR codegen needs [two additional parameters to generate AoT code for SGX](https://github.com/bytecodealliance/wasm-micro-runtime/blob/cba4c782735becf98f9aec9e60bd049e24620b85/wamr-compiler/main.c#L195). This PR includes the changes necessary to do this.

Now, machine code may be generated from the command line using:
```
(faasm) inv codegen <user> <function> [--wamr] [--sgx]
```

Similarly, we can invoke the function runner using:
```
(faasm) inv run <user> <function> [--wamr] [--sgx]
```

If the user provides the `--sgx` flag without the `--wamr` one, an error is prompted. It may be a bit more verbose, but I think we need to clearly state that you can't run SGX without WAMR.

Note that running SGX functions still only works in development clusters. For running in a production one, there are more changes to be made in the upload process. This is part of the breakdown of the attestation PR.