### PR TITLE
Fix memory overflow bug

### DIFF
--- a/include/sgx/SGXWAMRWasmModule.h
+++ b/include/sgx/SGXWAMRWasmModule.h
@@ -66,9 +66,9 @@ class SGXWAMRWasmModule final : public WasmModule
 
     int32_t executeFunction(faabric::Message& msg) override;
 
-    uint32_t growMemory(uint32_t nBytes) override;
+    uint32_t growMemory(size_t nBytes) override;
 
-    uint32_t shrinkMemory(uint32_t nBytes) override;
+    uint32_t shrinkMemory(size_t nBytes) override;
 
     // TODO: Move in gs/fs
     faaslet_sgx_msg_buffer_t sgxWamrMsgResponse;

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -53,13 +53,13 @@ class WAMRWasmModule final : public WasmModule
     uint32_t nativePointerToWasm(void* nativePtr);
 
     // ----- Memory management -----
-    uint32_t growMemory(uint32_t nBytes) override;
+    uint32_t growMemory(size_t nBytes) override;
 
-    uint32_t shrinkMemory(uint32_t nBytes) override;
+    uint32_t shrinkMemory(size_t nBytes) override;
 
-    uint32_t mmapMemory(uint32_t nBytes) override;
+    uint32_t mmapMemory(size_t nBytes) override;
 
-    uint32_t mmapFile(uint32_t fp, uint32_t length) override;
+    uint32_t mmapFile(uint32_t fp, size_t length) override;
 
     size_t getMemorySizeBytes() override;
 

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -96,17 +96,17 @@ class WasmModule
     // ----- Memory management -----
     uint32_t getCurrentBrk();
 
-    virtual void setMemorySize(uint32_t nBytes);
+    virtual void setMemorySize(size_t nBytes);
 
-    virtual uint32_t growMemory(uint32_t nBytes);
+    virtual uint32_t growMemory(size_t nBytes);
 
-    virtual uint32_t shrinkMemory(uint32_t nBytes);
+    virtual uint32_t shrinkMemory(size_t nBytes);
 
-    virtual uint32_t mmapMemory(uint32_t nBytes);
+    virtual uint32_t mmapMemory(size_t nBytes);
 
-    virtual uint32_t mmapFile(uint32_t fp, uint32_t length);
+    virtual uint32_t mmapFile(uint32_t fp, size_t length);
 
-    virtual void unmapMemory(uint32_t offset, uint32_t nBytes);
+    virtual void unmapMemory(uint32_t offset, size_t nBytes);
 
     uint32_t createMemoryGuardRegion(uint32_t wasmOffset);
 
@@ -215,7 +215,7 @@ class WasmModule
 };
 
 // Convenience functions
-size_t getNumberOfWasmPagesForBytes(uint32_t nBytes);
+size_t getNumberOfWasmPagesForBytes(size_t nBytes);
 
 uint32_t roundUpToWasmPageAligned(uint32_t nBytes);
 

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -64,15 +64,15 @@ class WAVMWasmModule final
     void reset(faabric::Message& msg, const std::string& snapshotKey) override;
 
     // ----- Memory management -----
-    uint32_t growMemory(uint32_t nBytes) override;
+    uint32_t growMemory(size_t nBytes) override;
 
-    uint32_t shrinkMemory(uint32_t nBytes) override;
+    uint32_t shrinkMemory(size_t nBytes) override;
 
-    uint32_t mmapMemory(uint32_t nBytes) override;
+    uint32_t mmapMemory(size_t nBytes) override;
 
-    uint32_t mmapFile(uint32_t fd, uint32_t length) override;
+    uint32_t mmapFile(uint32_t fd, size_t length) override;
 
-    void unmapMemory(uint32_t offset, uint32_t nBytes) override;
+    void unmapMemory(uint32_t offset, size_t nBytes) override;
 
     uint8_t* wasmPointerToNative(uint32_t wasmPtr) override;
 

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -153,7 +153,7 @@ int32_t SGXWAMRWasmModule::executeFunction(faabric::Message& msg)
     return 0;
 }
 
-uint32_t SGXWAMRWasmModule::growMemory(uint32_t nBytes)
+uint32_t SGXWAMRWasmModule::growMemory(size_t nBytes)
 {
     SPDLOG_DEBUG("SGX-WAMR growing memory by {}", nBytes);
 
@@ -167,7 +167,7 @@ uint32_t SGXWAMRWasmModule::growMemory(uint32_t nBytes)
     return memBase;
 }
 
