### PR TITLE
Remove WAMR's interpreter mode support

### DIFF
--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -9,11 +9,7 @@
 
 namespace wasm {
 
-#if (WAMR_EXECUTION_MODE_INTERP)
-// We can't support WAMR codegen in interpreter mode
-#else
 std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx);
-#endif
 
 class WAMRWasmModule final : public WasmModule
 {
@@ -46,10 +42,6 @@ class WAMRWasmModule final : public WasmModule
 
   private:
     char errorBuffer[ERROR_BUFFER_SIZE];
-
-#if (WAMR_EXECUTION_MODE_INTERP)
-    std::vector<uint8_t> wasmBytes;
-#endif
 
     WASMModuleCommon* wasmModule;
     WASMModuleInstanceCommon* moduleInstance;

--- a/src/codegen/MachineCodeGenerator.cpp
+++ b/src/codegen/MachineCodeGenerator.cpp
@@ -1,11 +1,6 @@
-#if (WAMR_EXECUTION_MODE_INTERP)
-// Import for codegen not needed as it's not supported
-#else
-#include <wamr/WAMRWasmModule.h>
-#endif
-
 #include <codegen/MachineCodeGenerator.h>
 #include <storage/FileLoader.h>
+#include <wamr/WAMRWasmModule.h>
 #include <wavm/WAVMWasmModule.h>
 
 #include <openssl/md5.h>
@@ -53,12 +48,7 @@ std::vector<uint8_t> MachineCodeGenerator::doCodegen(
   bool isSgx)
 {
     if (conf.wasmVm == "wamr") {
-#if (WAMR_EXECTION_MODE_INTERP)
-        throw std::runtime_error(
-          "WAMR codegen not supported with WAMR interp mode");
-#else
         return wasm::wamrCodegen(bytes, isSgx);
-#endif
     } else {
         assert(isSgx == false);
         return wasm::wavmCodegen(bytes, fileName);


### PR DESCRIPTION
We agreed not to support WAMR's interpreter mode in SGX, so it seems reasonable to also delete it's support for WAMR without SGX.