### PR TITLE
Latest faabric

### DIFF
--- a/include/threads/ThreadState.h
+++ b/include/threads/ThreadState.h
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include <faabric/proto/faabric.pb.h>
-#include <faabric/util/barrier.h>
 #include <faabric/util/environment.h>
 #include <faabric/util/locks.h>
 

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -11,9 +11,8 @@
 #include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
-int main(int argc, char* argv[])
+int doRunner(int argc, char* argv[])
 {
-    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     if (argc < 3) {
@@ -108,6 +107,17 @@ int main(int argc, char* argv[])
 
     m.shutdown();
 
-    faabric::transport::closeGlobalMessageContext();
     return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    faabric::transport::initGlobalMessageContext();
+
+    // WARNING: All 0MQ-related operations must take place in a self-contined
+    // scope to ensure all sockets are destructed before closing the context.
+    int result = doRunner(argc, argv);
+
+    faabric::transport::closeGlobalMessageContext();
+    return result;
 }

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -6,12 +6,14 @@
 #include <faabric/redis/Redis.h>
 #include <faabric/runner/FaabricMain.h>
 #include <faabric/scheduler/ExecutorFactory.h>
+#include <faabric/transport/context.h>
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/timing.h>
 
 int main(int argc, char* argv[])
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     if (argc < 3) {
@@ -106,5 +108,6 @@ int main(int argc, char* argv[])
 
     m.shutdown();
 
+    faabric::transport::closeGlobalMessageContext();
     return 0;
 }

--- a/src/runner/pool_runner.cpp
+++ b/src/runner/pool_runner.cpp
@@ -2,10 +2,12 @@
 
 #include <faabric/endpoint/FaabricEndpoint.h>
 #include <faabric/runner/FaabricMain.h>
+#include <faabric/transport/context.h>
 #include <faabric/util/logging.h>
 
 int main()
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     auto fac = std::make_shared<faaslet::FaasletFactory>();
@@ -20,5 +22,6 @@ int main()
     SPDLOG_INFO("Shutting down");
     m.shutdown();
 
+    faabric::transport::closeGlobalMessageContext();
     return EXIT_SUCCESS;
 }

--- a/src/runner/pool_runner.cpp
+++ b/src/runner/pool_runner.cpp
@@ -10,18 +10,23 @@ int main()
     faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
-    auto fac = std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startBackground();
+    // WARNING: All 0MQ-related operations must take place in a self-contined
+    // scope to ensure all sockets are destructed before closing the context.
+    {
+        auto fac = std::make_shared<faaslet::FaasletFactory>();
+        faabric::runner::FaabricMain m(fac);
+        m.startBackground();
 
-    // Start endpoint (will also have multiple threads)
-    SPDLOG_INFO("Starting endpoint");
-    faabric::endpoint::FaabricEndpoint endpoint;
-    endpoint.start();
+        // Start endpoint (will also have multiple threads)
+        SPDLOG_INFO("Starting endpoint");
+        faabric::endpoint::FaabricEndpoint endpoint;
+        endpoint.start();
 
-    SPDLOG_INFO("Shutting down");
-    m.shutdown();
+        SPDLOG_INFO("Shutting down");
+        m.shutdown();
 
-    faabric::transport::closeGlobalMessageContext();
-    return EXIT_SUCCESS;
+        faabric::transport::closeGlobalMessageContext();
+    }
+
+    return 0;
 }

--- a/src/upload/upload_server.cpp
+++ b/src/upload/upload_server.cpp
@@ -1,11 +1,13 @@
 #include <upload/UploadServer.h>
 
 #include <faabric/state/StateServer.h>
+#include <faabric/transport/context.h>
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
 
 int main()
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     faabric::util::SystemConfig& config = faabric::util::getSystemConfig();
@@ -21,6 +23,7 @@ int main()
 
     // Stop the state server
     stateServer.stop();
+    faabric::transport::closeGlobalMessageContext();
 
     return 0;
 }

--- a/src/upload/upload_server.cpp
+++ b/src/upload/upload_server.cpp
@@ -13,16 +13,21 @@ int main()
     faabric::util::SystemConfig& config = faabric::util::getSystemConfig();
     config.print();
 
-    // Add a state server in the background
-    faabric::state::StateServer stateServer(faabric::state::getGlobalState());
-    stateServer.start();
+    // WARNING: All 0MQ-related operations must take place in a self-contined
+    // scope to ensure all sockets are destructed before closing the context.
+    {
+        faabric::state::StateServer stateServer(
+          faabric::state::getGlobalState());
+        stateServer.start();
 
-    // Start the upload server in the main thread
-    edge::UploadServer server;
-    server.listen(UPLOAD_PORT);
+        // Start the upload server in the main thread
+        edge::UploadServer server;
+        server.listen(UPLOAD_PORT);
 
-    // Stop the state server
-    stateServer.stop();
+        // Stop the state server
+        stateServer.stop();
+    }
+
     faabric::transport::closeGlobalMessageContext();
 
     return 0;