-uint32_t SGXWAMRWasmModule::shrinkMemory(uint32_t nBytes)
+uint32_t SGXWAMRWasmModule::shrinkMemory(size_t nBytes)
 {
     SPDLOG_WARN("SGX-WAMR ignoring shrink memory");
     return 0;

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -283,7 +283,7 @@ uint32_t WAMRWasmModule::nativePointerToWasm(void* nativePtr)
     return wasm_runtime_addr_native_to_app(moduleInstance, nativePtr);
 }
 
-uint32_t WAMRWasmModule::growMemory(uint32_t nBytes)
+uint32_t WAMRWasmModule::growMemory(size_t nBytes)
 {
 
     uint32_t oldBytes = getMemorySizeBytes();
@@ -333,14 +333,14 @@ uint32_t WAMRWasmModule::growMemory(uint32_t nBytes)
     return oldBrk;
 }
 
-uint32_t WAMRWasmModule::shrinkMemory(uint32_t nBytes)
+uint32_t WAMRWasmModule::shrinkMemory(size_t nBytes)
 {
 
     SPDLOG_WARN("WAMR ignoring shrink memory");
     return 0;
 }
 
-uint32_t WAMRWasmModule::mmapMemory(uint32_t nBytes)
+uint32_t WAMRWasmModule::mmapMemory(size_t nBytes)
 {
     return growMemory(nBytes);
 }
@@ -376,7 +376,7 @@ WASMModuleInstanceCommon* WAMRWasmModule::getModuleInstance()
     return moduleInstance;
 }
 
-uint32_t WAMRWasmModule::mmapFile(uint32_t fp, uint32_t length)
+uint32_t WAMRWasmModule::mmapFile(uint32_t fp, size_t length)
 {
     // TODO - implement
     return 0;

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -33,7 +33,7 @@ bool isWasmPageAligned(int32_t offset)
     }
 }
 
-size_t getNumberOfWasmPagesForBytes(uint32_t nBytes)
+size_t getNumberOfWasmPagesForBytes(size_t nBytes)
 {
     // Round up to nearest page
     size_t pageCount =
@@ -117,18 +117,18 @@ std::string WasmModule::snapshot(bool locallyRestorable)
     return snapKey;
 }
 
-void WasmModule::setMemorySize(uint32_t nBytes)
+void WasmModule::setMemorySize(size_t nBytes)
 {
     uint32_t memSize = getCurrentBrk();
 
     if (nBytes > memSize) {
         size_t bytesRequired = nBytes - memSize;
-        SPDLOG_DEBUG("Growing memory by {} bytes to restore snapshot",
+        SPDLOG_DEBUG("Growing memory by {} bytes to set memory size",
                      bytesRequired);
         this->growMemory(bytesRequired);
     } else if (nBytes < memSize) {
         size_t shrinkBy = memSize - nBytes;
-        SPDLOG_DEBUG("Shrinking memory by {} bytes to restore snapshot",
+        SPDLOG_DEBUG("Shrinking memory by {} bytes to set memory size",
                      shrinkBy);
         this->shrinkMemory(shrinkBy);
     } else {
@@ -636,27 +636,27 @@ void WasmModule::writeWasmEnvToMemory(uint32_t envPointers, uint32_t envBuffer)
     throw std::runtime_error("writeWasmEnvToMemory not implemented");
 }
 
-uint32_t WasmModule::growMemory(uint32_t nBytes)
+uint32_t WasmModule::growMemory(size_t nBytes)
 {
     throw std::runtime_error("growMemory not implemented");
 }
 
-uint32_t WasmModule::shrinkMemory(uint32_t nBytes)
+uint32_t WasmModule::shrinkMemory(size_t nBytes)
 {
     throw std::runtime_error("shrinkMemory not implemented");
 }
 
-uint32_t WasmModule::mmapMemory(uint32_t nBytes)
+uint32_t WasmModule::mmapMemory(size_t nBytes)
 {
     throw std::runtime_error("mmapMemory not implemented");
 }
 
-uint32_t WasmModule::mmapFile(uint32_t fp, uint32_t length)
+uint32_t WasmModule::mmapFile(uint32_t fp, size_t length)
 {
     throw std::runtime_error("mmapFile not implemented");
 }
 
-void WasmModule::unmapMemory(uint32_t offset, uint32_t nBytes)
+void WasmModule::unmapMemory(uint32_t offset, size_t nBytes)
 {
     throw std::runtime_error("unmapMemory not implemented");
 }


### PR DESCRIPTION
Because we kept memory size in a `uint32_t`, it never caught memory overflows in wasm (as the `uint32_t` would overflow).