### PR TITLE
Fix thread level barrier deadlock

### DIFF
--- a/src/threads/ThreadState.cpp
+++ b/src/threads/ThreadState.cpp
@@ -250,19 +250,19 @@ void Level::waitOnBarrier()
 
     // Create if necessary
     if (barriers.find(id) == barriers.end()) {
-        faabric::util::FullLock lock(sharedMutex);
-        if (barriers.find(id) == barriers.end()) {
-            SPDLOG_TRACE("Creating barrier for level {}", id);
+        bool locked = sharedMutex.try_lock();
+        if (locked && (barriers.find(id) == barriers.end())) {
             barriers[id] = Barrier::create(numThreads);
-            SPDLOG_TRACE("Created barrier for level {}", id);
+        }
+
+        if (locked) {
+            sharedMutex.unlock();
         }
     }
 
     // Wait
     {
-        SPDLOG_TRACE("Getting lock for barrier for level {}", id);
         faabric::util::SharedLock lock(sharedMutex);
-        SPDLOG_TRACE("Waiting on barrier for level {}", id);
         barriers[id]->wait();
     }
 }

--- a/src/threads/ThreadState.cpp
+++ b/src/threads/ThreadState.cpp
@@ -1,9 +1,9 @@
 #include <faabric/scheduler/Scheduler.h>
+#include <faabric/util/barrier.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 #include <faabric/util/gids.h>
-#include <faabric/util/latch.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
@@ -18,33 +18,39 @@ using namespace faabric::util;
 #define FROM_MAP(varName, T, m, ...)                                           \
     {                                                                          \
         if (m.find(id) == m.end()) {                                           \
-            faabric::util::UniqueLock lock(sharedMutex);                       \
+            faabric::util::FullLock lock(sharedMutex);                         \
             if (m.find(id) == m.end()) {                                       \
                 m[id] = std::make_shared<T>(__VA_ARGS__);                      \
             }                                                                  \
         }                                                                      \
     }                                                                          \
-    std::shared_ptr<T> varName = m[id];
+    std::shared_ptr<T> varName;                                                \
+    {                                                                          \
+        faabric::util::SharedLock lock(sharedMutex);                           \
+        varName = m[id];                                                       \
+    }
 
 namespace threads {
 
 static thread_local std::shared_ptr<Level> currentLevel = nullptr;
 
-std::mutex sharedMutex;
+std::shared_mutex sharedMutex;
 
-std::unordered_map<uint32_t, std::shared_ptr<faabric::util::Latch>> latches;
+static std::unordered_map<uint32_t, std::shared_ptr<faabric::util::Barrier>>
+  barriers;
 
-std::unordered_map<uint32_t, std::shared_ptr<std::recursive_mutex>>
+static std::unordered_map<uint32_t, std::shared_ptr<std::recursive_mutex>>
   levelMutexes;
 
-std::unordered_map<uint32_t, std::shared_ptr<std::mutex>> nowaitMutexes;
-std::unordered_map<uint32_t, std::shared_ptr<std::atomic<int>>> nowaitCounts;
-std::unordered_map<uint32_t, std::shared_ptr<std::condition_variable>>
+static std::unordered_map<uint32_t, std::shared_ptr<std::mutex>> nowaitMutexes;
+static std::unordered_map<uint32_t, std::shared_ptr<std::atomic<int>>>
+  nowaitCounts;
+static std::unordered_map<uint32_t, std::shared_ptr<std::condition_variable>>
   nowaitCvs;
 
 void clearThreadState()
 {
-    latches.clear();
+    barriers.clear();
 
     levelMutexes.clear();
 
@@ -243,21 +249,21 @@ void Level::waitOnBarrier()
     }
 
     // Create if necessary
-    if (latches.find(id) == latches.end()) {
-        faabric::util::UniqueLock lock(sharedMutex);
-        if (latches.find(id) == latches.end()) {
-            latches[id] = Latch::create(numThreads);
+    if (barriers.find(id) == barriers.end()) {
+        faabric::util::FullLock lock(sharedMutex);
+        if (barriers.find(id) == barriers.end()) {
+            SPDLOG_TRACE("Creating barrier for level {}", id);
+            barriers[id] = Barrier::create(numThreads);
+            SPDLOG_TRACE("Created barrier for level {}", id);
         }
     }
 
-    latches[id]->wait();
-
-    // Remove the used latch from the map
-    if (latches.find(id) != latches.end()) {
-        faabric::util::UniqueLock lock(sharedMutex);
-        if (latches.find(id) != latches.end()) {
-            latches.erase(id);
-        }
+    // Wait
+    {
+        SPDLOG_TRACE("Getting lock for barrier for level {}", id);
+        faabric::util::SharedLock lock(sharedMutex);
+        SPDLOG_TRACE("Waiting on barrier for level {}", id);
+        barriers[id]->wait();
     }
 }
 


### PR DESCRIPTION
This should fix the issues we've been seeing around the levels test. 

Firstly, using a latch in the `Level` class was not a good fit as it needs to be used over and over again, so I switched to using the `Barrier` from Faabric. 

Secondly, the combination of the barrier and the pattern we use for thread-safe map access can cause a deadlock. Namely:

```  
if (m.find(id) == m.end()) {
  faabric::util::FullLock lock(sharedMutex);
  if (m.find(id) == m.end()) {
    m[id] = ...; // Initialise
  }
}

{
  faabric::util::SharedLock lock(sharedMutex);
  // Do something with m[id];
}
```

It appears that the view of the map can be sufficiently inconsistent between threads that one thread can have initialised the element and acquired the shared lock, then another one comes in and sees `m.find(id) == m.end()`. This is usually fine, as the `Do something with m[id]` can complete, release the lock and everything continues. However, when `Do something with m[id]` is a barrier, it causes a deadlock, as all the threads have to hit the barrier before others can continue. 

This is fixed by changing the first block to:

```
if (m.find(id) == m.end()) {
  bool locked = sharedMutex.try_lock();
  if (locked && (m.find(id) == m.end())) {
    m[id] = ...; // Initialise
  }
  
  if(locked) {
    sharedMutex.unlock();
  }
}
```