### PR TITLE
Bump KNative Version

### DIFF
--- a/faasmcli/faasmcli/tasks/knative.py
+++ b/faasmcli/faasmcli/tasks/knative.py
@@ -18,7 +18,7 @@ LOCALHOST_IP = "127.0.0.1"
 K8S_DIR = join(PROJ_ROOT, "deploy", "k8s")
 NAMESPACE_FILE = join(K8S_DIR, "namespace.yml")
 
-KNATIVE_VERSION = "0.24.0"
+KNATIVE_VERSION = "1.1.0"
 
 # Notes on Knative client
 # https://github.com/knative/client/blob/master/docs/cmd/kn_service_create.md
@@ -176,7 +176,7 @@ def _kn_github_url(repo, filename):
     url = [
         "https://github.com/",
         repo,
-        "/releases/download/v{}/".format(KNATIVE_VERSION),
+        "/releases/download/knative-v{}/".format(KNATIVE_VERSION),
         filename,
     ]
     return "".join(url)


### PR DESCRIPTION
Bump Knative to support the latest k8s version used in the experiments.

See faasm/experiment-base#26 for a more in-depth explanation.