### PR TITLE
Cache conan dependencies in tests for faster build times

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,12 +221,26 @@ jobs:
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
       - name: "Print CPU model"
         run: echo "${{ env.CPU_MODEL}}"
+      # --- Cache - use minio directory to share between containers ---
+      - name: "Configure S3 cache"
+        uses: actions/cache@v2
+        with:
+          path: ./dev/minio/data/faasm
+          key: ${{ env.CPU_MODEL }}-s3-data-${{ secrets.CACHE_VERSION }}
       # --- Cache based on Conan version and ExternalProjects cmake source
       - name: Get Conan version
         id: get-conan-version
         run: |
-          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+          docker-compose run --rm faasm-cli conan --version 2>/tmp/conan-ver-log | tee /tmp/conan-ver
+          grep 'Conan version' /tmp/conan-ver || exit 1
+          echo "::set-output name=conan-version::$(grep 'Conan version' /tmp/conan-ver | tr -d '[:alpha:] ')"
         shell: bash
+        env:
+          FAASM_BUILD_MOUNT: /build/faasm
+          CONAN_CACHE_MOUNT_SOURCE: ~/.conan/
+      - name: Get Conan Version - Show Log
+        if: always()
+        run: cat /tmp/conan-ver-log
       - name: Hash ExternalProjects
         id: hash-external
         run: |
@@ -239,12 +253,6 @@ jobs:
           restore-keys: |
             ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
             ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-
-      # --- Cache - use minio directory to share between containers ---
-      - name: "Configure S3 cache"
-        uses: actions/cache@v2
-        with:
-          path: ./dev/minio/data/faasm
-          key: ${{ env.CPU_MODEL }}-s3-data-${{ secrets.CACHE_VERSION }}
       # --- Set up and run ---
       - name: "Build tests"
         run: ./deploy/dist-test/build.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -164,6 +164,24 @@ jobs:
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
       - name: "Print CPU model"
         run: echo "${{ env.CPU_MODEL}}"
+      # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+        shell: bash
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)-$(sha256sum faabric/cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-
       # --- Cache ---
       - name: "Configure machine code cache"
         uses: actions/cache@v2
@@ -203,6 +221,24 @@ jobs:
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
       - name: "Print CPU model"
         run: echo "${{ env.CPU_MODEL}}"
+      # --- Cache based on Conan version and ExternalProjects cmake source
+      - name: Get Conan version
+        id: get-conan-version
+        run: |
+          echo "::set-output name=conan-version::$(conan --version | tr -d '[:alpha:] ')"
+        shell: bash
+      - name: Hash ExternalProjects
+        id: hash-external
+        run: |
+          echo "::set-output name=hash-external::$(sha256sum cmake/ExternalProjects.cmake | cut '-d ' -f 1)-$(sha256sum faabric/cmake/ExternalProjects.cmake | cut '-d ' -f 1)"
+        shell: bash
+      - uses: actions/cache@v2
+        with:
+          path: '~/.conan'
+          key: ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-${{ steps.hash-external.outputs.hash-external }}
+          restore-keys: |
+            ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-${{ steps.get-conan-version.outputs.conan-version }}-
+            ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-
       # --- Cache - use minio directory to share between containers ---
       - name: "Configure S3 cache"
         uses: actions/cache@v2

--- a/deploy/dist-test/build.sh
+++ b/deploy/dist-test/build.sh
@@ -7,6 +7,9 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} >> /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
+export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
+# Ensure the cache directory exists before starting the containers
+mkdir -p ${CONAN_CACHE_MOUNT_SOURCE}
 
 # Run the build
 docker-compose \

--- a/deploy/dist-test/run.sh
+++ b/deploy/dist-test/run.sh
@@ -5,6 +5,7 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} > /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
+export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
 
 RETURN_VAL=0
 

--- a/deploy/dist-test/upload.sh
+++ b/deploy/dist-test/upload.sh
@@ -7,6 +7,7 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} > /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
+export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
 
 # Make sure upload server is running
 docker-compose \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,7 +127,7 @@ services:
       - ./:/usr/local/code/faasm/
       - ./dev/faasm/build/:${FAASM_BUILD_MOUNT}
       - ./dev/faasm-local/:${FAASM_LOCAL_MOUNT}
-      - ./dev/faasm/conan/:/root/.conan
+      - ${CONAN_CACHE_MOUNT_SOURCE:-./dev/faasm/conan/}:/root/.conan
 
   # Distributed tests server
   dist-test-server:


### PR DESCRIPTION
Just like in faabric, cache conan dependencies for faster test build times. Instead of a separate build step, just use the cache in the two containers directly as there's only 2, introducing a third one to pre-populate the cache would most likely by slower.