### PR TITLE
Minor changes for better MPI testing and usability

### DIFF
--- a/faasmcli/faasmcli/tasks/call.py
+++ b/faasmcli/faasmcli/tasks/call.py
@@ -22,6 +22,7 @@ def invoke(
     knative=True,
     poll=False,
     cmdline=None,
+    mpi_world_size=None,
     debug=False,
     sgx=False,
 ):
@@ -37,6 +38,7 @@ def invoke(
         knative=knative,
         poll=poll,
         cmdline=cmdline,
+        mpi_world_size=mpi_world_size,
         debug=debug,
         sgx=sgx,
     )

--- a/faasmcli/faasmcli/util/call.py
+++ b/faasmcli/faasmcli/util/call.py
@@ -113,7 +113,7 @@ def invoke_impl(
         msg["cmdline"] = cmdline
 
     if mpi_world_size:
-        msg["mpi_world_size"] = mpi_world_size
+        msg["mpi_world_size"] = int(mpi_world_size)
 
     # Knative must pass custom headers
     headers = dict()


### PR DESCRIPTION
We were already allowing a `mpi_world_size` argument in `invoke_impl` but not in `invoke`. Adding the same argument (defaulted to `None`) in the high-level call helps running MPI tasks from the command line easier.