### PR TITLE
Conan cache improvements

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,5 @@ COMPOSE_PROJECT_NAME=faasm-dev
 # into junk locations
 FAASM_BUILD_MOUNT=/host_dev/build
 FAASM_LOCAL_MOUNT=/host_dev/faasm-local
+
+CONAN_CACHE_MOUNT_SOURCE=./dev/faasm/conan/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,6 +225,8 @@ jobs:
     defaults:
       run:
         working-directory: /home/runner/work/faasm/faasm
+    env:
+        CONAN_CACHE_MOUNT_SOURCE: ${{ env.HOME }}/.conan
     steps:
       - name: "Check out code"
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,23 +221,22 @@ jobs:
   dist-tests:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    needs: [conan-cache]
     defaults:
       run:
-        working-directory: /home/runner/work/faasm/faasm
+        working-directory: ${{ github.workspace }}
     env:
         CONAN_CACHE_MOUNT_SOURCE: ${{ env.HOME }}/.conan
     steps:
       - name: "Check out code"
         uses: actions/checkout@v2
+      - name: "Conan cache"
+        uses: faasm/conan-cache-action@v1
+        with:
+          directory: ${{ github.workspace }}
       - name: "Update faabric submodule"
         run: git submodule update --init faabric
       - name: "Update cpp client submodule"
         run: git submodule update --init clients/cpp
-      - name: "Conan cache"
-        uses: faasm/conan-cache-action@v1
-        with:
-          directory: /home/runner/work/faasm/faasm
       # Cache contains architecture-specific machine code
       - name: "Get CPU model name"
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
@@ -260,7 +259,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: /home/runner/work/faasm/faasm
+        working-directory: ${{ github.workspace }}
     env:
       PYTHON_CODEGEN: "on"
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,7 +225,7 @@ jobs:
       run:
         working-directory: ${{ github.workspace }}
     env:
-        CONAN_CACHE_MOUNT_SOURCE: ${{ env.HOME }}/.conan
+        CONAN_CACHE_MOUNT_SOURCE: ~/.conan
     steps:
       - name: "Check out code"
         uses: actions/checkout@v2

--- a/deploy/dist-test/build.sh
+++ b/deploy/dist-test/build.sh
@@ -7,9 +7,6 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} >> /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
-export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
-# Ensure the cache directory exists before starting the containers
-mkdir -p ${CONAN_CACHE_MOUNT_SOURCE}
 
 # Run the build
 docker-compose \

--- a/deploy/dist-test/run.sh
+++ b/deploy/dist-test/run.sh
@@ -5,7 +5,6 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} > /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
-export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
 
 RETURN_VAL=0
 

--- a/deploy/dist-test/upload.sh
+++ b/deploy/dist-test/upload.sh
@@ -7,7 +7,6 @@ export PROJ_ROOT=${THIS_DIR}/../..
 pushd ${PROJ_ROOT} > /dev/null
 
 export FAASM_BUILD_MOUNT=/build/faasm
-export CONAN_CACHE_MOUNT_SOURCE=$HOME/.conan/
 
 # Make sure upload server is running
 docker-compose \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
       - ./:/usr/local/code/faasm/
       - ./dev/faasm/build/:${FAASM_BUILD_MOUNT}
       - ./dev/faasm-local/:${FAASM_LOCAL_MOUNT}
-      - ${CONAN_CACHE_MOUNT_SOURCE:-./dev/faasm/conan/}:/root/.conan
+      - ${CONAN_CACHE_MOUNT_SOURCE}:/root/.conan
 
   # Distributed tests server
   dist-test-server:


### PR DESCRIPTION
- Define docker-compose defaults in `.env` as we do with others
- Avoid setting environment in dist tests scripts, instead taking default
- Explicitly set cache in dist-test GHA step