### PR TITLE
Use map of mutexes for pthread locks

### DIFF
--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -141,6 +141,12 @@ class WasmModule
 
     std::vector<uint32_t> getThreadStacks();
 
+    // Returns the given pthread mutex and errors if it doesn't exist
+    std::shared_ptr<std::mutex> getPthreadMutex(uint32_t id);
+
+    // Returns the given pthread mutex, creating it if it doesn't exist
+    std::shared_ptr<std::mutex> getOrCreatePthreadMutex(uint32_t id);
+
     // Adds a merge region to be used in the next threaded operation spawned by
     // this module
     void addMergeRegionForNextThreads(
@@ -193,6 +199,9 @@ class WasmModule
     std::unordered_map<int32_t, uint32_t> pthreadPtrsToChainedCalls;
     std::vector<std::pair<uint32_t, int32_t>> lastPthreadResults;
     std::vector<faabric::util::SnapshotMergeRegion> mergeRegions;
+
+    std::shared_mutex pthreadLocksMx;
+    std::unordered_map<uint32_t, std::shared_ptr<std::mutex>> pthreadLocks;
 
     // Shared memory regions
     std::shared_mutex sharedMemWasmPtrsMutex;

--- a/src/threads/ThreadState.cpp
+++ b/src/threads/ThreadState.cpp
@@ -117,7 +117,7 @@ int Level::getMaxThreadsAtNextLevel() const
         return wantedThreads;
     }
 
-    int defaultNumThreads = faabric::util::getUsableCores();
+    int defaultNumThreads = faabric::util::getUsableCores() - 1;
     return defaultNumThreads;
 }
 

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -606,6 +606,41 @@ std::vector<uint32_t> WasmModule::getThreadStacks()
     return threadStacks;
 }
 
+std::shared_ptr<std::mutex> WasmModule::getPthreadMutex(uint32_t id)
+{
+    faabric::util::SharedLock lock(pthreadLocksMx);
+    auto it = pthreadLocks.find(id);
+    if (it != pthreadLocks.end()) {
+        return it->second;
+    }
+
+    SPDLOG_ERROR("Trying to get non-existent pthread lock {}", id);
+    throw std::runtime_error("Non-existent pthread lock");
+}
+
+std::shared_ptr<std::mutex> WasmModule::getOrCreatePthreadMutex(uint32_t id)
+{
+    std::shared_ptr<std::mutex> mx = nullptr;
+    {
+        faabric::util::SharedLock lock(pthreadLocksMx);
+        auto it = pthreadLocks.find(id);
+        if (it != pthreadLocks.end()) {
+            return it->second;
+        }
+    }
+
+    faabric::util::FullLock lock(pthreadLocksMx);
+    auto it = pthreadLocks.find(id);
+    if (it != pthreadLocks.end()) {
+        return it->second;
+    }
+
+    mx = std::make_shared<std::mutex>();
+    pthreadLocks[id] = mx;
+
+    return mx;
+}
+
 bool WasmModule::isBound()
 {
     return _isBound;


### PR DESCRIPTION
These are used very heavily as they're the basis for libc locking, so have moved to using a separate map of mutexes, no longer using the point-to-point groups from Faabric.