### PR TITLE
Use C++ inside enclaves

### DIFF
--- a/include/sgx/crypto/encryption.h
+++ b/include/sgx/crypto/encryption.h
@@ -6,21 +6,18 @@
 #include <sgx_tcrypto.h>
 #include <sgx_trts.h>
 
-extern "C"
-{
-    // --------------------------------------
-    // Symmetric encryption
-    // --------------------------------------
+// --------------------------------------
+// Symmetric encryption
+// --------------------------------------
 
-    FaasmSgxEncryptedMsg* doSymEncrypt(FaasmSgxMsg* decryptedMsg,
-                                       FaasmSgxSymKey symKey);
+FaasmSgxEncryptedMsg* doSymEncrypt(FaasmSgxMsg* decryptedMsg,
+                                   FaasmSgxSymKey symKey);
 
-    FaasmSgxMsg* doSymDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
-                              FaasmSgxSymKey symKey);
+FaasmSgxMsg* doSymDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
+                          FaasmSgxSymKey symKey);
 
-    static FaasmSgxEncryptedMsg* doAesGcmEncrypt(FaasmSgxMsg* decryptedMsg,
-                                                 FaasmSgxSymKey symKey);
+static FaasmSgxEncryptedMsg* doAesGcmEncrypt(FaasmSgxMsg* decryptedMsg,
+                                             FaasmSgxSymKey symKey);
 
-    static FaasmSgxMsg* doAesGcmDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
-                                        FaasmSgxSymKey symKey);
-}
+static FaasmSgxMsg* doAesGcmDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
+                                    FaasmSgxSymKey symKey);

--- a/include/sgx/crypto/hash.h
+++ b/include/sgx/crypto/hash.h
@@ -4,11 +4,8 @@
 
 #include <sgx_tcrypto.h>
 
-extern "C"
-{
-    // --------------------------------------
-    // Hashing
-    // --------------------------------------
+// --------------------------------------
+// Hashing
+// --------------------------------------
 
-    FaasmSgxHashedMsg* doSha256(FaasmSgxMsg* srcMsg);
-}
+FaasmSgxHashedMsg* doSha256(FaasmSgxMsg* srcMsg);

--- a/include/sgx/rw_lock.h
+++ b/include/sgx/rw_lock.h
@@ -1,31 +1,23 @@
 #pragma once
 
-#ifdef __cplusplus
-extern "C"
+typedef union __rwlock
 {
-#endif
-    typedef union __rwlock
+    unsigned u;
+    unsigned short us;
+    __extension__ struct
     {
-        unsigned u;
-        unsigned short us;
-        __extension__ struct
-        {
-            unsigned char write;
-            unsigned char read;
-            unsigned char users;
-        } s;
-    } rwlock_t;
+        unsigned char write;
+        unsigned char read;
+        unsigned char users;
+    } s;
+} rwlock_t;
 
-    typedef void (*unlock_func)(rwlock_t*);
+typedef void (*unlock_func)(rwlock_t*);
 
-    void write_lock(rwlock_t* l);
+void write_lock(rwlock_t* l);
 
-    void write_unlock(rwlock_t* l);
+void write_unlock(rwlock_t* l);
 
-    void read_lock(rwlock_t* l);
+void read_lock(rwlock_t* l);
 
-    void read_unlock(rwlock_t* l);
-
-#ifdef __cplusplus
-}
-#endif
+void read_unlock(rwlock_t* l);

--- a/src/sgx/crypto/encryption.cpp
+++ b/src/sgx/crypto/encryption.cpp
@@ -1,104 +1,100 @@
 #include <sgx/crypto/encryption.h>
 
