### PR TITLE
Add restart to upload container in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       - redis-queue
       - redis-state
       - minio
+    restart: on-failure
     volumes:
       - ./:/usr/local/code/faasm/
       - ./dev/faasm/build/:${FAASM_BUILD_MOUNT}


### PR DESCRIPTION
Sometimes `minio` hasn't started fully by the time `upload` has started. Although we have a `depends_on` between `upload` and `minio`, `minio` isn't always ready to accept requests by the time it's started. 

There doesn't seem to be a nice way to hook into the health checks ([any more](https://stackoverflow.com/questions/31746182/docker-compose-wait-for-container-x-before-starting-y/41854997#41854997)), but this restart should do the trick. 