### PR TITLE
Add support for deleting generated code

### DIFF
--- a/faasmcli/faasmcli/util/codegen.py
+++ b/faasmcli/faasmcli/util/codegen.py
@@ -7,3 +7,7 @@ def find_codegen_shared_lib():
 
 def find_codegen_func():
     return find_command("codegen_func")
+
+
+def find_codegen_del():
+    return find_command("codegen_del")

--- a/include/codegen/MachineCodeGenerator.h
+++ b/include/codegen/MachineCodeGenerator.h
@@ -16,6 +16,8 @@ class MachineCodeGenerator
 
     void codegenForFunction(faabric::Message& msg);
 
+    void deleteCodegenForFunction(const faabric::Message& msg);
+
     void codegenForSharedObject(const std::string& inputPath);
 
   private:

--- a/include/storage/FileLoader.h
+++ b/include/storage/FileLoader.h
@@ -147,7 +147,7 @@ class FileLoader
                          const std::string& localCachePath);
 
     void deleteHashFileBytes(const std::string& path,
-                         const std::string& localCachePath);
+                             const std::string& localCachePath);
 };
 
 FileLoader& getFileLoader();

--- a/src/codegen/MachineCodeGenerator.cpp
+++ b/src/codegen/MachineCodeGenerator.cpp
@@ -105,11 +105,11 @@ void MachineCodeGenerator::codegenForFunction(faabric::Message& msg)
     }
 }
 