-extern "C"
+FaasmSgxEncryptedMsg* doSymEncrypt(FaasmSgxMsg* decryptedMsg,
+                                   FaasmSgxSymKey symKey)
 {
-    FaasmSgxEncryptedMsg* doSymEncrypt(FaasmSgxMsg* decryptedMsg,
-                                       FaasmSgxSymKey symKey)
-    {
-        return doAesGcmEncrypt(decryptedMsg, symKey);
+    return doAesGcmEncrypt(decryptedMsg, symKey);
+}
+
+FaasmSgxMsg* doSymDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
+                          FaasmSgxSymKey symKey)
+{
+    return doAesGcmDecrypt(encryptedMsg, symKey);
+}
+
+FaasmSgxEncryptedMsg* doAesGcmEncrypt(FaasmSgxMsg* decryptedMsg,
+                                      FaasmSgxSymKey symKey)
+{
+    FaasmSgxEncryptedMsg* encryptedMsg;
+
+    // Allocate size for the cipher text
+    // Note - the output pointer must have a size greater or equal than
+    // bufferLen.
+    if (!(encryptedMsg =
+            (FaasmSgxEncryptedMsg*)calloc(1, sizeof(FaasmSgxEncryptedMsg)))) {
+        return NULL;
+    }
+    // Initialise the IV
+    if (sgx_read_rand(encryptedMsg->iv, SGX_AESGCM_IV_SIZE) != SGX_SUCCESS) {
+        return NULL;
+    }
+    // Initialise the buffer
+    if (!(encryptedMsg->buffer =
+            (uint8_t*)calloc(decryptedMsg->bufferLen, sizeof(uint8_t)))) {
+        free(encryptedMsg);
+        return NULL;
+    }
+    encryptedMsg->bufferLen = decryptedMsg->bufferLen;
+
+    // Do the actual encryption
+    // Note - we set the Additional Authentication Data (AAD) pointer to
+    // null and it's corresponding length to 0
+    sgx_status_t ret;
+    ret =
+      sgx_rijndael128GCM_encrypt((sgx_aes_gcm_128bit_key_t*)symKey,
+                                 decryptedMsg->buffer,
+                                 decryptedMsg->bufferLen,
+                                 encryptedMsg->buffer,
+                                 encryptedMsg->iv,
+                                 SGX_AESGCM_IV_SIZE,
+                                 NULL,
+                                 0,
+                                 (sgx_aes_gcm_128bit_tag_t*)encryptedMsg->mac);
+    if (ret != SGX_SUCCESS) {
+        free(encryptedMsg->buffer);
+        free(encryptedMsg);
+        return NULL;
     }
 
-    FaasmSgxMsg* doSymDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
-                              FaasmSgxSymKey symKey)
-    {
-        return doAesGcmDecrypt(encryptedMsg, symKey);
+    return encryptedMsg;
+}
+
+FaasmSgxMsg* doAesGcmDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
+                             FaasmSgxSymKey symKey)
+{
+    FaasmSgxMsg* decryptedMsg;
+
+    // Allocate size for the clear text
+    // Note - the output pointer must have a size greater or equal than
+    // the input buffer len.
+    if (!(decryptedMsg = (FaasmSgxMsg*)calloc(1, sizeof(FaasmSgxMsg)))) {
+        return NULL;
+    }
+    if (!(decryptedMsg->buffer =
+            (uint8_t*)calloc(encryptedMsg->bufferLen, sizeof(uint8_t)))) {
+        free(decryptedMsg);
+        return NULL;
     }
 
-    FaasmSgxEncryptedMsg* doAesGcmEncrypt(FaasmSgxMsg* decryptedMsg,
-                                          FaasmSgxSymKey symKey)
-    {
-        FaasmSgxEncryptedMsg* encryptedMsg;
-
-        // Allocate size for the cipher text
-        // Note - the output pointer must have a size greater or equal than
-        // bufferLen.
-        if (!(encryptedMsg = (FaasmSgxEncryptedMsg*)calloc(
-                1, sizeof(FaasmSgxEncryptedMsg)))) {
-            return NULL;
-        }
-        // Initialise the IV
-        if (sgx_read_rand(encryptedMsg->iv, SGX_AESGCM_IV_SIZE) !=
-            SGX_SUCCESS) {
-            return NULL;
-        }
-        // Initialise the buffer
-        if (!(encryptedMsg->buffer =
-                (uint8_t*)calloc(decryptedMsg->bufferLen, sizeof(uint8_t)))) {
-            free(encryptedMsg);
-            return NULL;
-        }
-        encryptedMsg->bufferLen = decryptedMsg->bufferLen;
-
-        // Do the actual encryption
-        // Note - we set the Additional Authentication Data (AAD) pointer to
-        // null and it's corresponding length to 0
-        sgx_status_t ret;
-        ret = sgx_rijndael128GCM_encrypt(
-          (sgx_aes_gcm_128bit_key_t*)symKey,
-          decryptedMsg->buffer,
-          decryptedMsg->bufferLen,
-          encryptedMsg->buffer,
-          encryptedMsg->iv,
-          SGX_AESGCM_IV_SIZE,
-          NULL,
-          0,
-          (sgx_aes_gcm_128bit_tag_t*)encryptedMsg->mac);
-        if (ret != SGX_SUCCESS) {
-            free(encryptedMsg->buffer);
-            free(encryptedMsg);
-            return NULL;
-        }
-
-        return encryptedMsg;
+    // Do the actual decryption
+    // Note - we set the Additional Authentication Data (AAD) pointer to
+    // null and it's corresponding length to 0
+    sgx_status_t ret;
+    ret = sgx_rijndael128GCM_decrypt(
+      (sgx_aes_gcm_128bit_key_t*)symKey,
+      encryptedMsg->buffer,
+      encryptedMsg->bufferLen,
+      decryptedMsg->buffer,
+      encryptedMsg->iv,
+      SGX_AESGCM_IV_SIZE,
+      NULL,
+      0,
+      (const sgx_aes_gcm_128bit_tag_t*)encryptedMsg->mac);
+    if (ret != SGX_SUCCESS) {
+        free(decryptedMsg->buffer);
+        free(decryptedMsg);
+        return NULL;
     }
 
-    FaasmSgxMsg* doAesGcmDecrypt(FaasmSgxEncryptedMsg* encryptedMsg,
-                                 FaasmSgxSymKey symKey)
-    {
-        FaasmSgxMsg* decryptedMsg;
-
-        // Allocate size for the clear text
-        // Note - the output pointer must have a size greater or equal than
-        // the input buffer len.
-        if (!(decryptedMsg = (FaasmSgxMsg*)calloc(1, sizeof(FaasmSgxMsg)))) {
-            return NULL;
-        }
-        if (!(decryptedMsg->buffer =
-                (uint8_t*)calloc(encryptedMsg->bufferLen, sizeof(uint8_t)))) {
-            free(decryptedMsg);
-            return NULL;
-        }
-
-        // Do the actual decryption
-        // Note - we set the Additional Authentication Data (AAD) pointer to
-        // null and it's corresponding length to 0
-        sgx_status_t ret;
-        ret = sgx_rijndael128GCM_decrypt(
-          (sgx_aes_gcm_128bit_key_t*)symKey,
-          encryptedMsg->buffer,
-          encryptedMsg->bufferLen,
-          decryptedMsg->buffer,
-          encryptedMsg->iv,
-          SGX_AESGCM_IV_SIZE,
-          NULL,
-          0,
-          (const sgx_aes_gcm_128bit_tag_t*)encryptedMsg->mac);
-        if (ret != SGX_SUCCESS) {
-            free(decryptedMsg->buffer);
-            free(decryptedMsg);
-            return NULL;
-        }
-
-        return decryptedMsg;
-    }
+    return decryptedMsg;
 }

--- a/src/sgx/crypto/hash.cpp
+++ b/src/sgx/crypto/hash.cpp
@@ -1,24 +1,21 @@
 #include <sgx/crypto/hash.h>
 
-extern "C"
+FaasmSgxHashedMsg* doSha256(FaasmSgxMsg* srcMsg)
 {
-    FaasmSgxHashedMsg* doSha256(FaasmSgxMsg* srcMsg)
-    {
-        // Allocate size for the hashed message
-        FaasmSgxHashedMsg* hashedMsg =
-          (FaasmSgxHashedMsg*)malloc(sizeof(FaasmSgxHashedMsg));
-        if (hashedMsg == NULL) {
-            return NULL;
-        }
-
-        // Do the actual hashing
-        sgx_status_t ret = sgx_sha256_msg(
-          srcMsg->buffer, srcMsg->bufferLen, (sgx_sha256_hash_t*)*hashedMsg);
-        if (ret != SGX_SUCCESS) {
-            free(hashedMsg);
-            return NULL;
-        }
-
-        return hashedMsg;
+    // Allocate size for the hashed message
+    FaasmSgxHashedMsg* hashedMsg =
+      (FaasmSgxHashedMsg*)malloc(sizeof(FaasmSgxHashedMsg));
+    if (hashedMsg == NULL) {
+        return NULL;
     }
+
+    // Do the actual hashing
+    sgx_status_t ret = sgx_sha256_msg(
+      srcMsg->buffer, srcMsg->bufferLen, (sgx_sha256_hash_t*)*hashedMsg);
+    if (ret != SGX_SUCCESS) {
+        free(hashedMsg);
+        return NULL;
+    }
+
+    return hashedMsg;
 }

--- a/src/sgx/native_symbols_wrapper.cpp
+++ b/src/sgx/native_symbols_wrapper.cpp
@@ -33,465 +33,451 @@
 #funcName, (void*)funcName##_wrapper, funcSig, 0x0                     \
     }
 
-extern "C"
+// ------------------------------------
+// FUNCTIONS
+// ------------------------------------
+
+static int32_t faasm_read_input_wrapper(wasm_exec_env_t exec_env,
+                                        uint8_t* buffer,
+                                        unsigned int buffer_size)
 {
-
-    // ------------------------------------
-    // FUNCTIONS
-    // ------------------------------------
-
-    static int32_t faasm_read_input_wrapper(wasm_exec_env_t exec_env,
-                                            uint8_t* buffer,
-                                            unsigned int buffer_size)
-    {
-        int32_t returnValue;
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_read_input(
-               &returnValue, buffer, buffer_size)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-        return returnValue;
+    int32_t returnValue;
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_read_input(
+           &returnValue, buffer, buffer_size)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
     }
-
-    static void faasm_write_output_wrapper(wasm_exec_env_t exec_env,
-                                           uint8_t* output,
-                                           unsigned int output_size)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_write_output(output, output_size)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    // --------------------------------------
-    // STATE
-    // --------------------------------------
-
-    static uint64_t faasm_read_state_wrapper(wasm_exec_env_t exec_env,
-                                             const char* key,
-                                             uint8_t* buffer_ptr,
-                                             const uint32_t buffer_len)
-    {
-        sgx_status_t sgxReturnValue;
-        uint64_t returnValue;
-        if ((sgxReturnValue = ocall_faasm_read_state(
-               &returnValue, key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-        return returnValue;
-    }
-
-    static void faasm_read_appended_state_wrapper(wasm_exec_env_t exec_env,
-                                                  const char* key,
-                                                  uint8_t* buffer_ptr,
-                                                  const uint32_t buffer_len,
-                                                  const uint32_t element_num)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_read_appended_state(
-               key, buffer_ptr, buffer_len, element_num)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_read_state_offset_wrapper(wasm_exec_env_t exec_env,
-                                                const char* key,
-                                                const uint64_t total_len,
-                                                const uint64_t offset,
-                                                uint8_t* buffer_ptr,
-                                                const uint32_t buffer_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_read_state_offset(
-               key, total_len, offset, buffer_ptr, buffer_len)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_write_state_wrapper(wasm_exec_env_t exec_env,
-                                          const char* key,
-                                          const uint8_t* buffer_ptr,
-                                          const uint32_t buffer_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_write_state(
-               key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_append_state_wrapper(wasm_exec_env_t exec_env,
-                                           const char* key,
-                                           const uint8_t* buffer_ptr,
-                                           const uint32_t buffer_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_append_state(
-               key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_clear_appended_state_wrapper(wasm_exec_env_t exec_env,
-                                                   const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_clear_appended_state(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_write_state_offset_wrapper(wasm_exec_env_t exec_env,
-                                                 const char* key,
-                                                 const uint64_t total_len,
-                                                 const uint64_t offset,
-                                                 const uint8_t* buffer_ptr,
-                                                 const uint32_t buffer_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_write_state_offset(
-               key, total_len, offset, buffer_ptr, buffer_len)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_flag_state_dirty_wrapper(wasm_exec_env_t exec_env,
-                                               const char* key,
-                                               const uint64_t total_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_flag_state_dirty(key, total_len)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_flag_state_offset_dirty_wrapper(wasm_exec_env_t exec_env,
-                                                      const char* key,
-                                                      const uint64_t total_len,
-                                                      const uint64_t offset,
-                                                      const uint64_t len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_flag_state_offset_dirty(
-               key, total_len, offset, len)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_push_state_wrapper(wasm_exec_env_t exec_env,
-                                         const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_push_state(key)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_push_state_partial_wrapper(wasm_exec_env_t exec_env,
-                                                 const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_push_state_partial(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_push_state_partial_mask_wrapper(wasm_exec_env_t exec_env,
-                                                      const char* key,
-                                                      const char* mask_key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_push_state_partial_mask(
-               key, mask_key)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_pull_state_wrapper(wasm_exec_env_t exec_env,
-                                         const char* key,
-                                         const uint64_t state_len)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_pull_state(key, state_len)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_lock_state_global_wrapper(wasm_exec_env_t exec_env,
-                                                const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_lock_state_global(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_unlock_state_global_wrapper(wasm_exec_env_t exec_env,
-                                                  const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_unlock_state_global(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_lock_state_read_wrapper(wasm_exec_env_t exec_env,
-                                              const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_lock_state_read(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_unlock_state_read_wrapper(wasm_exec_env_t exec_env,
-                                                const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_unlock_state_read(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_lock_state_write_wrapper(wasm_exec_env_t exec_env,
-                                               const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_lock_state_write(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    static void faasm_unlock_state_write_wrapper(wasm_exec_env_t exec_env,
-                                                 const char* key)
-    {
-        sgx_status_t sgxReturnValue;
-        if ((sgxReturnValue = ocall_faasm_unlock_state_write(key)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-    }
-
-    // ------------------------------
-    // CHAINING
-    // ------------------------------
-
-    static unsigned int faasm_chain_name_wrapper(wasm_exec_env_t exec_env,
-                                                 const char* name,
-                                                 const uint8_t* input,
-                                                 unsigned int input_size)
-    {
-        sgx_status_t sgxReturnValue;
-        unsigned int returnValue;
-        if ((sgxReturnValue = ocall_faasm_chain_name(
-               &returnValue, name, input, input_size)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-
-        return returnValue;
-    }
-
-    static unsigned int faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
-                                                int wasmFuncPtr,
-                                                const uint8_t* input_data,
-                                                unsigned int input_size)
-    {
-        // 01/07/2021 - Chain function by pointer is not supported in SGX as it
-        // breaks attestation model. Chain by name instead.
-        SET_ERROR(FAASM_SGX_WAMR_FUNCTION_NOT_IMPLEMENTED);
-
-        return 1;
-    }
-
-    static unsigned int faasm_await_call_wrapper(wasm_exec_env_t exec_env,
-                                                 unsigned int call_id)
-    {
-        sgx_status_t sgxReturnValue;
-        unsigned int returnValue;
-        if ((sgxReturnValue = ocall_faasm_await_call(&returnValue, call_id)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-        return returnValue;
-    }
-
-    static unsigned int faasm_await_call_output_wrapper(
-      wasm_exec_env_t exec_env,
-      unsigned int call_id,
-      uint8_t* buffer,
-      unsigned int buffer_size)
-    {
-        sgx_status_t sgxReturnValue;
-        unsigned int returnValue;
-        if ((sgxReturnValue = ocall_faasm_await_call_output(
-               &returnValue, call_id, buffer, buffer_size)) != SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-        return returnValue;
-    }
-
-    // -------------------------------------------
-    // PTHREADS
-    // 28/06/21 - WAMR-SGX threading not implemented
-    // -------------------------------------------
-
-    static int32_t pthread_mutex_init_wrapper(wasm_exec_env_t exec_env,
-                                              int32_t a,
-                                              int32_t b)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_mutex_lock_wrapper(wasm_exec_env_t exec_env,
-                                              int32_t a)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_mutex_unlock_wrapper(wasm_exec_env_t exec_env,
-                                                int32_t a)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_cond_broadcast_wrapper(wasm_exec_env_t exec_env,
-                                                  int32_t a)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_mutexattr_init_wrapper(wasm_exec_env_t exec_env,
-                                                  int32_t a)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_mutexattr_destroy_wrapper(wasm_exec_env_t exec_env,
-                                                     int32_t a)
-    {
-        return 0;
-    }
-
-    static int32_t pthread_equal_wrapper(wasm_exec_env_t exec_env,
-                                         int32_t a,
-                                         int32_t b)
-    {
-        return 0;
-    }
-
-    // ------------------------------
-    // MEMORY
-    // ------------------------------
-
-    static int32_t __sbrk_wrapper(wasm_exec_env_t exec_env, int32_t increment)
-    {
-        int32_t returnValue;
-        sgx_status_t sgxReturnValue = ocall_sbrk(&returnValue, increment);
-
-        if ((sgxReturnValue = ocall_sbrk(&returnValue, increment)) !=
-            SGX_SUCCESS) {
-            SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
-        }
-
-        return returnValue;
-    }
-
-    // ------------------------------
-    // WASI default wrapper
-    // ------------------------------
-
-    static int args_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
-    {
-        return 0;
-    }
-
-    static int args_sizes_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
-    {
-        return 0;
-    }
-
-    static int fd_close_wrapper(wasm_exec_env_t exec_env, int a) { return 0; }
-
-    static int fd_seek_wrapper(wasm_exec_env_t exec_env,
-                               int a,
-                               int64 b,
-                               int c,
-                               int d)
-    {
-        return 0;
-    }
-
-    static int fd_write_wrapper(wasm_exec_env_t exec_env,
-                                int a,
-                                int b,
-                                int c,
-                                int d)
-    {
-        return 0;
-    }
-
-    static int fd_fdstat_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
-    {
-        return 0;
-    }
-
-    static void proc_exit_wrapper(wasm_exec_env_t exec_env, int returnCode) {}
-
-    NativeSymbol faasm_sgx_native_symbols[FAASM_SGX_NATIVE_SYMBOLS_LEN] = {
-        NATIVE_FUNC(faasm_read_input, "($i)i"),
-        NATIVE_FUNC(faasm_write_output, "($i)"),
-        NATIVE_FUNC(faasm_read_state, "($$i)i"),
-        NATIVE_FUNC(faasm_read_state_offset, "($ii$i)i"),
-        NATIVE_FUNC(faasm_write_state, "($$i)"),
-        NATIVE_FUNC(faasm_write_state_offset, "($ii$i)"),
-        NATIVE_FUNC(faasm_push_state, "($)"),
-        NATIVE_FUNC(faasm_push_state_partial, "($)"),
-        NATIVE_FUNC(faasm_push_state_partial_mask, "($$)"),
-        NATIVE_FUNC(faasm_pull_state, "($i)"),
-        NATIVE_FUNC(faasm_lock_state_global, "($)"),
-        NATIVE_FUNC(faasm_unlock_state_global, "($)"),
-        NATIVE_FUNC(faasm_lock_state_read, "($)"),
-        NATIVE_FUNC(faasm_unlock_state_read, "($)"),
-        NATIVE_FUNC(faasm_lock_state_write, "($)"),
-        NATIVE_FUNC(faasm_unlock_state_write, "($)"),
-        NATIVE_FUNC(faasm_append_state, "($$i)"),
-        NATIVE_FUNC(faasm_read_appended_state, "($$ii)"),
-        NATIVE_FUNC(faasm_clear_appended_state, "($)"),
-        NATIVE_FUNC(faasm_flag_state_dirty, "($i)"),
-        NATIVE_FUNC(faasm_flag_state_offset_dirty, "($iii)"),
-        NATIVE_FUNC(faasm_chain_name, "($$i)i"),
-        NATIVE_FUNC(faasm_chain_ptr, "(*$i)i"),
-        NATIVE_FUNC(faasm_await_call, "(i)i"),
-        NATIVE_FUNC(faasm_await_call_output, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_mutex_init, "(ii)i"),
-        PTHREAD_NATIVE_FUNC(pthread_mutex_lock, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_mutex_unlock, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_cond_broadcast, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_mutexattr_init, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_mutexattr_destroy, "(i)i"),
-        PTHREAD_NATIVE_FUNC(pthread_equal, "(ii)i"),
-        MEMORY_NATIVE_FUNC(__sbrk, "(i)i"),
-    };
-
-    NativeSymbol faasm_sgx_wasi_symbols[FAASM_SGX_WASI_SYMBOLS_LEN] = {
-        WASI_NATIVE_FUNC(args_get, "(ii)i"),
-        WASI_NATIVE_FUNC(args_sizes_get, "(ii)i"),
-        WASI_NATIVE_FUNC(fd_close, "(i)i"),
-        WASI_NATIVE_FUNC(fd_seek, "(iIii)i"),
-        WASI_NATIVE_FUNC(fd_write, "(iiii)i"),
-        WASI_NATIVE_FUNC(fd_fdstat_get, "(ii)i"),
-        WASI_NATIVE_FUNC(proc_exit, "(i)"),
-    };
+    return returnValue;
 }
+
+static void faasm_write_output_wrapper(wasm_exec_env_t exec_env,
+                                       uint8_t* output,
+                                       unsigned int output_size)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_write_output(output, output_size)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+// --------------------------------------
+// STATE
+// --------------------------------------
+
+static uint64_t faasm_read_state_wrapper(wasm_exec_env_t exec_env,
+                                         const char* key,
+                                         uint8_t* buffer_ptr,
+                                         const uint32_t buffer_len)
+{
+    sgx_status_t sgxReturnValue;
+    uint64_t returnValue;
+    if ((sgxReturnValue = ocall_faasm_read_state(
+           &returnValue, key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+    return returnValue;
+}
+
+static void faasm_read_appended_state_wrapper(wasm_exec_env_t exec_env,
+                                              const char* key,
+                                              uint8_t* buffer_ptr,
+                                              const uint32_t buffer_len,
+                                              const uint32_t element_num)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_read_appended_state(
+           key, buffer_ptr, buffer_len, element_num)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_read_state_offset_wrapper(wasm_exec_env_t exec_env,
+                                            const char* key,
+                                            const uint64_t total_len,
+                                            const uint64_t offset,
+                                            uint8_t* buffer_ptr,
+                                            const uint32_t buffer_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_read_state_offset(
+           key, total_len, offset, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_write_state_wrapper(wasm_exec_env_t exec_env,
+                                      const char* key,
+                                      const uint8_t* buffer_ptr,
+                                      const uint32_t buffer_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_write_state(
+           key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_append_state_wrapper(wasm_exec_env_t exec_env,
+                                       const char* key,
+                                       const uint8_t* buffer_ptr,
+                                       const uint32_t buffer_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_append_state(
+           key, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_clear_appended_state_wrapper(wasm_exec_env_t exec_env,
+                                               const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_clear_appended_state(key)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_write_state_offset_wrapper(wasm_exec_env_t exec_env,
+                                             const char* key,
+                                             const uint64_t total_len,
+                                             const uint64_t offset,
+                                             const uint8_t* buffer_ptr,
+                                             const uint32_t buffer_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_write_state_offset(
+           key, total_len, offset, buffer_ptr, buffer_len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_flag_state_dirty_wrapper(wasm_exec_env_t exec_env,
+                                           const char* key,
+                                           const uint64_t total_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_flag_state_dirty(key, total_len)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_flag_state_offset_dirty_wrapper(wasm_exec_env_t exec_env,
+                                                  const char* key,
+                                                  const uint64_t total_len,
+                                                  const uint64_t offset,
+                                                  const uint64_t len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_flag_state_offset_dirty(
+           key, total_len, offset, len)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_push_state_wrapper(wasm_exec_env_t exec_env, const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_push_state(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_push_state_partial_wrapper(wasm_exec_env_t exec_env,
+                                             const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_push_state_partial(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_push_state_partial_mask_wrapper(wasm_exec_env_t exec_env,
+                                                  const char* key,
+                                                  const char* mask_key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_push_state_partial_mask(key, mask_key)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_pull_state_wrapper(wasm_exec_env_t exec_env,
+                                     const char* key,
+                                     const uint64_t state_len)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_pull_state(key, state_len)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_lock_state_global_wrapper(wasm_exec_env_t exec_env,
+                                            const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_lock_state_global(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_unlock_state_global_wrapper(wasm_exec_env_t exec_env,
+                                              const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_unlock_state_global(key)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_lock_state_read_wrapper(wasm_exec_env_t exec_env,
+                                          const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_lock_state_read(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_unlock_state_read_wrapper(wasm_exec_env_t exec_env,
+                                            const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_unlock_state_read(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_lock_state_write_wrapper(wasm_exec_env_t exec_env,
+                                           const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_lock_state_write(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+static void faasm_unlock_state_write_wrapper(wasm_exec_env_t exec_env,
+                                             const char* key)
+{
+    sgx_status_t sgxReturnValue;
+    if ((sgxReturnValue = ocall_faasm_unlock_state_write(key)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+}
+
+// ------------------------------
+// CHAINING
+// ------------------------------
+
+static unsigned int faasm_chain_name_wrapper(wasm_exec_env_t exec_env,
+                                             const char* name,
+                                             const uint8_t* input,
+                                             unsigned int input_size)
+{
+    sgx_status_t sgxReturnValue;
+    unsigned int returnValue;
+    if ((sgxReturnValue = ocall_faasm_chain_name(
+           &returnValue, name, input, input_size)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+
+    return returnValue;
+}
+
+static unsigned int faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
+                                            int wasmFuncPtr,
+                                            const uint8_t* input_data,
+                                            unsigned int input_size)
+{
+    // 01/07/2021 - Chain function by pointer is not supported in SGX as it
+    // breaks attestation model. Chain by name instead.
+    SET_ERROR(FAASM_SGX_WAMR_FUNCTION_NOT_IMPLEMENTED);
+
+    return 1;
+}
+
+static unsigned int faasm_await_call_wrapper(wasm_exec_env_t exec_env,
+                                             unsigned int call_id)
+{
+    sgx_status_t sgxReturnValue;
+    unsigned int returnValue;
+    if ((sgxReturnValue = ocall_faasm_await_call(&returnValue, call_id)) !=
+        SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+    return returnValue;
+}
+
+static unsigned int faasm_await_call_output_wrapper(wasm_exec_env_t exec_env,
+                                                    unsigned int call_id,
+                                                    uint8_t* buffer,
+                                                    unsigned int buffer_size)
+{
+    sgx_status_t sgxReturnValue;
+    unsigned int returnValue;
+    if ((sgxReturnValue = ocall_faasm_await_call_output(
+           &returnValue, call_id, buffer, buffer_size)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+    return returnValue;
+}
+
+// -------------------------------------------
+// PTHREADS
+// 28/06/21 - WAMR-SGX threading not implemented
+// -------------------------------------------
+
+static int32_t pthread_mutex_init_wrapper(wasm_exec_env_t exec_env,
+                                          int32_t a,
+                                          int32_t b)
+{
+    return 0;
+}
+
+static int32_t pthread_mutex_lock_wrapper(wasm_exec_env_t exec_env, int32_t a)
+{
+    return 0;
+}
+
+static int32_t pthread_mutex_unlock_wrapper(wasm_exec_env_t exec_env, int32_t a)
+{
+    return 0;
+}
+
+static int32_t pthread_cond_broadcast_wrapper(wasm_exec_env_t exec_env,
+                                              int32_t a)
+{
+    return 0;
+}
+
+static int32_t pthread_mutexattr_init_wrapper(wasm_exec_env_t exec_env,
+                                              int32_t a)
+{
+    return 0;
+}
+
+static int32_t pthread_mutexattr_destroy_wrapper(wasm_exec_env_t exec_env,
+                                                 int32_t a)
+{
+    return 0;
+}
+
+static int32_t pthread_equal_wrapper(wasm_exec_env_t exec_env,
+                                     int32_t a,
+                                     int32_t b)
+{
+    return 0;
+}
+
+// ------------------------------
+// MEMORY
+// ------------------------------
+
+static int32_t __sbrk_wrapper(wasm_exec_env_t exec_env, int32_t increment)
+{
+    int32_t returnValue;
+    sgx_status_t sgxReturnValue = ocall_sbrk(&returnValue, increment);
+
+    if ((sgxReturnValue = ocall_sbrk(&returnValue, increment)) != SGX_SUCCESS) {
+        SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
+    }
+
+    return returnValue;
+}
+
+// ------------------------------
+// WASI default wrapper
+// ------------------------------
+
+static int args_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
+{
+    return 0;
+}
+
+static int args_sizes_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
+{
+    return 0;
+}
+
+static int fd_close_wrapper(wasm_exec_env_t exec_env, int a)
+{
+    return 0;
+}
+
+static int fd_seek_wrapper(wasm_exec_env_t exec_env,
+                           int a,
+                           int64 b,
+                           int c,
+                           int d)
+{
+    return 0;
+}
+
+static int fd_write_wrapper(wasm_exec_env_t exec_env,
+                            int a,
+                            int b,
+                            int c,
+                            int d)
+{
+    return 0;
+}
+
+static int fd_fdstat_get_wrapper(wasm_exec_env_t exec_env, int a, int b)
+{
+    return 0;
+}
+
+static void proc_exit_wrapper(wasm_exec_env_t exec_env, int returnCode) {}
+
+NativeSymbol faasm_sgx_native_symbols[FAASM_SGX_NATIVE_SYMBOLS_LEN] = {
+    NATIVE_FUNC(faasm_read_input, "($i)i"),
+    NATIVE_FUNC(faasm_write_output, "($i)"),
+    NATIVE_FUNC(faasm_read_state, "($$i)i"),
+    NATIVE_FUNC(faasm_read_state_offset, "($ii$i)i"),
+    NATIVE_FUNC(faasm_write_state, "($$i)"),
+    NATIVE_FUNC(faasm_write_state_offset, "($ii$i)"),
+    NATIVE_FUNC(faasm_push_state, "($)"),
+    NATIVE_FUNC(faasm_push_state_partial, "($)"),
+    NATIVE_FUNC(faasm_push_state_partial_mask, "($$)"),
+    NATIVE_FUNC(faasm_pull_state, "($i)"),
+    NATIVE_FUNC(faasm_lock_state_global, "($)"),
+    NATIVE_FUNC(faasm_unlock_state_global, "($)"),
+    NATIVE_FUNC(faasm_lock_state_read, "($)"),
+    NATIVE_FUNC(faasm_unlock_state_read, "($)"),
+    NATIVE_FUNC(faasm_lock_state_write, "($)"),
+    NATIVE_FUNC(faasm_unlock_state_write, "($)"),
+    NATIVE_FUNC(faasm_append_state, "($$i)"),
+    NATIVE_FUNC(faasm_read_appended_state, "($$ii)"),
+    NATIVE_FUNC(faasm_clear_appended_state, "($)"),
+    NATIVE_FUNC(faasm_flag_state_dirty, "($i)"),
+    NATIVE_FUNC(faasm_flag_state_offset_dirty, "($iii)"),
+    NATIVE_FUNC(faasm_chain_name, "($$i)i"),
+    NATIVE_FUNC(faasm_chain_ptr, "(*$i)i"),
+    NATIVE_FUNC(faasm_await_call, "(i)i"),
+    NATIVE_FUNC(faasm_await_call_output, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_mutex_init, "(ii)i"),
+    PTHREAD_NATIVE_FUNC(pthread_mutex_lock, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_mutex_unlock, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_cond_broadcast, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_mutexattr_init, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_mutexattr_destroy, "(i)i"),
+    PTHREAD_NATIVE_FUNC(pthread_equal, "(ii)i"),
+    MEMORY_NATIVE_FUNC(__sbrk, "(i)i"),
+};
+
+NativeSymbol faasm_sgx_wasi_symbols[FAASM_SGX_WASI_SYMBOLS_LEN] = {
+    WASI_NATIVE_FUNC(args_get, "(ii)i"),
+    WASI_NATIVE_FUNC(args_sizes_get, "(ii)i"),
+    WASI_NATIVE_FUNC(fd_close, "(i)i"),
+    WASI_NATIVE_FUNC(fd_seek, "(iIii)i"),
+    WASI_NATIVE_FUNC(fd_write, "(iiii)i"),
+    WASI_NATIVE_FUNC(fd_fdstat_get, "(ii)i"),
+    WASI_NATIVE_FUNC(proc_exit, "(i)"),
+};


### PR DESCRIPTION
At the moment, we were using C code (or C language linkage) for anything under the `src/sgx` directory. This is not really needed.

According to the SGX reference, enclave code can be written in both `C` and `C++`. However, special rules apply for `ECalls` and `OCalls`. Citing the [developer reference](https://01.org/sites/default/files/documentation/intel_sgx_sdk_developer_reference_for_linux_os_pdf.pdf):
* `Enclave interface functions are limited to C (no C++).` (p.26, table)
* `OCALL functions must be C functions, or C++ functions with C linkage.` (p.31)

The diff is very large, but mostly due to indentation issues.