### PR TITLE
Batch pthreads

### DIFF
--- a/include/threads/ThreadState.h
+++ b/include/threads/ThreadState.h
@@ -75,35 +75,12 @@ class Level
     int getGlobalThreadNum(faabric::Message* msg);
 };
 
-class PthreadTask
+class PthreadCall
 {
   public:
-    PthreadTask(faabric::Message* parentMsgIn,
-                std::shared_ptr<faabric::Message> msgIn)
-      : parentMsg(parentMsgIn)
-      , msg(msgIn)
-    {}
-
-    bool isShutdown = false;
-    faabric::Message* parentMsg;
-    std::shared_ptr<faabric::Message> msg;
-};
-
-class OpenMPTask
-{
-  public:
-    faabric::Message* parentMsg;
-    std::shared_ptr<faabric::Message> msg;
-    std::shared_ptr<threads::Level> nextLevel;
-    bool isShutdown = false;
-
-    OpenMPTask(faabric::Message* parentMsgIn,
-               std::shared_ptr<faabric::Message> msgIn,
-               std::shared_ptr<threads::Level> nextLevelIn)
-      : parentMsg(parentMsgIn)
-      , msg(msgIn)
-      , nextLevel(nextLevelIn)
-    {}
+    int32_t pthreadPtr;
+    int32_t entryFunc;
+    int32_t argsPtr;
 };
 
 std::shared_ptr<Level> levelFromBatchRequest(

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -146,6 +146,11 @@ class WasmModule
 
     void restore(const std::string& snapshotKey);
 
+    // ----- Threading -----
+    void queuePthreadCall(threads::PthreadCall call);
+
+    int awaitPthreadCall(const faabric::Message& msg, int pthreadPtr);
+
     // ----- Debugging -----
     virtual void printDebugInfo();
 
@@ -177,6 +182,10 @@ class WasmModule
     unsigned int argc;
     std::vector<std::string> argv;
     size_t argvBufferSize;
+
+    // Threads
+    std::vector<threads::PthreadCall> queuedPthreadCalls;
+    std::unordered_map<int32_t, uint32_t> pthreadPtrsToChainedCalls;
 
     // Shared memory regions
     std::unordered_map<std::string, uint32_t> sharedMemWasmPtrs;

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -149,7 +149,7 @@ class WasmModule
     // ----- Threading -----
     void queuePthreadCall(threads::PthreadCall call);
 
-    int awaitPthreadCall(const faabric::Message& msg, int pthreadPtr);
+    int awaitPthreadCall(const faabric::Message* msg, int pthreadPtr);
 
     // ----- Debugging -----
     virtual void printDebugInfo();
@@ -176,6 +176,7 @@ class WasmModule
     threads::MutexManager mutexes;
 
     std::shared_mutex moduleMemoryMutex;
+    std::mutex modulePthreadsMutex;
     std::mutex moduleStateMutex;
 
     // Argc/argv

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -59,7 +59,7 @@ class WAVMWasmModule final
 
     uint8_t* getMemoryBase() override;
 
-    // ----- Environment variables
+    // ----- Environment variables -----
     void writeWasmEnvToMemory(uint32_t envPointers,
                               uint32_t envBuffer) override;
 
@@ -115,10 +115,6 @@ class WAVMWasmModule final
     static WAVM::Runtime::Context* createThreadContext(
       uint32_t stackTop,
       WAVM::Runtime::ContextRuntimeData* contextRuntimeData);
-
-    std::unordered_map<int32_t, uint32_t> chainedThreads;
-
-    std::atomic<int> pthreadCounter = 0;
 
     // ----- Disassembly -----
     std::map<std::string, std::string> buildDisassemblyMap();

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -399,9 +399,76 @@ uint32_t WasmModule::createMemoryGuardRegion(uint32_t wasmOffset)
     return wasmOffset + regionSize;
 }
 
