### PR TITLE
Print only Pod IPs in running state

### DIFF
--- a/faasmcli/faasmcli/tasks/knative.py
+++ b/faasmcli/faasmcli/tasks/knative.py
@@ -57,10 +57,11 @@ def _get_faasm_worker_pods():
         "-n faasm",
         "get pods",
         "-l serving.knative.dev/service=faasm-worker",
-        "-o jsonpath='{range .items[*]}{@.status.podIP}{\" \"}{end}'",
+        """--template "{{range .items}}{{ if not .metadata.deletionTimestamp"""
+        """ }}{{.status.podIP}}:{{end}}{{end}}" """,
     ]
     output = _capture_cmd_output(cmd)
-    ips = [o.strip() for o in output.split(" ") if o.strip()]
+    ips = [o.strip() for o in output.split(":") if o.strip()]
 
     print("Using faasm worker pods: {}".format(ips))
     return names, ips


### PR DESCRIPTION
When we merged #489 we only changed the command to print the worker names, but we forgot to change the command to print the worker IPs.

In this PR I change the latter (same rationale as #489).