### PR TITLE
Use Faabric `ExecutorContext`

### DIFF
--- a/include/wasm/WasmExecutionContext.h
+++ b/include/wasm/WasmExecutionContext.h
@@ -12,9 +12,8 @@ class WasmExecutionContext
 {
   public:
     WasmModule* executingModule = nullptr;
-    faabric::Message* executingCall = nullptr;
 
-    WasmExecutionContext(WasmModule* module, faabric::Message* call);
+    WasmExecutionContext(WasmModule* module);
 
     ~WasmExecutionContext();
 
@@ -23,6 +22,4 @@ class WasmExecutionContext
 };
 
 WasmModule* getExecutingModule();
-
-faabric::Message* getExecutingCall();
 }

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -115,7 +115,7 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
     SPDLOG_DEBUG("WAMR executing message {}", msg.id());
 
     // Make sure context is set
-    WasmExecutionContext ctx(this, &msg);
+    WasmExecutionContext ctx(this);
     int returnValue = 0;
 
     // Run wasm initialisers

--- a/src/wamr/funcs.cpp
+++ b/src/wamr/funcs.cpp
@@ -1,4 +1,5 @@
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/macros.h>
@@ -8,6 +9,8 @@
 #include <wasm/WasmModule.h>
 #include <wasm/chaining.h>
 #include <wasm_export.h>
