### PR TITLE
SGX: Re-run tests again as part of GHA.

### DIFF
--- a/faasmcli/faasmcli/tasks/dev.py
+++ b/faasmcli/faasmcli/tasks/dev.py
@@ -25,7 +25,7 @@ def cmake(
     perf=False,
     prof=False,
     sanitiser="None",
-    nosgx=True,
+    nosgx=False,
 ):
     """
     Configures the CMake build

--- a/include/sgx/SGXWAMRWasmModule.h
+++ b/include/sgx/SGXWAMRWasmModule.h
@@ -70,6 +70,10 @@ class SGXWAMRWasmModule final : public WasmModule
 
     uint32_t shrinkMemory(size_t nBytes) override;
 
+    size_t getMemorySizeBytes() override;
+
+    uint8_t* getMemoryBase() override;
+
     // TODO: Move in gs/fs
     faaslet_sgx_msg_buffer_t sgxWamrMsgResponse;
 

--- a/src/sgx/SGXWAMRWasmModule.cpp
+++ b/src/sgx/SGXWAMRWasmModule.cpp
@@ -18,6 +18,8 @@ using namespace sgx;
 namespace wasm {
 SGXWAMRWasmModule::SGXWAMRWasmModule()
 {
+    checkSgxSetup();
+
     // Allocate memory for response
     sgxWamrMsgResponse.buffer_len =
       (sizeof(sgx_wamr_msg_t) + sizeof(sgx_wamr_msg_hdr_t));
@@ -171,5 +173,17 @@ uint32_t SGXWAMRWasmModule::shrinkMemory(size_t nBytes)
 {
     SPDLOG_WARN("SGX-WAMR ignoring shrink memory");
     return 0;
+}
+
+size_t SGXWAMRWasmModule::getMemorySizeBytes()
+{
+    SPDLOG_WARN("SGX-WAMR getMemorySizeBytes not implemented");
+    return 0;
+}
+
+uint8_t* SGXWAMRWasmModule::getMemoryBase()
+{
+    SPDLOG_WARN("SGX-WAMR getMemoryBase not implemented");
+    return nullptr;
 }
 }

--- a/tests/test/sgx/test_sgx.cpp
+++ b/tests/test/sgx/test_sgx.cpp
@@ -12,7 +12,7 @@ TEST_CASE("Test executing hello function with SGX", "[sgx]")
     executeWithSGX("demo", "hello");
 }
 
-TEST_CASE("Test executing chaining by name with SGX", "[.][sgx]")
+TEST_CASE("Test executing chaining by name with SGX", "[sgx]")
 {
     executeWithSGX("demo", "chain_named_a", 10000);
 }

--- a/tests/test/sgx/test_sgx.cpp
+++ b/tests/test/sgx/test_sgx.cpp
@@ -7,7 +7,7 @@
 using namespace wasm;
 
 namespace tests {
-TEST_CASE("Test executing hello function with SGX", "[.][sgx]")
+TEST_CASE("Test executing hello function with SGX", "[sgx]")
 {
     executeWithSGX("demo", "hello");
 }


### PR DESCRIPTION
Fix SGX execution, broken after the removal of `checkSgxSetup()` in faabric.

Make sure we are running SGX tests as part of our GHA pipelines.