-void MachineCodeGenerator::deleteCodegenForFunc(const faabric::Message& msg)
+void MachineCodeGenerator::deleteCodegenForFunction(const faabric::Message& msg)
 {
     if (conf.wasmVm == "wamr") {
-        loader.deleteFunctionObjectFile(msg);
-        loader.deleteFunctionObjectHash(msg);
+        loader.deleteFunctionWamrAotFile(msg);
+        loader.deleteFunctionWamrAotHash(msg);
     } else {
         loader.deleteFunctionObjectFile(msg);
         loader.deleteFunctionObjectHash(msg);

--- a/src/runner/CMakeLists.txt
+++ b/src/runner/CMakeLists.txt
@@ -37,3 +37,7 @@ target_link_libraries(codegen_shared_obj ${CODEGEN_LIBS})
 
 add_executable(codegen_func codegen_func.cpp)
 target_link_libraries(codegen_func ${CODEGEN_LIBS})
+
+add_executable(codegen_del codegen_del.cpp)
+target_link_libraries(codegen_del ${CODEGEN_LIBS})
+add_dependencies(codegen_del codegen_func)

--- a/src/runner/codegen_del.cpp
+++ b/src/runner/codegen_del.cpp
@@ -1,0 +1,118 @@
+#include <boost/filesystem.hpp>
+#include <faabric/util/config.h>
+#include <faabric/util/environment.h>
+#include <faabric/util/func.h>
+#include <faabric/util/locks.h>
+#include <faabric/util/logging.h>
+
+#include <codegen/MachineCodeGenerator.h>
+#include <conf/FaasmConfig.h>
+#include <storage/FileLoader.h>
+#include <storage/S3Wrapper.h>
+
+using namespace boost::filesystem;
+
+void deleteCodegenForFunc(const std::string& user,
+                          const std::string& func,
+                          bool isSgx = false)
+{
+    codegen::MachineCodeGenerator& gen = codegen::getMachineCodeGenerator();
+    storage::FileLoader& loader = storage::getFileLoader();
+    faabric::Message msg = faabric::util::messageFactory(user, func);
+
+    std::string funcFile = loader.getFunctionFile(msg);
+    if (!boost::filesystem::exists(funcFile)) {
+        SPDLOG_WARN("Invalid function: {}/{}", user, func);
+        return;
+    }
+
+    if (isSgx) {
+        msg.set_issgx(true);
+        SPDLOG_INFO("Deleting SGX machine code for {}/{}", user, func);
+    } else {
+        SPDLOG_INFO("Deleting machine code for {}/{}", user, func);
+    }
+
+    gen.deleteCodegenForFunction(msg);
+}
+
+int main(int argc, char* argv[])
+{
+    faabric::util::initLogging();
+    storage::initFaasmS3();
+
+    if (argc == 3) {
+        std::string user = argv[1];
+        std::string func = argv[2];
+
+        SPDLOG_INFO("Deleting codegen for function {}/{}", user, func);
+        deleteCodegenForFunc(user, func);
+    } else if (argc == 2) {
+        std::string user = argv[1];
+
+        conf::FaasmConfig& conf = conf::getFaasmConfig();
+        SPDLOG_INFO(
+          "Deleting codegen for user {} on dir {}", user, conf.functionDir);
+
+        boost::filesystem::path path(conf.functionDir);
+        path.append(user);
+
+        if (!boost::filesystem::is_directory(path)) {
+            SPDLOG_ERROR("Expected {} to be a directory", path.string());
+            return 1;
+        }
+
+        boost::filesystem::directory_iterator iter(path), end;
+        std::mutex mx;
+
+        unsigned int nThreads = faabric::util::getUsableCores();
+        std::vector<std::thread> threads;
+
+        for (unsigned int i = 0; i < nThreads; i++) {
+            threads.emplace_back([&iter, &mx, &end, &user] {
+                SPDLOG_INFO("Spawning codegen thread");
+
+                while (true) {
+                    std::string thisPath;
+
+                    {
+                        // Get lock
+                        faabric::util::UniqueLock lock(mx);
+
+                        // Check if we've got more to do
+                        if (iter == end) {
+                            SPDLOG_INFO("Codegen thread finished");
+                            break;
+                        }
+
+                        // Get path and increment
+                        thisPath = iter->path().string();
+                        iter++;
+                    }
+
+                    directory_entry subPath(thisPath);
+                    std::string functionName =
+                      subPath.path().filename().string();
+                    deleteCodegenForFunc(user, functionName);
+                }
+            });
+        }
+
+        for (auto& t : threads) {
+            if (t.joinable()) {
+                t.join();
+            }
+        }
+    } else if (argc == 4 && std::string(argv[3]) == "--sgx") {
+        std::string user = argv[1];
+        std::string func = argv[2];
+
+        SPDLOG_INFO("Deleting SGX codegen for function {}/{}", user, func);
+        deleteCodegenForFunc(user, func, true);
+    } else {
+        SPDLOG_ERROR("Must provide function user and optional function name");
+        return 0;
+    }
+
+    storage::shutdownFaasmS3();
+}

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -181,6 +181,8 @@ void FileLoader::uploadFileString(const std::string& path,
 void FileLoader::deleteFileBytes(const std::string& path,
                                  const std::string& localCachePath)
 {
+    SPDLOG_TRACE("Deleting files {} ({})", path, localCachePath);
+
     // Remove local cache path if it exists
     if (useLocalFsCache && boost::filesystem::exists(localCachePath)) {
         boost::filesystem::remove(localCachePath);
@@ -364,17 +366,17 @@ void FileLoader::uploadFunctionWamrAotHash(const faabric::Message& msg,
     uploadHashFileBytes(key, localCachePath, hash);
 }
 
-void FileLoader::deleteFunctionObjectFile(const faabric::Message& msg)
+void FileLoader::deleteFunctionWamrAotFile(const faabric::Message& msg)
 {
     const std::string key = getWamrAotKey(msg);
-    const std::string localCachePath = getFunctionObjectFile(msg);
+    const std::string localCachePath = getFunctionAotFile(msg);
     deleteFileBytes(key, localCachePath);
 }
 
-void FileLoader::deleteFunctionObjectHash(const faabric::Message& msg)
+void FileLoader::deleteFunctionWamrAotHash(const faabric::Message& msg)
 {
     const std::string key = getWamrAotKey(msg);
-    const std::string localCachePath = getFunctionObjectFile(msg);
+    const std::string localCachePath = getFunctionAotFile(msg);
     deleteHashFileBytes(key, localCachePath);
 }
 

--- a/tests/test/codegen/test_machine_code_generator.cpp
+++ b/tests/test/codegen/test_machine_code_generator.cpp
@@ -73,6 +73,81 @@ TEST_CASE_METHOD(CodegenTestFixture, "Test basic codegen", "[codegen]")
 }
 
 TEST_CASE_METHOD(CodegenTestFixture,
+                 "Test deleting generated code",
+                 "[codegen]")
+{
+    std::string hashFileA;
+    std::string objectFileA;
+
+    SECTION("WAVM codegen")
+    {
+        conf.wasmVm = "wavm";
+        objectFileA = "/tmp/obj/demo/hello/function.wasm.o";
+        hashFileA = objectFileA + HASH_EXT;
+
+        // Upload function and run codegen
+        loader.uploadFunction(msgA);
+        gen.codegenForFunction(msgA);
+
+        REQUIRE(boost::filesystem::exists(objectFileA));
+        REQUIRE(boost::filesystem::exists(hashFileA));
+        REQUIRE_NOTHROW(loader.loadFunctionObjectFile(msgA));
+
+        // Delete codegen
+        gen.deleteCodegenForFunction(msgA);
+
+        REQUIRE(!boost::filesystem::exists(objectFileA));
+        REQUIRE(!boost::filesystem::exists(hashFileA));
+        REQUIRE_THROWS(loader.loadFunctionObjectFile(msgA));
+    }
+
+    SECTION("WAMR codegen")
+    {
+        conf.wasmVm = "wamr";
+        objectFileA = "/tmp/obj/demo/hello/function.aot";
+        hashFileA = objectFileA + HASH_EXT;
+
+        // Upload function and run codegen
+        loader.uploadFunction(msgA);
+        gen.codegenForFunction(msgA);
+
+        REQUIRE(boost::filesystem::exists(objectFileA));
+        REQUIRE(boost::filesystem::exists(hashFileA));
+        REQUIRE_NOTHROW(loader.loadFunctionWamrAotFile(msgA));
+
+        // Delete codegen
+        gen.deleteCodegenForFunction(msgA);
+
+        REQUIRE(!boost::filesystem::exists(objectFileA));
+        REQUIRE(!boost::filesystem::exists(hashFileA));
+        REQUIRE_THROWS(loader.loadFunctionWamrAotFile(msgA));
+    }
+
+    SECTION("WAMR-SGX codegen")
+    {
+        conf.wasmVm = "wamr";
+        objectFileA = "/tmp/obj/demo/hello/function.aot.sgx";
+        hashFileA = objectFileA + HASH_EXT;
+        msgA.set_issgx(true);
+
+        // Upload function and run codegen
+        loader.uploadFunction(msgA);
+        gen.codegenForFunction(msgA);
+
+        REQUIRE(boost::filesystem::exists(objectFileA));
+        REQUIRE(boost::filesystem::exists(hashFileA));
+        REQUIRE_NOTHROW(loader.loadFunctionWamrAotFile(msgA));
+
+        // Delete codegen
+        gen.deleteCodegenForFunction(msgA);
+
+        REQUIRE(!boost::filesystem::exists(objectFileA));
+        REQUIRE(!boost::filesystem::exists(hashFileA));
+        REQUIRE_THROWS(loader.loadFunctionWamrAotFile(msgA));
+    }
+}
+
+TEST_CASE_METHOD(CodegenTestFixture,
                  "Test function codegen hashing",
                  "[codegen]")
 {


### PR DESCRIPTION
In this PR I introduce the ability to clear generated machine code from the command line. The proposed API is very similar to the existing one for the `codegen` tasks. The task signature is:

```bash
inv codegen.delete <user> <func> [--wamr [--sgx]]
```

Forcing machine code re-generation has proven useful in different situations and there was not an easy way to do it.

Note that, with the changes in this PR, we could theoretically support many more CLI features like:
* Deleting WASM files from the CLI
* Deleting shared files from the CLI
* Having a version of the `upload` command that forces overwriting of the machine code/wasm/shared file

However, I've just implemented the remove a single function's machine code, as it was the one I needed. Happy to include any other feature though.