+
+using namespace faabric::scheduler;
 
 namespace wasm {
 
@@ -20,9 +23,9 @@ static int32_t __faasm_read_input_wrapper(wasm_exec_env_t exec_env,
 {
     SPDLOG_DEBUG("S - faasm_read_input {} {}", inBuff, inLen);
 
-    faabric::Message* call = getExecutingCall();
+    faabric::Message& call = ExecutorContext::get()->getMsg();
     std::vector<uint8_t> inputBytes =
-      faabric::util::stringToBytes(call->inputdata());
+      faabric::util::stringToBytes(call.inputdata());
 
     // If nothing, return nothing
     if (inputBytes.empty()) {
@@ -44,8 +47,8 @@ static void __faasm_write_output_wrapper(wasm_exec_env_t exec_env,
 {
     SPDLOG_DEBUG("S - faasm_write_output {} {}", outBuff, outLen);
 
-    faabric::Message* call = getExecutingCall();
-    call->set_outputdata(outBuff, outLen);
+    faabric::Message& call = ExecutorContext::get()->getMsg();
+    call.set_outputdata(outBuff, outLen);
 }
 
 /**
@@ -58,9 +61,9 @@ static int32_t __faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
 {
     SPDLOG_DEBUG("S - faasm_chain_ptr {} {} {}", wasmFuncPtr, inBuff, inLen);
 
-    faabric::Message* call = getExecutingCall();
+    faabric::Message& call = ExecutorContext::get()->getMsg();
     std::vector<uint8_t> inputData(BYTES(inBuff), BYTES(inBuff) + inLen);
-    return makeChainedCall(call->function(), wasmFuncPtr, nullptr, inputData);
+    return makeChainedCall(call.function(), wasmFuncPtr, nullptr, inputData);
 }
 
 /**

--- a/src/wamr/state.cpp
+++ b/src/wamr/state.cpp
@@ -1,4 +1,5 @@
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/logging.h>
 
 #include <wamr/WAMRWasmModule.h>
@@ -6,6 +7,8 @@
 #include <wasm/WasmExecutionContext.h>
 #include <wasm/WasmModule.h>
 #include <wasm_export.h>
+
+using namespace faabric::scheduler;
 
 namespace wasm {
 /**
@@ -20,7 +23,7 @@ static int32_t __faasm_read_state_wrapper(wasm_exec_env_t exec_env,
 {
     SPDLOG_DEBUG("S - faasm_read_state {} <buffer> {}", key, bufferLen);
 
-    std::string user = getExecutingCall()->user();
+    std::string user = ExecutorContext::get()->getMsg().user();
 
     if (bufferLen == 0) {
         // If buffer len is zero, just need the state size
@@ -45,7 +48,7 @@ static int32_t __faasm_read_state_ptr_wrapper(wasm_exec_env_t exec_env,
                                               char* key,
                                               int32_t bufferLen)
 {
-    std::string user = getExecutingCall()->user();
+    std::string user = ExecutorContext::get()->getMsg().user();
     auto kv = faabric::state::getGlobalState().getKV(user, key, bufferLen);
 
     SPDLOG_DEBUG("S - faasm_read_state_ptr - {} {}", kv->key, bufferLen);
@@ -68,7 +71,7 @@ static void __faasm_write_state_wrapper(wasm_exec_env_t exec_env,
                                         char* buffer,
                                         int32_t bufferLen)
 {
-    std::string user = getExecutingCall()->user();
+    std::string user = ExecutorContext::get()->getMsg().user();
     auto kv = faabric::state::getGlobalState().getKV(user, key, bufferLen);
 
     SPDLOG_DEBUG("S - faasm_write_state - {} <data> {}", kv->key, bufferLen);
@@ -83,7 +86,7 @@ static void __faasm_push_state_wrapper(wasm_exec_env_t exec_env, char* key)
 {
     SPDLOG_DEBUG("S - faasm_push_state - {}", key);
 
-    std::string user = getExecutingCall()->user();
+    std::string user = ExecutorContext::get()->getMsg().user();
     auto kv = faabric::state::getGlobalState().getKV(user, key, 0);
     kv->pushFull();
 }

--- a/src/wasm/WasmExecutionContext.cpp
+++ b/src/wasm/WasmExecutionContext.cpp
@@ -8,11 +8,8 @@ namespace wasm {
 // global accessor methods for the current context
 static thread_local std::stack<WasmExecutionContext*> contexts;
 
-WasmExecutionContext::WasmExecutionContext(WasmModule* module,
-                                           faabric::Message* call)
-
+WasmExecutionContext::WasmExecutionContext(WasmModule* module)
   : executingModule(module)
-  , executingCall(call)
 {
     contexts.push(this);
 }
@@ -29,14 +26,5 @@ WasmModule* getExecutingModule()
     }
 
     return contexts.top()->executingModule;
-}
-
-faabric::Message* getExecutingCall()
-{
-    if (contexts.empty()) {
-        return nullptr;
-    }
-
-    return contexts.top()->executingCall;
 }
 }

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -4,6 +4,7 @@
 #include <wasm/WasmModule.h>
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/util/bytes.h>
@@ -281,7 +282,7 @@ void WasmModule::bindToFunction(faabric::Message& msg, bool cache)
     boundFunction = msg.function();
 
     // Call into subclass hook, setting the context beforehand
-    WasmExecutionContext ctx(this, &msg);
+    WasmExecutionContext ctx(this);
     doBindToFunction(msg, cache);
 }
 
@@ -380,7 +381,7 @@ int32_t WasmModule::executeTask(
     assert(boundFunction == msg.function());
 
     // Set up context for this task
-    WasmExecutionContext ctx(this, &msg);
+    WasmExecutionContext ctx(this);
 
     // Modules must have provisioned their own thread stacks
     assert(!threadStacks.empty());
@@ -501,7 +502,7 @@ int WasmModule::awaitPthreadCall(faabric::Message* msg, int pthreadPtr)
 
     // Execute the queued pthread calls
     faabric::scheduler::Executor* executor =
-      faabric::scheduler::getExecutingExecutor();
+      faabric::scheduler::ExecutorContext::get()->getExecutor();
     if (!queuedPthreadCalls.empty()) {
         int nPthreadCalls = queuedPthreadCalls.size();
 

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -1,5 +1,5 @@
-#include "WasmModule.h"
 
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/func.h>
@@ -7,6 +7,7 @@
 
 #include <conf/FaasmConfig.h>
 #include <wasm/WasmExecutionContext.h>
+#include <wasm/WasmModule.h>
 #include <wasm/chaining.h>
 
 namespace wasm {
@@ -36,7 +37,7 @@ int makeChainedCall(const std::string& functionName,
                     const std::vector<uint8_t>& inputData)
 {
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    faabric::Message* originalCall = getExecutingCall();
+    faabric::Message* originalCall = &ExecutorContext::get()->getMsg();
 
     std::string user = originalCall->user();
 
@@ -100,13 +101,14 @@ int spawnChainedThread(const std::string& snapshotKey,
 {
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
 
-    faabric::Message* originalCall = getExecutingCall();
-    faabric::Message call = faabric::util::messageFactory(
-      originalCall->user(), originalCall->function());
+    faabric::Message& originalMsg =
+      faabric::scheduler::ExecutorContext::get()->getMsg();
+    faabric::Message call =
+      faabric::util::messageFactory(originalMsg.user(), originalMsg.function());
     call.set_isasync(true);
 
     // Propagate app ID
-    call.set_appid(originalCall->appid());
+    call.set_appid(originalMsg.appid());
 
     // Snapshot details
     call.set_snapshotkey(snapshotKey);
@@ -118,8 +120,7 @@ int spawnChainedThread(const std::string& snapshotKey,
     call.set_funcptr(funcPtr);
     call.set_inputdata(std::to_string(argsPtr));
 
-    const std::string origStr =
-      faabric::util::funcToString(*originalCall, false);
+    const std::string origStr = faabric::util::funcToString(originalMsg, false);
     const std::string chainedStr = faabric::util::funcToString(call, false);
 
     // Schedule the call

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -1,4 +1,3 @@
-
 #include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
@@ -37,7 +36,8 @@ int makeChainedCall(const std::string& functionName,
                     const std::vector<uint8_t>& inputData)
 {
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    faabric::Message* originalCall = &ExecutorContext::get()->getMsg();
+    faabric::Message* originalCall =
+      &faabric::scheduler::ExecutorContext::get()->getMsg();
 
     std::string user = originalCall->user();
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -885,7 +885,7 @@ int32_t WAVMWasmModule::executeFunction(faabric::Message& msg)
     }
 
     // Call the function
-    WasmExecutionContext ctx(this, &msg);
+    WasmExecutionContext ctx(this);
     int returnValue = 0;
     try {
         Runtime::catchRuntimeExceptions(

--- a/src/wavm/chaining.cpp
+++ b/src/wavm/chaining.cpp
@@ -1,6 +1,7 @@
 #include "WAVMWasmModule.h"
 #include "syscalls.h"
 
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/logging.h>
@@ -11,6 +12,7 @@
 #include <WAVM/Runtime/Runtime.h>
 
 using namespace WAVM;
+using namespace faabric::scheduler;
 
 namespace wasm {
 void chainLink() {}
@@ -77,7 +79,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
     SPDLOG_DEBUG(
       "S - chain_ptr - {} {} {}", wasmFuncPtr, inputDataPtr, inputDataLen);
 
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
     const std::vector<uint8_t> inputData =
       getBytesFromWasm(inputDataPtr, inputDataLen);
 
@@ -96,7 +98,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
     SPDLOG_DEBUG(
       "S - chain_py - {} {} {}", pyFuncName, inputDataPtr, inputDataLen);
 
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
     const std::vector<uint8_t> inputData =
       getBytesFromWasm(inputDataPtr, inputDataLen);
 

--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -764,7 +764,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
         // chaining from the master host of the app, and
         // we are most likely migrating from a non-master host. Thus, we must
         // take and push the snapshot manually.
-        auto* exec = faabric::scheduler::getExecutingExecutor();
+        auto* exec = faabric::scheduler::ExecutorContext::get()->getExecutor();
         auto snap =
           std::make_shared<faabric::util::SnapshotData>(exec->getMemoryView());
         std::string snapKey = "migration_" + std::to_string(msg.id());

--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -8,6 +8,7 @@
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Runtime.h>
 
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotClient.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
@@ -25,6 +26,7 @@
 
 using namespace WAVM;
 using namespace faabric::transport;
+using namespace faabric::scheduler;
 
 namespace wasm {
 
@@ -300,7 +302,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
     // If buffer len is zero, just need the state size
     if (bufferLen == 0) {
-        std::string user = getExecutingCall()->user();
+        std::string user = ExecutorContext::get()->getMsg().user();
         std::string key = getStringFromWasm(keyPtr);
         SPDLOG_DEBUG("S - read_state - {} {} {}", key, bufferPtr, bufferLen);
 
@@ -425,7 +427,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 I32 _readInputImpl(I32 bufferPtr, I32 bufferLen)
 {
     // Get the input
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
     std::vector<uint8_t> inputBytes =
       faabric::util::stringToBytes(call->inputdata());
 
@@ -463,7 +465,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 void _writeOutputImpl(I32 outputPtr, I32 outputLen)
 {
     std::vector<uint8_t> outputData = getBytesFromWasm(outputPtr, outputLen);
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
     call->set_outputdata(outputData.data(), outputData.size());
 }
 
@@ -505,7 +507,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                                I32 bufferLen)
 {
     SPDLOG_DEBUG("S - get_py_user - {} {}", bufferPtr, bufferLen);
-    std::string value = getExecutingCall()->pythonuser();
+    std::string value = ExecutorContext::get()->getMsg().pythonuser();
 
     if (value.empty()) {
         throw std::runtime_error("Python user empty, cannot return");
@@ -522,7 +524,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                                I32 bufferLen)
 {
     SPDLOG_DEBUG("S - get_py_func - {} {}", bufferPtr, bufferLen);
-    std::string value = getExecutingCall()->pythonfunction();
+    std::string value = ExecutorContext::get()->getMsg().pythonfunction();
     _readPythonInput(bufferPtr, bufferLen, value);
 }
 
@@ -534,7 +536,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                                I32 bufferLen)
 {
     SPDLOG_DEBUG("S - get_py_entry - {} {}", bufferPtr, bufferLen);
-    std::string value = getExecutingCall()->pythonentry();
+    std::string value = ExecutorContext::get()->getMsg().pythonentry();
     _readPythonInput(bufferPtr, bufferLen, value);
 }
 
@@ -599,8 +601,8 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
 static std::shared_ptr<PointToPointGroup> getPointToPointGroup()
 {
-    faabric::Message* msg = getExecutingCall();
-    return PointToPointGroup::getOrAwaitGroup(msg->groupid());
+    faabric::Message msg = ExecutorContext::get()->getMsg();
+    return PointToPointGroup::getOrAwaitGroup(msg.groupid());
 }
 
 static std::pair<uint32_t, faabric::util::SnapshotDataType>
@@ -660,7 +662,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
       extractSnapshotMergeOp(reduceOp);
 
     bool isCurrentBatch = currentBatch == 1;
-    faabric::Message* msg = getExecutingCall();
+    faabric::Message* msg = &ExecutorContext::get()->getMsg();
 
     SPDLOG_DEBUG("Registering reduction variable {}-{} for {} {}",
                  varPtr,
@@ -670,7 +672,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
     if (isCurrentBatch) {
         faabric::scheduler::Executor* executor =
-          faabric::scheduler::getExecutingExecutor();
+          ExecutorContext::get()->getExecutor();
         auto snap = executor->getMainThreadSnapshot(*msg, false);
         snap->addMergeRegion(varPtr, dataType.first, dataType.second, mergeOp);
     } else {
@@ -714,7 +716,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
     SPDLOG_DEBUG(
       "S - faasm_migrate_point {} {}", entrypointFuncPtr, entrypointFuncArg);
 
-    auto* call = getExecutingCall();
+    auto* call = &ExecutorContext::get()->getMsg();
     auto& sch = faabric::scheduler::getScheduler();
 
     // Detect if there is a pending migration for the current app

--- a/src/wavm/mpi.cpp
+++ b/src/wavm/mpi.cpp
@@ -1,17 +1,20 @@
-#include "WAVMWasmModule.h"
 #include "math.h"
 #include "syscalls.h"
-#include "wasm/WasmModule.h"
+
+#include <wasm/WasmModule.h>
+#include <wavm/WAVMWasmModule.h>
 
 #include <WAVM/Runtime/Intrinsics.h>
 #include <WAVM/Runtime/Runtime.h>
 
 #include <faabric/mpi/mpi.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/MpiContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/util/gids.h>
 #include <faabric/util/logging.h>
 
+using namespace faabric::scheduler;
 using namespace WAVM;
 
 #define MPI_FUNC(str)                                                          \
@@ -123,7 +126,7 @@ static thread_local std::unique_ptr<ContextWrapper> ctx = nullptr;
  */
 WAVM_DEFINE_INTRINSIC_FUNCTION(env, "MPI_Init", I32, MPI_Init, I32 a, I32 b)
 {
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
 
     // Note - only want to initialise the world on rank zero (or when rank isn't
     // set yet)

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -464,7 +464,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
     // Execute the threads
     faabric::scheduler::Executor* executor =
-      faabric::scheduler::getExecutingExecutor();
+      faabric::scheduler::ExecutorContext::get()->getExecutor();
     std::vector<std::pair<uint32_t, int>> results =
       executor->executeThreads(req, parentModule->getMergeRegions());
 

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -3,6 +3,7 @@
 #include <WAVM/Runtime/Runtime.h>
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/state/StateKeyValue.h>
@@ -24,6 +25,7 @@
 #include <wavm/WAVMWasmModule.h>
 
 using namespace WAVM;
+using namespace faabric::scheduler;
 
 namespace wasm {
 
@@ -33,7 +35,7 @@ namespace wasm {
 
 #define OMP_FUNC(str)                                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    faabric::Message* msg = getExecutingCall();                                \
+    faabric::Message* msg = &ExecutorContext::get()->getMsg();                 \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     UNUSED(level);                                                             \
@@ -44,7 +46,7 @@ namespace wasm {
 
 #define OMP_FUNC_ARGS(formatStr, ...)                                          \
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();  \
-    faabric::Message* msg = getExecutingCall();                                \
+    faabric::Message* msg = &ExecutorContext::get()->getMsg();                 \
     int localThreadNum = level->getLocalThreadNum(msg);                        \
     int globalThreadNum = level->getGlobalThreadNum(msg);                      \
     UNUSED(level);                                                             \
@@ -59,9 +61,9 @@ namespace wasm {
 static std::shared_ptr<faabric::transport::PointToPointGroup>
 getExecutingPointToPointGroup()
 {
-    faabric::Message* msg = getExecutingCall();
+    faabric::Message& msg = ExecutorContext::get()->getMsg();
     return faabric::transport::PointToPointGroup::getOrAwaitGroup(
-      msg->groupid());
+      msg.groupid());
 }
 
 // ------------------------------------------------
@@ -406,7 +408,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 
     WAVMWasmModule* parentModule = getExecutingWAVMModule();
     Runtime::Memory* memoryPtr = parentModule->defaultMemory;
-    faabric::Message* parentCall = getExecutingCall();
+    faabric::Message* parentCall = &ExecutorContext::get()->getMsg();
 
     const std::string parentStr =
       faabric::util::funcToString(*parentCall, false);
@@ -513,7 +515,7 @@ void for_static_init(I32 schedule,
     // Unsigned version of the given template parameter
     typedef typename std::make_unsigned<T>::type UT;
 
-    faabric::Message* msg = getExecutingCall();
+    faabric::Message* msg = &ExecutorContext::get()->getMsg();
     std::shared_ptr<threads::Level> level = threads::getCurrentOpenMPLevel();
     int localThreadNum = level->getLocalThreadNum(msg);
 

--- a/src/wavm/threads.cpp
+++ b/src/wavm/threads.cpp
@@ -1,6 +1,7 @@
 #include "syscalls.h"
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/scheduler/Scheduler.h>
 #include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/transport/PointToPointBroker.h>
@@ -21,6 +22,7 @@
 #include <WAVM/Runtime/Runtime.h>
 
 using namespace WAVM;
+using namespace faabric::scheduler;
 
 namespace wasm {
 
@@ -88,7 +90,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
 {
     SPDLOG_DEBUG("S - pthread_join - {} {}", pthreadPtr, resPtrPtr);
 
-    faabric::Message* call = getExecutingCall();
+    faabric::Message* call = &ExecutorContext::get()->getMsg();
     WasmModule* thisModule = getExecutingModule();
 
     // Await the result

--- a/src/wavm/util.cpp
+++ b/src/wavm/util.cpp
@@ -1,6 +1,8 @@
-#include "WAVMWasmModule.h"
 #include "syscalls.h"
 
+#include <wavm/WAVMWasmModule.h>
+
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/logging.h>
@@ -10,6 +12,7 @@
 #include <WAVM/WASI/WASIABI.h>
 
 using namespace WAVM;
+using namespace faabric::scheduler;
 
 namespace wasm {
 void getBytesFromWasm(I32 dataPtr, I32 dataLen, uint8_t* buffer)
@@ -42,7 +45,7 @@ std::pair<std::string, std::string> getUserKeyPairFromWasm(I32 keyPtr)
     Runtime::Memory* memoryPtr = getExecutingWAVMModule()->defaultMemory;
     char* key = &Runtime::memoryRef<char>(memoryPtr, (Uptr)keyPtr);
 
-    const faabric::Message* call = getExecutingCall();
+    const faabric::Message* call = &ExecutorContext::get()->getMsg();
     return std::pair<std::string, std::string>(call->user(), key);
 }
 

--- a/tests/test/faaslet/test_flushing.cpp
+++ b/tests/test/faaslet/test_flushing.cpp
@@ -5,6 +5,7 @@
 
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/runner/FaabricMain.h>
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/config.h>
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
@@ -123,6 +124,8 @@ TEST_CASE_METHOD(FlushingTestFixture,
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory("demo", "echo", 1);
     faabric::Message& msg = req->mutable_messages()->at(0);
+
+    faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
     faaslet::Faaslet f(msg);
     f.executeTask(0, 0, req);
 

--- a/tests/test/wasm/test_execution_context.cpp
+++ b/tests/test/wasm/test_execution_context.cpp
@@ -1,7 +1,9 @@
 #include "utils.h"
 #include <catch2/catch.hpp>
 
+#include <faabric/scheduler/ExecutorContext.h>
 #include <faabric/util/func.h>
+
 #include <wasm/WasmExecutionContext.h>
 #include <wavm/WAVMWasmModule.h>
 
@@ -15,25 +17,20 @@ TEST_CASE("Test nesting wasm execution contexts", "[wasm]")
     faabric::Message msgA = faabric::util::messageFactory("demo", "echo");
     faabric::Message msgB = faabric::util::messageFactory("demo", "hello");
 
-    REQUIRE(wasm::getExecutingCall() == nullptr);
     REQUIRE(wasm::getExecutingModule() == nullptr);
 
     {
         wasm::WasmExecutionContext ctxA(&moduleA, &msgA);
         REQUIRE(wasm::getExecutingModule() == &moduleA);
-        REQUIRE(wasm::getExecutingCall() == &msgA);
 
         {
             wasm::WasmExecutionContext ctxB(&moduleB, &msgB);
             REQUIRE(wasm::getExecutingModule() == &moduleB);
-            REQUIRE(wasm::getExecutingCall() == &msgB);
         }
 
         REQUIRE(wasm::getExecutingModule() == &moduleA);
-        REQUIRE(wasm::getExecutingCall() == &msgA);
     }
 
-    REQUIRE(wasm::getExecutingCall() == nullptr);
     REQUIRE(wasm::getExecutingModule() == nullptr);
 }
 }

--- a/tests/test/wasm/test_execution_context.cpp
+++ b/tests/test/wasm/test_execution_context.cpp
@@ -20,11 +20,11 @@ TEST_CASE("Test nesting wasm execution contexts", "[wasm]")
     REQUIRE(wasm::getExecutingModule() == nullptr);
 
     {
-        wasm::WasmExecutionContext ctxA(&moduleA, &msgA);
+        wasm::WasmExecutionContext ctxA(&moduleA);
         REQUIRE(wasm::getExecutingModule() == &moduleA);
 
         {
-            wasm::WasmExecutionContext ctxB(&moduleB, &msgB);
+            wasm::WasmExecutionContext ctxB(&moduleB);
             REQUIRE(wasm::getExecutingModule() == &moduleB);
         }
 


### PR DESCRIPTION
Update to using `ExecutorContext` to give access to currently executing batch execute request.

Use this context to reinstate failing OpenMP tests. 