### PR TITLE
Change microbench runner to reset, not restore

### DIFF
--- a/src/runner/MicrobenchRunner.cpp
+++ b/src/runner/MicrobenchRunner.cpp
@@ -85,7 +85,7 @@ int doRun(std::ofstream& outFs,
 
         // Reset
         TimePoint resetStart = startTimer();
-        f.restore(msg);
+        f.reset(msg);
         long resetNanos = getTimeDiffNanos(resetStart);
         float resetMicros = float(resetNanos) / 1000;
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -210,6 +210,9 @@ void WAVMWasmModule::clone(const WAVMWasmModule& other,
         // Remap dynamic modules
         lastLoadedDynamicModuleHandle = other.lastLoadedDynamicModuleHandle;
         dynamicPathToHandleMap = other.dynamicPathToHandleMap;
+
+        // Recreate map of dynamic modules
+        dynamicModuleMap.clear();
         for (const auto& p : other.dynamicModuleMap) {
             Runtime::Instance* newInstance =
               Runtime::remapToClonedCompartment(p.second.ptr, compartment);

--- a/tests/test/runner/test_microbench_runner.cpp
+++ b/tests/test/runner/test_microbench_runner.cpp
@@ -53,6 +53,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
 
     specFs << "demo,echo,4,blah" << std::endl;
     specFs << "demo,hello,3" << std::endl;
+    specFs << "python,hello,3" << std::endl;
     specFs.close();
 
     std::string outFile = "/tmp/microbench_out.csv";
@@ -63,7 +64,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
     std::vector<std::string> lines;
     boost::split(lines, result, [](char c) { return c == '\n'; });
 
-    REQUIRE(lines.size() == 9);
+    REQUIRE(lines.size() == 12);
 
     REQUIRE(lines.at(0) ==
             "User,Function,Return value,Execution (us),Reset (us)");
@@ -76,6 +77,10 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
         checkLine(lines.at(i), "demo", "hello");
     }
 
-    REQUIRE(lines.at(8).empty());
+    for (int i = 8; i < 11; i++) {
+        checkLine(lines.at(i), "python", "hello");
+    }
+
+    REQUIRE(lines.at(11).empty());
 }
 }


### PR DESCRIPTION
Subtle difference which only causes problems with repeated execution of Python functions, not C/C++ ones.

Tests only covered C/C++, so updated to include Python.