### PR TITLE
Pin HostStats version in the dockerfiles

### DIFF
--- a/docker/upload.dockerfile
+++ b/docker/upload.dockerfile
@@ -8,7 +8,7 @@ RUN cmake --build . --target codegen_shared_obj
 RUN cmake --build . --target codegen_func
 
 # Install hoststats
-RUN pip3 install hoststats
+RUN pip3 install -v hoststats==0.1.0
 
 # Set up entrypoint
 COPY bin/entrypoint_codegen.sh /entrypoint_codegen.sh

--- a/docker/worker.dockerfile
+++ b/docker/worker.dockerfile
@@ -8,7 +8,7 @@ RUN cmake --build . --target codegen_func
 RUN cmake --build . --target pool_runner
 
 # Install hoststats
-RUN pip3 install hoststats
+RUN pip3 install -v hoststats==0.1.0
 
 # Set up entrypoint (for cgroups, namespaces etc.)
 COPY bin/entrypoint_codegen.sh /entrypoint_codegen.sh


### PR DESCRIPTION
I am aware that we should pin versions to all `pip3` commands, but this was an easy win, and we really want to ensure the `HostStats` version is the correct one.