### PR TITLE
Set fixed location for config on filesystem

### DIFF
--- a/bin/update_ini.sh
+++ b/bin/update_ini.sh
@@ -4,7 +4,13 @@ set -e
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJ_ROOT=${THIS_DIR}/..
+
 INI_FILE=${PROJ_ROOT}/faasm.ini
+
+GLOBAL_INI_FILE=${HOME}/.config/faasm.ini
+if [ ! -d ${HOME}/.config ]; then
+    mkdir -p ${HOME}/.config
+fi
 
 KNATIVE_HOST=$(kn service describe faasm-worker -o url -n faasm | cut -c 8-)
 
@@ -40,19 +46,9 @@ echo "-----        Upload        -----"
 echo ""
 echo "curl -X PUT http://${UPLOAD_IP}:${UPLOAD_PORT}/f/<user>/<func> -T <wasm_file>"
 
-echo ""
-echo "-----       INI file       -----"
-echo ""
-echo "[Faasm]"
-echo "invoke_host = ${ISTIO_IP}"
-echo "invoke_port = ${ISTIO_PORT}"
-echo "upload_host = ${UPLOAD_IP}"
-echo "upload_port = ${UPLOAD_PORT}"
-echo "knative_host = ${KNATIVE_HOST}"
-echo ""
-
 echo "Overwriting config file at ${INI_FILE}"
 
+# Write the file into place
 echo "# Auto-generated at $(date +"%y-%m-%d %T")" > ${INI_FILE}
 echo "[Faasm]" >> ${INI_FILE}
 echo "invoke_host = ${ISTIO_IP}" >> ${INI_FILE}
@@ -61,3 +57,12 @@ echo "upload_host = ${UPLOAD_IP}" >> ${INI_FILE}
 echo "upload_port = ${UPLOAD_PORT}" >> ${INI_FILE}
 echo "knative_host = ${KNATIVE_HOST}" >> ${INI_FILE}
 
+echo ""
+echo "-----       INI file       -----"
+echo ""
+cat ${INI_FILE}
+
+# Place symlink to file at standard location to allow other projects access
+echo "Symlinking ${GLOBAL_INI_FILE} to ${INI_FILE}"
+rm -f ${GLOBAL_INI_FILE}
+ln -s ${INI_FILE} ${GLOBAL_INI_FILE}


### PR DESCRIPTION
Allow other projects to more easily access `faasm.ini` by symlinking to user's home directory at `~/.config/faasm.ini`