### PR TITLE
Updates for out-of-container builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
 
   minio:
     image: faasm/minio:${FAASM_VERSION}
-    expose:
-      - "9000"
+    ports:
+      - "9000:9000"
     environment:
       MINIO_ROOT_USER: minio
       MINIO_ROOT_PASSWORD: minio123

--- a/docs/development.md
+++ b/docs/development.md
@@ -154,13 +154,13 @@ local machine.
 This is not the recommended approach to developing Faasm, so it's not scripted,
 but you can work out what's required by looking at the following Dockerfiles:
 
-- [`faasm/grpc-root`](https://github.com/faasm/faabric/blob/master/docker/grpc-root.dockerfile)
+- [`faasm/faabric-base`](https://github.com/faasm/faabric/blob/master/docker/faabric-base.dockerfile)
 - [`faasm/cpp-root`](../docker/cpp-root.dockerfile)
 
 Most things can be done with `apt`, but the difficult bits might be:
 
 - LLVM and Clang
-- gRPC
+- Conan
 - Up-to-date CMake
 
 You will also need to set up the Python environment:
@@ -187,7 +187,7 @@ highly likely that the permissions will be messed up and cause cryptic error
 messages. To be safe, reset the permissions on everything:
 
 ```bash
-sudo chown -R ${SUDO_USER}:${SUDO_USER} .
+sudo sh -c 'chown -R ${SUDO_USER}:${SUDO_USER} .'
 ```
 
 Then you can try building one of the executables:
@@ -202,9 +202,24 @@ inv dev.cc func_runner
 
 # Check which binary is on the path
 which func_runner
+```
 
-# Run it
-func_runner demo hello
+Before running one of the executables, you must make sure that the `minio`
+container is running, and reachable from outside the container.
+
+```
+# Stop anything that may be running in the background
+docker-compose down
+
+docker-compose up -d redis-state redis-queue minio
+
+docker-compose ps
+```
+
+Take good note of the host and the port for `minio`, and then run:
+
+```
+S3_HOST="127.0.0.1" S3_PORT="9000" func_runner demo hello
 ```
 
 ## Code style


### PR DESCRIPTION
After going through the docs to build the code outside the container myself, I update some of the instructions that were outdated.

Most importantly, we must be able to hit S3 from outside the container, thus we need to publish the S3 ports in `docker-compose.yml`.

If this is not worth doing only for out-of-container builds (as they are not recommended) I can amend the docs indicating the changes that need to be done to the compose file, and maybe add a `sed` onliner.