### PR TITLE
Chained SGX function calls

### DIFF
--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -97,4 +97,6 @@ def local(ctx):
 
     # Run the SGX codegen required by the tests
     codegen(ctx, "demo", "hello", wamr=True, sgx=True)
-    codegen(ctx, "demo", "chain", wamr=True, sgx=True)
+    codegen(ctx, "demo", "chain_named_a", wamr=True, sgx=True)
+    codegen(ctx, "demo", "chain_named_b", wamr=True, sgx=True)
+    codegen(ctx, "demo", "chain_named_c", wamr=True, sgx=True)

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -97,3 +97,4 @@ def local(ctx):
 
     # Run the SGX codegen required by the tests
     codegen(ctx, "demo", "hello", wamr=True, sgx=True)
+    codegen(ctx, "demo", "chain", wamr=True, sgx=True)

--- a/include/sgx/SGXWAMRWasmModule.h
+++ b/include/sgx/SGXWAMRWasmModule.h
@@ -49,8 +49,7 @@ extern "C"
     extern sgx_status_t faasm_sgx_enclave_call_function(
       sgx_enclave_id_t enclave_id,
       faasm_sgx_status_t* ret_val,
-      const uint32_t thread_id,
-      const uint32_t func_id);
+      const uint32_t thread_id);
 }
 
 namespace wasm {

--- a/include/sgx/faasm_sgx_native_symbols_wrapper.h
+++ b/include/sgx/faasm_sgx_native_symbols_wrapper.h
@@ -6,7 +6,7 @@
 
 // Length of used native symbols
 #define FAASM_SGX_NATIVE_SYMBOLS_LEN 33
-#define FAASM_SGX_WASI_SYMBOLS_LEN 6
+#define FAASM_SGX_WASI_SYMBOLS_LEN 7
 
 // Define symbols that need to be available for functions inside enclaves
 extern "C"
@@ -294,6 +294,8 @@ extern "C"
                                 int b,
                                 int c,
                                 int d);
+
+    static int fd_fdstat_get_wrapper(wasm_exec_env_t exec_env, int a, int b);
 
     static void proc_exit_wrapper(wasm_exec_env_t exec_env, int returnCode);
 }

--- a/src/sgx/CMakeLists.txt
+++ b/src/sgx/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SGX_SDK_ENCLAVE_EDGER8R ${SGX_SDK_PATH}/bin/x64/sgx_edger8r)
 # Set target platform details
 set (WAMR_BUILD_PLATFORM "linux-sgx")
 set (WAMR_BUILD_TARGET X86_64)
+set (WAMR_BUILD_SPEC_TEST)
 
 # Set AOT mode, disable JIT
 set (WAMR_BUILD_AOT 1)

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -130,8 +130,8 @@ int32_t SGXWAMRWasmModule::executeFunction(faabric::Message& msg)
 
     // Enter enclave and call function
     faasm_sgx_status_t returnValue;
