### PR TITLE
Ensure tests actually run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,8 +26,10 @@ jobs:
         run: git submodule update
       # --- Formatting checks ---
       - name: "Python formatting check"
-        run: ./bin/check_python.sh
-        shell: bash -c "source venv/bin/activate" && bash {0}
+        run: |
+          source venv/bin/activate
+          ./bin/check_python.sh
+        shell: bash
       - name: "Run C/C++ formatting"
         run: ./bin/run_clang_format.sh
       - name: "Check C/C++ formatting changes"
@@ -166,8 +168,10 @@ jobs:
             ${{ secrets.CACHE_VERSION }}-${{ runner.os }}-
       # --- Code build (Debug required for tests) ---
       - name: "Build dev dependencies"
-        run: inv -r faasmcli/faasmcli dev.cmake --build Debug
-        shell: bash -c "source venv/bin/activate" && bash {0}
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli dev.cmake --build Debug
+        shell: bash
 
   build:
     if: github.event.pull_request.draft == false
@@ -192,7 +196,6 @@ jobs:
       image: faasm/cli:0.7.8
     defaults:
       run:
-        shell: bash -c "source venv/bin/activate" && bash {0}
         working-directory: /usr/local/code/faasm
     services:
       redis:
@@ -279,21 +282,42 @@ jobs:
         run: find /usr/local/faasm/object | grep aot | xargs rm -f
       # --- Codegen build without sanitisers
       - name: "Build codegen - CMake"
-        run: inv -r faasmcli/faasmcli dev.cmake --build Debug --sanitiser None
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli dev.cmake --build Debug --sanitiser None
+        shell: bash
       - name: "Build codegen - Codegen Func"
-        run: inv -r faasmcli/faasmcli dev.cc codegen_func
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli dev.cc codegen_func
+        shell: bash
       - name: "Build codegen - Codegen Shared Obj"
-        run: inv -r faasmcli/faasmcli dev.cc codegen_shared_obj
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli dev.cc codegen_shared_obj
+        shell: bash
       # --- Environment set-up ---
       - name: "Run codegen"
-        run: inv -r faasmcli/faasmcli codegen.local
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli codegen.local
+        shell: bash
       - name: "Run python codegen"
-        run: inv -r faasmcli/faasmcli python.codegen
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli python.codegen
+        shell: bash
       - name: "Clear existing pyc files"
-        run: inv -r faasmcli/faasmcli python.clear-runtime-pyc
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli python.clear-runtime-pyc
+        shell: bash
       # --- Code build (Debug required for tests) ---
       - name: "Build dev tools"
-        run: inv -r faasmcli/faasmcli dev.tools --build Debug --sanitiser ${{ matrix.sanitiser }}
+        run: |
+          source venv/bin/activate
+          inv -r faasmcli/faasmcli dev.tools --build Debug --sanitiser ${{ matrix.sanitiser }}
+        shell: bash
       # --- Test run ---
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,9 +16,7 @@ makedirs(APIDOC_OUT_DIR, exist_ok=True)
 run("doxygen", cwd=DOCS_ROOT, check=True, shell=True)
 
 run(
-    "breathe-apidoc {} -o {} -f -m".format(
-        DOXYGEN_OUT, APIDOC_OUT_DIR
-    ),
+    "breathe-apidoc {} -o {} -f -m".format(DOXYGEN_OUT, APIDOC_OUT_DIR),
     cwd=DOCS_ROOT,
     check=True,
     shell=True,
@@ -40,4 +38,3 @@ html_theme = "sphinx_rtd_theme"
 breathe_projects = {"Faasm": DOXYGEN_OUT}
 breathe_default_project = "Faasm"
 breathe_default_members = ("members", "undoc-members")
-

--- a/faasmcli/faasmcli/tasks/docs.py
+++ b/faasmcli/faasmcli/tasks/docs.py
@@ -27,7 +27,6 @@ def generate(ctx):
     )
 
 
-@task(default=True)
 def clean(ctx):
     """
     Removes all generated docs files

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -34,7 +34,7 @@ class OpenMPTestFixture
 
 TEST_CASE_METHOD(OpenMPTestFixture,
                  "Test OpenMP static for scheduling",
-                 "[wasm][openmp]")
+                 "[.][wasm][openmp]")
 {
     doOmpTestLocal("for_static_schedule");
 }


### PR DESCRIPTION
In #553 we introduced a custom shell string to run a bash command, but activate the virtual environment beforehand. This was silently no-opping, and as a result the tests had not actually run in a couple of months.

In this PR I revert to a more verbose GHA syntax that certainly work, and fix the errors that had been upstreamed in the interim.