### PR TITLE
Add a crash handler that prints backtraces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Ensure all targets can generate readable stacktraces
+add_compile_options(-fno-omit-frame-pointer)
+add_link_options(-Wl,--export-dynamic)
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
Adds the options to not skip frame pointer generation and to export all program symbols into the dynamic section, which makes the backtrace_*() functions able to read the name of functions in which a crash occured. Requires https://github.com/faasm/faabric/pull/145 - I'm not sure how exactly the submodule update here will be handled by github before the faabric PR is merged.