### PR TITLE
Support for running SGX functions in `microbench_runner`

### DIFF
--- a/docs/source/profiling.md
+++ b/docs/source/profiling.md
@@ -43,6 +43,12 @@ demo,hello,0,29.0,0.18
 These can then be parsed and plotted, as is done in the
 [experiment-microbench](https://github.com/faasm/experiment-microbench) repo.
 
+To run the same micro-benchmark in SGX, re-run the same command as follows:
+
+```bash
+WASM_VM="wamr" microbenchmark_runner <spec_file> <out_file> --sgx
+```
+
 ## High-level
 
 To get a quick overview of how things are performing you can use

--- a/include/runner/MicrobenchRunner.h
+++ b/include/runner/MicrobenchRunner.h
@@ -4,6 +4,8 @@ namespace runner {
 class MicrobenchRunner
 {
   public:
-    static int execute(const std::string& inFile, const std::string& outFile);
+    static int execute(const std::string& inFile,
+                       const std::string& outFile,
+                       bool isSgx = false);
 };
 }

--- a/src/runner/MicrobenchRunner.cpp
+++ b/src/runner/MicrobenchRunner.cpp
@@ -29,7 +29,8 @@ int doRun(std::ofstream& outFs,
           const std::string& user,
           const std::string& function,
           int nRuns,
-          const std::string& inputData)
+          const std::string& inputData,
+          bool isSgx = false)
 {
     // Clear out redis
     faabric::redis::Redis& redis = faabric::redis::Redis::getQueue();
@@ -47,6 +48,10 @@ int doRun(std::ofstream& outFs,
 
         msg.set_user(PYTHON_USER);
         msg.set_function(PYTHON_FUNC);
+    }
+
+    if (isSgx) {
+        msg.set_issgx(true);
     }
 
     msg.set_inputdata(inputData);
@@ -107,7 +112,8 @@ int doRun(std::ofstream& outFs,
 }
 
 int MicrobenchRunner::execute(const std::string& inFile,
-                              const std::string& outFile)
+                              const std::string& outFile,
+                              bool isSgx)
 {
     if (!boost::filesystem::exists(inFile)) {
         SPDLOG_ERROR("Input file does not exist: {}", inFile);
@@ -157,7 +163,7 @@ int MicrobenchRunner::execute(const std::string& inFile,
         SPDLOG_INFO(
           "Running {}/{} x{} (input [{}])", user, function, nRuns, inputData);
 
-        int returnValue = doRun(outFs, user, function, nRuns, inputData);
+        int returnValue = doRun(outFs, user, function, nRuns, inputData, isSgx);
         if (returnValue != 0) {
             break;
         }

--- a/src/runner/microbench_runner.cpp
+++ b/src/runner/microbench_runner.cpp
@@ -26,8 +26,13 @@ int main(int argc, char* argv[])
     initLogging();
 
     if (argc < 3) {
-        SPDLOG_ERROR("Usage: microbench_runner <infile> <outfile>");
+        SPDLOG_ERROR("Usage: microbench_runner <infile> <outfile> [--sgx]");
         return 1;
+    }
+
+    bool isSgx = false;
+    if (argc == 4 && std::string(argv[3]) == "--sgx") {
+        isSgx = true;
     }
 
     // Process input args
@@ -47,7 +52,7 @@ int main(int argc, char* argv[])
       std::make_shared<faaslet::FaasletFactory>();
     faabric::scheduler::setExecutorFactory(fac);
 
-    int returnValue = MicrobenchRunner::execute(inFile, outFile);
+    int returnValue = MicrobenchRunner::execute(inFile, outFile, isSgx);
 
     faabric::transport::closeGlobalMessageContext();
     storage::shutdownFaasmS3();


### PR DESCRIPTION
Add a flag in the `microbench_runner` to measure functions executed inside SGX. For vanilla WAMR we can set the environment variables.