+void WasmModule::queuePthreadCall(threads::PthreadCall call)
+{
+    queuedPthreadCalls.emplace_back(call);
+}
+
+int WasmModule::awaitPthreadCall(const faabric::Message& msg, int pthreadPtr)
+{
+    if (!queuedPthreadCalls.empty()) {
+        faabric::util::FullLock lock(moduleMemoryMutex);
+
+        if (!queuedPthreadCalls.empty()) {
+            int nPthreadCalls = queuedPthreadCalls.size();
+            std::string snapshotKey = snapshot(false);
+            std::string funcStr = faabric::util::funcToString(msg, true);
+
+            SPDLOG_DEBUG("Executing {} pthread calls for {} with snapshot {}",
+                         nPthreadCalls,
+                         funcStr,
+                         snapshotKey);
+
+            std::shared_ptr<faabric::BatchExecuteRequest> req =
+              faabric::util::batchExecFactory(
+                msg.user(), msg.function(), nPthreadCalls);
+
+            req->set_type(faabric::BatchExecuteRequest::THREADS);
+            req->set_subtype(wasm::ThreadRequestType::PTHREAD);
+
+            for (int i = 0; i < nPthreadCalls; i++) {
+                threads::PthreadCall p = queuedPthreadCalls.at(i);
+                faabric::Message& m = req->mutable_messages()->at(i);
+
+                // Snapshot details
+                m.set_snapshotkey(snapshotKey);
+                // Function pointer and args
+                // NOTE - with a pthread interface we only ever pass the
+                // function a single pointer argument, hence we use the
+                // input data here to hold this argument as a string
+                m.set_funcptr(p.entryFunc);
+                m.set_inputdata(std::to_string(p.argsPtr));
+
+                // Assign a thread ID and increment. Our pthread IDs start
+                // at 1
+                m.set_appindex(i + 1);
+
+                // Record this thread -> call ID
+                pthreadPtrsToChainedCalls.insert({ p.pthreadPtr, m.id() });
+            }
+
+            // Submit the call
+            faabric::scheduler::getScheduler().callFunctions(req);
+
+            // Empty the queue
+            queuedPthreadCalls.clear();
+        }
+    }
+
+    // Await the results of this call
+    unsigned int callId = pthreadPtrsToChainedCalls[pthreadPtr];
+    SPDLOG_DEBUG("Awaiting pthread: {} ({})", pthreadPtr, callId);
+    auto& sch = faabric::scheduler::getScheduler();
+
+    int returnValue = sch.awaitThreadResult(callId);
+
+    pthreadPtrsToChainedCalls.erase(pthreadPtr);
+
+    return returnValue;
+}
+
 void WasmModule::createThreadStacks()
 {
-
     SPDLOG_DEBUG("Creating {} thread stacks", threadPoolSize);
 
     for (int i = 0; i < threadPoolSize; i++) {

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -5,6 +5,7 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 
+#include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
@@ -981,7 +982,6 @@ U32 WAVMWasmModule::mmapFile(U32 fd, U32 length)
 
 U32 WAVMWasmModule::growMemory(U32 nBytes)
 {
-
     U64 maxPages = getMemoryType(defaultMemory).size.max;
 
     // Check if we just need the size

--- a/src/wavm/threads.cpp
+++ b/src/wavm/threads.cpp
@@ -62,53 +62,13 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                  entryFunc,
                  argsPtr);
 
-    faabric::Message* originalCall = getExecutingCall();
-    std::string funcStr = faabric::util::funcToString(*originalCall, true);
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
+    threads::PthreadCall pthreadCall;
+    pthreadCall.pthreadPtr = pthreadPtr;
+    pthreadCall.entryFunc = entryFunc;
+    pthreadCall.argsPtr = argsPtr;
 
-    // Set the bits we care about on the pthread struct
-    // NOTE - setting the initial pointer is crucial for inter-operation with
-    // existing C code
-    WAVMWasmModule* thisModule = getExecutingWAVMModule();
-    wasm_pthread* pthreadNative =
-      &Runtime::memoryRef<wasm_pthread>(thisModule->defaultMemory, pthreadPtr);
-    pthreadNative->selfPtr = pthreadPtr;
-
-    // Create a new snapshot if one isn't already active
-    if (currentSnapshotKey.empty()) {
-        currentSnapshotKey = thisModule->snapshot(false);
-
-        SPDLOG_DEBUG(
-          "Setting pthread snapshot for {} ({})", funcStr, currentSnapshotKey);
-    }
-
-    std::shared_ptr<faabric::BatchExecuteRequest> req =
-      faabric::util::batchExecFactory(
-        originalCall->user(), originalCall->function(), 1);
-
-    req->set_type(faabric::BatchExecuteRequest::THREADS);
-    req->set_subtype(wasm::ThreadRequestType::PTHREAD);
-
-    faabric::Message& threadCall = req->mutable_messages()->at(0);
-
-    // Snapshot details
-    threadCall.set_snapshotkey(currentSnapshotKey);
-
-    // Function pointer and args
-    // NOTE - with a pthread interface we only ever pass the function a single
-    // pointer argument, hence we use the input data here to hold this argument
-    // as a string
-    threadCall.set_funcptr(entryFunc);
-    threadCall.set_inputdata(std::to_string(argsPtr));
-
-    // Assign a thread ID and increment. Our pthread IDs start at 1
-    threadCall.set_appindex(thisModule->pthreadCounter.fetch_add(1) + 1);
-
-    // Submit it
-    sch.callFunctions(req);
-
-    // Record this thread -> call ID
-    thisModule->chainedThreads.insert({ pthreadPtr, threadCall.id() });
+    WasmModule* thisModule = getExecutingModule();
+    thisModule->queuePthreadCall(pthreadCall);
 
     return 0;
 }
@@ -120,25 +80,11 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                                I32 pthreadPtr,
                                I32 resPtrPtr)
 {
-
     SPDLOG_DEBUG("S - pthread_join - {} {}", pthreadPtr, resPtrPtr);
 
-    // Await the chained thread
-    WAVMWasmModule* thisModule = getExecutingWAVMModule();
-    unsigned int callId = thisModule->chainedThreads[pthreadPtr];
-    SPDLOG_DEBUG("Awaiting pthread: {} ({})", pthreadPtr, callId);
-    auto& sch = faabric::scheduler::getScheduler();
-
-    int returnValue = sch.awaitThreadResult(callId);
-
-    // Remove record for the remote thread
-    thisModule->chainedThreads.erase(pthreadPtr);
-
-    // If we're done with executing threads, remove the snapshot
-    if (thisModule->chainedThreads.empty()) {
-        SPDLOG_DEBUG("Finished with snapshot: {}", currentSnapshotKey);
-        currentSnapshotKey = "";
-    }
+    faabric::Message* call = getExecutingCall();
+    WasmModule* thisModule = getExecutingModule();
+    int returnValue = thisModule->awaitPthreadCall(*call, pthreadPtr);
 
     // This function is passed a pointer to a pointer for the result,
     // so we dereference it once and are writing an integer (i.e. a wasm


### PR DESCRIPTION
A pthreaded application will call `pthread_create` in a loop, then call `pthread_join` in a loop. This means our implementation of `pthread_create` cannot batch up thread execution (as it just sees a stream of individual calls).

To support batch executing pthreads, this PR changes the approach to:

- On every call to `pthread_create`, we queue a pthread task
- On the first call to `pthread_join`, we batch execute all the queued tasks

The downside to this approach is that thread execution is delayed until the main thread calls `pthread_join`, however this seems not to be a problem from the applications we currently support, where the main thread moves straight onto `pthread_join` after finishing the `pthread_create` calls.

Most of the changes in the diff are related to moving the logic around handling pthreads into the `WasmModule` class, out from `src/wavm/threads.cpp` where it was nestled before.