-    sgx_status_t sgxReturnValue = faasm_sgx_enclave_call_function(
-      globalEnclaveId, &returnValue, threadId, msg.funcptr());
+    sgx_status_t sgxReturnValue =
+      faasm_sgx_enclave_call_function(globalEnclaveId, &returnValue, threadId);
 
     if (sgxReturnValue != SGX_SUCCESS) {
         SPDLOG_ERROR("Unable to enter enclave: {}",

--- a/src/sgx/faasm_sgx_enclave.cpp
+++ b/src/sgx/faasm_sgx_enclave.cpp
@@ -209,8 +209,8 @@ extern "C"
         return FAASM_SGX_SUCCESS;
     }
 
-    faasm_sgx_status_t faasm_sgx_enclave_call_function(const uint32_t thread_id,
-                                                       const uint32_t func_ptr)
+    // Execute the main function
+    faasm_sgx_status_t faasm_sgx_enclave_call_function(const uint32_t thread_id)
     {
         // Check if thread_id is in range
         if (thread_id >= _faasm_sgx_tcs_len) {
@@ -222,14 +222,9 @@ extern "C"
 
         // Get function to execute
         WASMFunctionInstanceCommon* wasm_func;
-        if (func_ptr == 0) {
-            if (!(wasm_func = wasm_runtime_lookup_function(
-                    tcs_ptr->module_inst, WASM_ENTRY_FUNC, NULL))) {
-            }
-
-        } else {
-            // Lookup by function pointer not supported in SGX yet
-            return FAASM_SGX_INVALID_FUNC_ID;
+        if (!(wasm_func = wasm_runtime_lookup_function(
+                tcs_ptr->module_inst, WASM_ENTRY_FUNC, NULL))) {
+            return FAASM_SGX_WAMR_FUNCTION_NOT_FOUND;
         }
 
 #if (FAASM_SGX_ATTESTATION)

--- a/src/sgx/faasm_sgx_enclave.edl
+++ b/src/sgx/faasm_sgx_enclave.edl
@@ -21,47 +21,151 @@ enclave{
 #endif
 
     trusted{
-        public faasm_sgx_status_t faasm_sgx_enclave_unload_module(uint32_t thread_id);
-        public faasm_sgx_status_t faasm_sgx_enclave_call_function(uint32_t thread_id, uint32_t func_id);
+        public faasm_sgx_status_t faasm_sgx_enclave_unload_module(
+            uint32_t thread_id
+        );
+
+        public faasm_sgx_status_t faasm_sgx_enclave_call_function(
+            uint32_t thread_id
+        );
+
 #if(FAASM_SGX_ATTESTATION)
-        public faasm_sgx_status_t faasm_sgx_enclave_load_module([user_check] const void *wasm_opcode_ptr, uint32_t wasm_opcode_size, [out] uint32_t *thread_id, [user_check] sgx_wamr_msg_t **response_ptr);
+        public faasm_sgx_status_t faasm_sgx_enclave_load_module(
+            [user_check]    const void *wasm_opcode_ptr,
+                            uint32_t wasm_opcode_size,
+            [out]           uint32_t *thread_id,
+            [user_check]    sgx_wamr_msg_t **response_ptr
+        );
 #else
-        public faasm_sgx_status_t faasm_sgx_enclave_load_module([user_check] const void *wasm_opcode_ptr, uint32_t wasm_opcode_size, [out] uint32_t *thread_id);
+        public faasm_sgx_status_t faasm_sgx_enclave_load_module(
+            [in, size=wasm_opcode_size]     const void *wasm_opcode_ptr,
+                                            uint32_t wasm_opcode_size,
+            [out]                           uint32_t *thread_id
+        );
 #endif
+
         public faasm_sgx_status_t faasm_sgx_enclave_init_wamr(void);
     };
 
     untrusted{
         void ocall_printf([in, string] const char* msg);
+
 #if(FAASM_SGX_ATTESTATION)
         faasm_sgx_status_t ocall_init_crt(void);
-        faasm_sgx_status_t ocall_send_msg([in, size=msg_len]sgx_wamr_msg_t* msg, uint32_t msg_len);
+
+        faasm_sgx_status_t ocall_send_msg(
+            [in, size=msg_len]  sgx_wamr_msg_t* msg,
+                                uint32_t msg_len
+        );
 #endif
-        uint64_t ocall_faasm_read_state([in, string] char* key, [out, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len);
-        void ocall_faasm_read_appended_state([in, string] char* key, [out, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len, uint32_t element_num);
-        void ocall_faasm_read_state_offset([in, string] char* key, uint64_t total_len, uint64_t offset, [out, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len);
-        void ocall_faasm_write_state([in, string] char* key, [in, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len);
-        void ocall_faasm_append_state([in, string] char* key, [in, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len);
+        uint64_t ocall_faasm_read_state(
+            [in, string]            char* key,
+            [out, size=buffer_len]  uint8_t* buffer_ptr,
+                                    uint32_t buffer_len
+        );
+
+        void ocall_faasm_read_appended_state(
+            [in, string]            char* key,
+            [out, size=buffer_len]  uint8_t* buffer_ptr,
+                                    uint32_t buffer_len,
+                                    uint32_t element_num
+        );
+
+        void ocall_faasm_read_state_offset(
+            [in, string]            char* key,
+                                    uint64_t total_len,
+                                    uint64_t offset,
+            [out, size=buffer_len]  uint8_t* buffer_ptr,
+                                    uint32_t buffer_len
+        );
+
+        void ocall_faasm_write_state(
+            [in, string]            char* key,
+            [in, size=buffer_len]   uint8_t* buffer_ptr,
+                                    uint32_t buffer_len
+        );
+
+        void ocall_faasm_append_state(
+            [in, string]            char* key,
+            [in, size=buffer_len]   uint8_t* buffer_ptr,
+                                    uint32_t buffer_len
+        );
+
         void ocall_faasm_clear_appended_state([in, string] char* key);
-        void ocall_faasm_write_state_offset([in, string] char* key, uint64_t total_len, uint64_t offset, [in, size=buffer_len] uint8_t* buffer_ptr, uint32_t buffer_len);
-        void ocall_faasm_flag_state_dirty([in, string] char* key, uint64_t total_len);
-        void ocall_faasm_flag_state_offset_dirty([in, string] char* key, uint64_t total_len, uint64_t offset, uint64_t len);
+
+        void ocall_faasm_write_state_offset(
+            [in, string]            char* key,
+                                    uint64_t total_len,
+                                    uint64_t offset,
+            [in, size=buffer_len]   uint8_t* buffer_ptr,
+                                    uint32_t buffer_len
+        );
+
+        void ocall_faasm_flag_state_dirty(
+            [in, string]    char* key,
+                            uint64_t total_len
+        );
+
+        void ocall_faasm_flag_state_offset_dirty(
+            [in, string]    char* key,
+                            uint64_t total_len,
+                            uint64_t offset,
+                            uint64_t len
+        );
+
         void ocall_faasm_push_state([in, string] char* key);
+
         void ocall_faasm_push_state_partial([in, string] char* key);
-        void ocall_faasm_push_state_partial_mask([in, string] char* key, [in, string] char* mask_key);
+
+        void ocall_faasm_push_state_partial_mask(
+            [in, string]    char* key,
+            [in, string]    char* mask_key
+        );
+
         void ocall_faasm_pull_state([in, string] char* key, uint64_t state_len);
+
         void ocall_faasm_lock_state_global([in, string] char* key);
+
         void ocall_faasm_unlock_state_global([in, string] char* key);
+
         void ocall_faasm_lock_state_read([in, string] char* key);
+
         void ocall_faasm_unlock_state_read([in, string] char* key);
+
         void ocall_faasm_lock_state_write([in, string] char* key);
+
         void ocall_faasm_unlock_state_write([in, string] char* key);
-        int ocall_faasm_read_input([in, out, size=buffer_size] uint8_t* buffer, unsigned int buffer_size);
-        void ocall_faasm_write_output([in, size=output_size] uint8_t* output, unsigned int output_size);
-        unsigned int ocall_faasm_chain_name([in, string] const char* name, [in, size=input_size] uint8_t* input, long input_size);
-        unsigned int ocall_faasm_chain_ptr(int wasmFuncPtr, [in, size=input_size] uint8_t* input, long input_size);
+
+        int ocall_faasm_read_input(
+            [in, out, size=buffer_size]     uint8_t* buffer,
+                                            unsigned int buffer_size
+        );
+
+        void ocall_faasm_write_output(
+            [in, size=output_size]  uint8_t* output,
+                                    unsigned int output_size
+        );
+
+        unsigned int ocall_faasm_chain_name(
+            [in, string]            const char* name,
+            [in, size=input_size]   uint8_t* input,
+                                    long input_size
+        ) allow(faasm_sgx_enclave_load_module);
+
+        unsigned int ocall_faasm_chain_ptr(
+                                    int wasmFuncPtr,
+            [in, size=input_size]   uint8_t* input,
+                                    long input_size
+        );
+
         unsigned int ocall_faasm_await_call(unsigned int call_id);
-        unsigned int ocall_faasm_await_call_output(unsigned int call_id, [out, size=buffer_size] uint8_t* buffer, unsigned int buffer_size);
+
+        unsigned int ocall_faasm_await_call_output(
+                                        unsigned int call_id,
+            [out, size=buffer_size]     uint8_t* buffer,
+                                        unsigned int buffer_size
+        );
+
         int32_t ocall_sbrk(int32_t increment);
     };
 };

--- a/src/sgx/faasm_sgx_native_symbols_wrapper.cpp
+++ b/src/sgx/faasm_sgx_native_symbols_wrapper.cpp
@@ -308,7 +308,7 @@ extern "C"
             SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
         }
 
-        return 0;
+        return returnValue;
     }
 
     static unsigned int faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
@@ -316,15 +316,11 @@ extern "C"
                                                 const uint8_t* input_data,
                                                 unsigned int input_size)
     {
-        unsigned int returnValue;
-        sgx_status_t sgxReturnValue = ocall_faasm_chain_ptr(
-          &returnValue, wasmFuncPtr, input_data, input_size);
+        // 01/07/2021 - Chain function by pointer is not supported in SGX as it
+        // breaks attestation model. Chain by name instead.
+        SET_ERROR(FAASM_SGX_WAMR_FUNCTION_NOT_IMPLEMENTED);
 
-        if (sgxReturnValue != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-
-        return returnValue;
+        return 1;
     }
 
     static unsigned int faasm_await_call_wrapper(wasm_exec_env_t exec_env,

--- a/src/sgx/faasm_sgx_native_symbols_wrapper.cpp
+++ b/src/sgx/faasm_sgx_native_symbols_wrapper.cpp
@@ -454,6 +454,11 @@ extern "C"
         return 0;
     }
 
+    static int fd_fdstat_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
+    {
+        return 0;
+    }
+
     static void proc_exit_wrapper(wasm_exec_env_t exec_env, int returnCode) {}
 
     NativeSymbol faasm_sgx_native_symbols[FAASM_SGX_NATIVE_SYMBOLS_LEN] = {
@@ -498,6 +503,7 @@ extern "C"
         WASI_NATIVE_FUNC(fd_close, "(i)i"),
         WASI_NATIVE_FUNC(fd_seek, "(iIii)i"),
         WASI_NATIVE_FUNC(fd_write, "(iiii)i"),
-        WASI_NATIVE_FUNC(proc_exit, "(i)")
+        WASI_NATIVE_FUNC(fd_fdstat_get, "(ii)i"),
+        WASI_NATIVE_FUNC(proc_exit, "(i)"),
     };
 }

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -43,9 +43,6 @@ int makeChainedCall(const std::string& functionName,
     assert(!user.empty());
     assert(!functionName.empty());
 
-    SPDLOG_DEBUG(
-      "Chaining call {}/{}:{}", user, functionName, originalCall->id());
-
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory(originalCall->user(), functionName, 1);
 
@@ -59,6 +56,26 @@ int makeChainedCall(const std::string& functionName,
         msg.set_pythonentry(pyFuncName);
     }
     msg.set_ispython(originalCall->ispython());
+
+    if (originalCall->issgx()) {
+        msg.set_issgx(true);
+    }
+
+    if (msg.funcptr() == 0) {
+        SPDLOG_INFO("Chaining call {}/{} -> {}/{} (ids: {} -> {})",
+                    originalCall->user(),
+                    originalCall->function(),
+                    msg.user(),
+                    msg.function(),
+                    originalCall->id(),
+                    msg.id());
+    } else {
+        SPDLOG_INFO("Chaining nested call {}/{} (ids: {} -> {})",
+                    msg.user(),
+                    msg.function(),
+                    originalCall->id(),
+                    msg.id());
+    }
 
     sch.callFunctions(req);
     sch.logChainedFunction(originalCall->id(), msg.id());

--- a/tests/test/sgx/test_sgx.cpp
+++ b/tests/test/sgx/test_sgx.cpp
@@ -12,8 +12,8 @@ TEST_CASE("Test executing hello function with SGX", "[sgx]")
     executeWithSGX("demo", "hello");
 }
 
-TEST_CASE("Test executing chain function with SGX", "[sgx2]")
+TEST_CASE("Test executing chaining by name with SGX", "[sgx]")
 {
-    executeWithSGX("demo", "chain");
+    executeWithSGX("demo", "chain_named_a");
 }
 }

--- a/tests/test/sgx/test_sgx.cpp
+++ b/tests/test/sgx/test_sgx.cpp
@@ -3,7 +3,6 @@
 #include <catch2/catch.hpp>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
-#include <wamr/WAMRWasmModule.h>
 
 using namespace wasm;
 
@@ -11,5 +10,10 @@ namespace tests {
 TEST_CASE("Test executing hello function with SGX", "[sgx]")
 {
     executeWithSGX("demo", "hello");
+}
+
+TEST_CASE("Test executing chain function with SGX", "[sgx2]")
+{
+    executeWithSGX("demo", "chain");
 }
 }


### PR DESCRIPTION
This PR provides support for function chaining in SGX.

Given the way we are planning on doing attestation, the only chaining supported is "chain by name", where a user chains two registered functions (`userA/funcA -> userA/funcB`).

The alternative "chain by pointer" nesting model could be problematic with enclaves.