### PR TITLE
Fix Build of Trusted Code in SGX

### DIFF
--- a/src/enclave/CMakeLists.txt
+++ b/src/enclave/CMakeLists.txt
@@ -107,3 +107,5 @@ add_subdirectory(inside)
 # --------------------------------------------------------
 add_subdirectory(outside)
 
+# Set dependency so that trusted code gets built with all major CMake targets
+add_dependencies(enclave_untrusted enclave_trusted)

--- a/src/enclave/inside/crypto/encryption.cpp
+++ b/src/enclave/inside/crypto/encryption.cpp
@@ -1,4 +1,4 @@
-#include <enclave/crypto/inside/encryption.h>
+#include <enclave/inside/crypto/encryption.h>
 
 FaasmSgxEncryptedMsg* doSymEncrypt(FaasmSgxMsg* decryptedMsg,
                                    FaasmSgxSymKey symKey)


### PR DESCRIPTION
The part of the code meant to run inside the enclave (`src/enclave/inside`) is only used as an API through the `ECall` interface. As a consequence, no CMake target (other than `enclave_trusted`) would trigger the build of the trusted side, and the enclave was not getting re-built (i.e. it was not there in _clean_ builds).

To dive in a bit deeper, enclave code (i.e. the `enclave_trusted` target in CMake) gets built into a signed library as a `post_target` command. Source code elsewhere just [_assumes_](https://github.com/faasm/faasm/blob/main/src/enclave/outside/system.cpp#L54) that the library will be there at runtime (path is [hardcoded](https://github.com/faasm/faasm/blob/main/src/enclave/CMakeLists.txt#L11)).

There used to be an `add_dependency` in the original CMake, but I dropped it in the re-factoring process in #588.

I also fix a compilation issue that had slipped because of this.