--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -25,19 +25,26 @@ int main(int argc, char* argv[])
     SPDLOG_INFO("Starting distributed test server on master");
     std::shared_ptr<faaslet::FaasletFactory> fac =
       std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startBackground();
 
-    // Wait for things to start
-    usleep(3000 * 1000);
+    // WARNING: all 0MQ sockets have to have gone *out of scope* before we shut
+    // down the context, therefore this segment must be in a nested scope (or
+    // another function).
+    int result;
+    {
+        faabric::runner::FaabricMain m(fac);
+        m.startBackground();
 
-    // Run the tests
-    int result = Catch::Session().run(argc, argv);
-    fflush(stdout);
+        // Wait for things to start
+        usleep(3000 * 1000);
 
-    // Shut down
-    SPDLOG_INFO("Shutting down");
-    m.shutdown();
+        // Run the tests
+        result = Catch::Session().run(argc, argv);
+        fflush(stdout);
+
+        // Shut down
+        SPDLOG_INFO("Shutting down");
+        m.shutdown();
+    }
 
     faabric::transport::closeGlobalMessageContext();
     return result;

--- a/tests/dist/main.cpp
+++ b/tests/dist/main.cpp
@@ -9,6 +9,7 @@
 #include <faabric/endpoint/FaabricEndpoint.h>
 #include <faabric/runner/FaabricMain.h>
 #include <faabric/scheduler/ExecutorFactory.h>
+#include <faabric/transport/context.h>
 #include <faabric/util/logging.h>
 
 using namespace faabric::scheduler;
@@ -17,6 +18,7 @@ FAABRIC_CATCH_LOGGER
 
 int main(int argc, char* argv[])
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     // Start everything up
@@ -37,5 +39,6 @@ int main(int argc, char* argv[])
     SPDLOG_INFO("Shutting down");
     m.shutdown();
 
+    faabric::transport::closeGlobalMessageContext();
     return result;
 }

--- a/tests/dist/server.cpp
+++ b/tests/dist/server.cpp
@@ -3,12 +3,14 @@
 #include <faabric/endpoint/FaabricEndpoint.h>
 #include <faabric/runner/FaabricMain.h>
 #include <faabric/scheduler/ExecutorFactory.h>
+#include <faabric/transport/context.h>
 #include <faabric/util/logging.h>
 
 using namespace faabric::scheduler;
 
 int main()
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     SPDLOG_INFO("Starting distributed test server on worker");
@@ -23,6 +25,7 @@ int main()
 
     SPDLOG_INFO("Shutting down");
     m.shutdown();
+    faabric::transport::closeGlobalMessageContext();
 
     return EXIT_SUCCESS;
 }

--- a/tests/dist/server.cpp
+++ b/tests/dist/server.cpp
@@ -13,19 +13,24 @@ int main()
     faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
-    SPDLOG_INFO("Starting distributed test server on worker");
-    std::shared_ptr<ExecutorFactory> fac =
-      std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startBackground();
+    // WARNING: All 0MQ-related operations must take place in a self-contined
+    // scope to ensure all sockets are destructed before closing the context.
+    {
+        SPDLOG_INFO("Starting distributed test server on worker");
+        std::shared_ptr<ExecutorFactory> fac =
+          std::make_shared<faaslet::FaasletFactory>();
+        faabric::runner::FaabricMain m(fac);
+        m.startBackground();
 
-    SPDLOG_INFO("Starting HTTP endpoint on worker");
-    faabric::endpoint::FaabricEndpoint endpoint;
-    endpoint.start();
+        SPDLOG_INFO("Starting HTTP endpoint on worker");
+        faabric::endpoint::FaabricEndpoint endpoint;
+        endpoint.start();
 
-    SPDLOG_INFO("Shutting down");
-    m.shutdown();
+        SPDLOG_INFO("Shutting down");
+        m.shutdown();
+    }
+
     faabric::transport::closeGlobalMessageContext();
 
-    return EXIT_SUCCESS;
+    return 0;
 }

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -4,12 +4,14 @@
 #include "utils.h"
 
 #include <catch2/catch.hpp>
+#include <faabric/transport/context.h>
 #include <faabric/util/logging.h>
 
 FAABRIC_CATCH_LOGGER
 
 int main(int argc, char* argv[])
 {
+    faabric::transport::initGlobalMessageContext();
     faabric::util::initLogging();
 
     // Clean the system
@@ -18,6 +20,7 @@ int main(int argc, char* argv[])
     int result = Catch::Session().run(argc, argv);
 
     fflush(stdout);
+    faabric::transport::closeGlobalMessageContext();
 
     return result;
 }


### PR DESCRIPTION
Adding new message context handling and changing use of barrier to latch. 

Also removed a test which relied on the old Faabric `DummyStateServer` as it was too tightly coupled to the Faabric test, and should really be covered by a new distributed test.