### PR TITLE
Clear shared files map upon flush

### DIFF
--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -1,5 +1,6 @@
 #include <conf/FaasmConfig.h>
 #include <storage/FileLoader.h>
+#include <storage/SharedFiles.h>
 
 #include <stdexcept>
 

--- a/tests/test/storage/test_file_loader.cpp
+++ b/tests/test/storage/test_file_loader.cpp
@@ -115,7 +115,6 @@ TEST_CASE_METHOD(FileLoaderTestFixture,
     REQUIRE(boost::filesystem::exists(funcFile));
 
     // Now flush
-    storage::FileLoader& loader = storage::getFileLoader();
     loader.clearLocalCache();
 
     // Check files don't exist


### PR DESCRIPTION
Previously we were not clearing the `SharedFiles` map upon flush. As a consequence, when opening a shared file that had been (1) synced, and (2) flushed, the filesystem implementation would act as if the file was cached, and try to `::open` it.

In more detail, `SharedFiles::syncSharedFile` would _not_ sync back the file after flush.

This PR fixes it and adds a regression test.