### PR TITLE
Set SGX execution through `WASM_VM` env. variable 

### DIFF
--- a/docs/source/sgx.md
+++ b/docs/source/sgx.md
@@ -20,11 +20,14 @@ inv func demo hello
 exit
 ./bin/cli.sh faasm
 
-# Generate machine code for SGX
-inv codegen demo hello --wamr --sgx
+# Set SGX as our execution mode of choice, and operate as usual
+export WASM_VM="sgx"
+
+# Generate machine code
+inv codegen demo hello
 
 # Run the code
-inv run demo hello --wamr --sgx
+inv run demo hello
 ```
 
 ## SGX Set-up

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -4,7 +4,6 @@ from invoke import task
 from copy import copy
 from os import environ
 from os.path import join
-from sys import exit
 
 from faasmcli.util.codegen import find_codegen_func, find_codegen_shared_lib
 from faasmcli.util.env import FAASM_RUNTIME_ROOT

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -44,25 +44,20 @@ SGX_WHITELISTED_FUNCS = [
 
 
 @task(default=True)
-def codegen(ctx, user, function, wamr=False, sgx=False):
+def codegen(ctx, user, function):
     """
     Generates machine code for the given function
     """
     env = copy(environ)
     env.update(
         {
-            "WASM_VM": "wamr" if wamr else "wavm",
             "LD_LIBRARY_PATH": "/usr/local/lib/",
         }
     )
 
-    if (not wamr) and sgx:
-        print("Can't run SGX codegen with WAVM. Add --wamr flag.")
-        exit(1)
-
     binary = find_codegen_func()
     run(
-        "{} {} {} {}".format(binary, user, function, "--sgx" if sgx else ""),
+        "{} {} {}".format(binary, user, function),
         shell=True,
         env=env,
         check=True,

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -13,7 +13,7 @@ LIB_FAKE_FILES = [
     join(FAASM_RUNTIME_ROOT, "lib", "fake", "libfakeLibB.so"),
 ]
 
-WAMR_WHITELISTED_FUNCS = [
+WAMR_ALLOWED_FUNCS = [
     # Misc
     ["demo", "chain"],
     ["ffmpeg", "check"],
@@ -34,7 +34,7 @@ WAMR_WHITELISTED_FUNCS = [
     ["demo", "stderr"],
 ]
 
-SGX_WHITELISTED_FUNCS = [
+SGX_ALLOWED_FUNCS = [
     ["demo", "hello"],
     ["demo", "chain_named_a"],
     ["demo", "chain_named_b"],
@@ -114,10 +114,15 @@ def local(ctx):
     for so in LIB_FAKE_FILES:
         _do_codegen_file(so)
 
+    # For WAMR and SGX codegen, we need to update the environment
+    env = copy(environ)
+
     # Run the WAMR codegen required by the tests
-    for user, func in WAMR_WHITELISTED_FUNCS:
-        codegen(ctx, user, func, wamr=True)
+    env.update({"WASM_VM": "wamr"})
+    for user, func in WAMR_ALLOWED_FUNCS:
+        codegen(ctx, user, func)
 
     # Run the SGX codegen required by the tests
-    for user, func in SGX_WHITELISTED_FUNCS:
-        codegen(ctx, user, func, wamr=True, sgx=True)
+    env.update({"WASM_VM": "sgx"})
+    for user, func in SGX_ALLOWED_FUNCS:
+        codegen(ctx, user, func)

--- a/faasmcli/faasmcli/tasks/run.py
+++ b/faasmcli/faasmcli/tasks/run.py
@@ -1,6 +1,5 @@
 from invoke import task
 from os import getenv
-from sys import exit
 
 from faasmcli.util.shell import run_command
 

--- a/faasmcli/faasmcli/tasks/run.py
+++ b/faasmcli/faasmcli/tasks/run.py
@@ -1,25 +1,20 @@
 from invoke import task
+from os import getenv
 from sys import exit
 
 from faasmcli.util.shell import run_command
 
 
 @task(default=True)
-def run(ctx, user, function, wamr=False, data=None, sgx=False):
+def run(ctx, user, function, data=None):
     """
     Execute a specific function
     """
     args = [user, function]
     if data:
         args.append(data)
-    if sgx:
-        args.append("--sgx")
 
-    wasm_vm = "wamr" if wamr else "wavm"
+    wasm_vm = getenv("WASM_VM", default="wavm")
     extra_env = {"WASM_VM": wasm_vm}
-
-    if (wasm_vm != "wamr") and sgx:
-        print("Can't run SGX functions with WAVM. Add --wamr flag.")
-        exit(1)
 
     run_command("func_runner", args, extra_env=extra_env)

--- a/src/runner/codegen_func.cpp
+++ b/src/runner/codegen_func.cpp
@@ -12,9 +12,7 @@
 
 using namespace boost::filesystem;
 
-void codegenForFunc(const std::string& user,
-                    const std::string& func,
-                    bool isSgx = false)
+void codegenForFunc(const std::string& user, const std::string& func)
 {
     codegen::MachineCodeGenerator& gen = codegen::getMachineCodeGenerator();
     storage::FileLoader& loader = storage::getFileLoader();
@@ -26,12 +24,10 @@ void codegenForFunc(const std::string& user,
         return;
     }
 
-    if (isSgx) {
-        msg.set_issgx(true);
-        SPDLOG_INFO("Generating SGX machine code for {}/{}", user, func);
-    } else {
-        SPDLOG_INFO("Generating machine code for {}/{}", user, func);
-    }
+    SPDLOG_INFO("Generating machine code for {}/{} (WASM VM: {})",
+                user,
+                func,
+                conf::getFaasmConfig().wasmVm);
 
     gen.codegenForFunction(msg);
 }
@@ -103,12 +99,6 @@ int main(int argc, char* argv[])
                 t.join();
             }
         }
-    } else if (argc == 4 && std::string(argv[3]) == "--sgx") {
-        std::string user = argv[1];
-        std::string func = argv[2];
-
-        SPDLOG_INFO("Running SGX codegen for function {}/{}", user, func);
-        codegenForFunc(user, func, true);
     } else {
         SPDLOG_ERROR("Must provide function user and optional function name");
         return 0;

--- a/src/runner/codegen_func.cpp
+++ b/src/runner/codegen_func.cpp
@@ -37,16 +37,19 @@ int main(int argc, char* argv[])
     faabric::util::initLogging();
     storage::initFaasmS3();
 
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
     if (argc == 3) {
         std::string user = argv[1];
         std::string func = argv[2];
 
-        SPDLOG_INFO("Running codegen for function {}/{}", user, func);
+        SPDLOG_INFO("Running codegen for function {}/{} (WASM VM: {})",
+                    user,
+                    func,
+                    conf.wasmVm);
         codegenForFunc(user, func);
     } else if (argc == 2) {
         std::string user = argv[1];
 
-        conf::FaasmConfig& conf = conf::getFaasmConfig();
         SPDLOG_INFO(
           "Running codegen for user {} on dir {}", user, conf.functionDir);
 

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -26,19 +26,10 @@ int doRunner(int argc, char* argv[])
     std::string function = argv[2];
 
     std::string inputData;
-    bool isSgx = false;
     bool hasInput = false;
     if (argc == 4) {
-        if (std::string(argv[3]) == "--sgx") {
-            isSgx = true;
-        } else {
-            inputData = argv[3];
-            hasInput = true;
-        }
-    } else if (argc == 5 && std::string(argv[4]) == "--sgx") {
         inputData = argv[3];
         hasInput = true;
-        isSgx = true;
     }
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =
@@ -86,11 +77,6 @@ int doRunner(int argc, char* argv[])
         msg.set_inputdata(inputData);
 
         SPDLOG_INFO("Adding input data: {}", inputData);
-    }
-
-    if (isSgx) {
-        msg.set_issgx(true);
-        SPDLOG_INFO("Running function in SGX");
     }
 
     // Set up the system

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -330,7 +330,7 @@ void FileLoader::uploadFunctionObjectHash(const faabric::Message& msg,
 
 static const std::string getWamrAotKey(const faabric::Message& msg)
 {
-    if (msg.issgx()) {
+    if (conf::getFaasmConfig().wasmVm == "sgx") {
         return getKey(msg, SGX_WAMR_AOT_FILENAME);
     } else {
         return getKey(msg, WAMR_AOT_FILENAME);
@@ -340,7 +340,7 @@ static const std::string getWamrAotKey(const faabric::Message& msg)
 std::string FileLoader::getFunctionAotFile(const faabric::Message& msg)
 {
     auto path = getDir(conf.objectFileDir, msg, true);
-    if (msg.issgx()) {
+    if (conf::getFaasmConfig().wasmVm == "sgx") {
         path.append(SGX_WAMR_AOT_FILENAME);
     } else {
         path.append(WAMR_AOT_FILENAME);

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -61,10 +61,6 @@ int makeChainedCall(const std::string& functionName,
     }
     msg.set_ispython(originalCall->ispython());
 
-    if (originalCall->issgx()) {
-        msg.set_issgx(true);
-    }
-
     if (originalCall->recordexecgraph()) {
         msg.set_recordexecgraph(true);
     }

--- a/tests/test/codegen/test_machine_code_generator.cpp
+++ b/tests/test/codegen/test_machine_code_generator.cpp
@@ -112,20 +112,15 @@ TEST_CASE_METHOD(CodegenTestFixture,
     SECTION("WAMR codegen")
     {
         conf.wasmVm = "wamr";
+        objectFileA = "/tmp/obj/demo/hello/function.aot";
+        objectFileB = "/tmp/obj/demo/echo/function.aot";
+    }
 
-        SECTION("Non-SGX")
-        {
-            objectFileA = "/tmp/obj/demo/hello/function.aot";
-            objectFileB = "/tmp/obj/demo/echo/function.aot";
-        }
-
-        SECTION("SGX")
-        {
-            objectFileA = "/tmp/obj/demo/hello/function.aot.sgx";
-            objectFileB = "/tmp/obj/demo/echo/function.aot.sgx";
-            msgA.set_issgx(true);
-            msgB.set_issgx(true);
-        }
+    SECTION("SGX codegen")
+    {
+        conf.wasmVm = "wamr";
+        objectFileA = "/tmp/obj/demo/hello/function.aot.sgx";
+        objectFileB = "/tmp/obj/demo/echo/function.aot.sgx";
     }
 
     codegen::MachineCodeGenerator gen(loader);
@@ -273,14 +268,11 @@ TEST_CASE_METHOD(CodegenTestFixture,
 {
     std::string objectFile;
     std::string objectFileSgx;
-    conf.wasmVm = "wamr";
 
     // Rename messages for more clarity
     faabric::Message msg = msgA;
     faabric::Message msgSgx = msgA;
 
-    msg.set_issgx(false);
-    msgSgx.set_issgx(true);
     objectFile = "/tmp/obj/demo/hello/function.aot";
     objectFileSgx = "/tmp/obj/demo/hello/function.aot.sgx";
 
@@ -302,20 +294,24 @@ TEST_CASE_METHOD(CodegenTestFixture,
     // Do codegen for both in different orders
     SECTION("SGX first")
     {
+        conf.wasmVm = "sgx";
         gen.codegenForFunction(msgSgx);
         REQUIRE(std::filesystem::exists(hashFileSgx));
         REQUIRE(!std::filesystem::exists(hashFile));
 
+        conf.wasmVm = "wamr";
         gen.codegenForFunction(msg);
         REQUIRE(std::filesystem::exists(hashFile));
     }
 
     SECTION("SGX second")
     {
+        conf.wasmVm = "wamr";
         gen.codegenForFunction(msg);
         REQUIRE(std::filesystem::exists(hashFile));
         REQUIRE(!std::filesystem::exists(hashFileSgx));
 
+        conf.wasmVm = "sgx";
         gen.codegenForFunction(msgSgx);
         REQUIRE(std::filesystem::exists(hashFileSgx));
     }

--- a/tests/test/codegen/test_machine_code_generator.cpp
+++ b/tests/test/codegen/test_machine_code_generator.cpp
@@ -118,7 +118,7 @@ TEST_CASE_METHOD(CodegenTestFixture,
 
     SECTION("SGX codegen")
     {
-        conf.wasmVm = "wamr";
+        conf.wasmVm = "sgx";
         objectFileA = "/tmp/obj/demo/hello/function.aot.sgx";
         objectFileB = "/tmp/obj/demo/echo/function.aot.sgx";
     }

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -227,9 +227,15 @@ void executeWithSGX(const std::string& user,
                     const std::string& func,
                     int timeout)
 {
-    faabric::Message call = faabric::util::messageFactory(user, func);
-    call.set_issgx(true);
-    doWamrPoolExecution(call, timeout);
+    faabric::Message msg = faabric::util::messageFactory(user, func);
+    conf::FaasmConfig& conf = conf::getFaasmConfig();
+    const std::string originalVm = conf.wasmVm;
+    conf.wasmVm = "sgx";
+
+    // Don't clean so that the SGX configuration persists
+    execFuncWithPool(msg, false, timeout);
+
+    conf.wasmVm = originalVm;
 }
 
 void checkCallingFunctionGivesBoolOutput(const std::string& user,


### PR DESCRIPTION
In this PR I change the way we indicate that we want to run a function with SGX. Even though it is not semantically correct, the environment variable indicating what `WASM_VM` we use takes now three possible values: `wavm` (default), `wamr`, and `sgx`.

This means that wen using the CLI we don't need to pass any extra parameters, just set the variable beforehand:

```bash
export WASM_VM="sgx"

# Codegen and run function inside enclave
inv codegen demo hello
inv run demo hello

export WASM_VM="wavm"

# Codegen and run function with WAVM
inv codegen demo hello
inv run demo hello
```

This also means that we can get rid of the references to SGX in the faabric message (faasm/faabric#229).