### PR TITLE
OpenMP test fix

### DIFF
--- a/tests/test/wasm/test_memory.cpp
+++ b/tests/test/wasm/test_memory.cpp
@@ -151,7 +151,7 @@ TEST_CASE_METHOD(FunctionExecTestFixture, "Test mmap/munmap", "[faaslet]")
     checkCallingFunctionGivesBoolOutput("demo", "mmap", true);
 }
 
-TEST_CASE_METHOD(FunctionExecTestFixture, "Test big mmap", "[.][faaslet]")
+TEST_CASE_METHOD(FunctionExecTestFixture, "Test big mmap", "[faaslet]")
 {
     faabric::Message msg = faabric::util::messageFactory("demo", "mmap_big");
     execFunction(msg);


### PR DESCRIPTION
We've been seeing regular OpenMP test failures which I think may be a stack overflow in disguise. WAVM is failing internally calling `alloca` and producing a segfault then totally bombing out (not even running the crash handler).

I've reproduced this locally, and expanding the stack size seems to fix it 🤷‍♂️ 