### PR TITLE
Fix `FAASM_SGX` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,6 @@ option(FAASM_PERF_PROFILING "Turn on profiling features as described in debuggin
 
 # SGX functionality
 # These options customise the SGX features _provided_ SGX is found
-unset(FAASM_SGX CACHE)
 option(FAASM_SGX "Enable SGX support" ON)
 option(FAASM_SGX_SIM_MODE "Turn on SGX sim mode" ON)
 option(FAASM_SGX_ATTESTATION "Turn on attestation" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(FAASM_PERF_PROFILING "Turn on profiling features as described in debuggin
 
 # SGX functionality
 # These options customise the SGX features _provided_ SGX is found
+unset(FAASM_SGX CACHE)
 option(FAASM_SGX "Enable SGX support" ON)
 option(FAASM_SGX_SIM_MODE "Turn on SGX sim mode" ON)
 option(FAASM_SGX_ATTESTATION "Turn on attestation" OFF)
@@ -70,8 +71,6 @@ elseif (FAASM_USE_SANITISER STREQUAL "Memory")
     set(FAASM_SGX OFF)
 elseif (NOT ((FAASM_USE_SANITISER STREQUAL "None") OR (NOT FAASM_USE_SANITISER)))
     message(FATAL_ERROR "Invalid FAASM_USE_SANITISER setting: ${FAASM_USE_SANITISER}")
-else ()
-    set(FAASM_SGX ON)
 endif()
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/faasmcli/faasmcli/tasks/dev.py
+++ b/faasmcli/faasmcli/tasks/dev.py
@@ -51,7 +51,7 @@ def cmake(
         "-DFAABRIC_SELF_TRACING=ON" if prof else "",
         "-DFAASM_USE_SANITISER={}".format(sanitiser),
         "-DFAABRIC_USE_SANITISER={}".format(sanitiser),
-        "-DFAASM_SGX=OFF" if nosgx else "",
+        "-DFAASM_SGX={}".format("OFF" if nosgx else "ON"),
         PROJ_ROOT,
     ]
 


### PR DESCRIPTION
In a previous PR (#590) I had to overwrite the `FAASM_SGX` CMake variable to set it to `ON` explicitly to make sure the SGX code was being built and tested. My fix was too brute, and broke the option to disable the SGX build, which is why the flag was introduced in the first place.

The crux of the problem is that, even though the default value is now `ON`, it is _cached_ (in `CMakeCache.txt`) as `OFF` from when the container image was built. As a consequence, if we don't set `FAASM_SGX` to `ON` explicitely, it will be set to `OFF`. As a proof of concept, I print all cached variables in an action run, where [we can see that `FAASM_SGX` is set to OFF](https://github.com/faasm/faasm/runs/5277343740?check_suite_focus=true#step:4:1617).

One possible workaround is to re-build the container images with a different default value, so that it gets properly cached. Another workaround (the one I have chosen) is to `unset` the variable from the CMake cache so that it is either the default (`ON`) or `OFF` if overriden from the command line.

Relevant links:
- https://gitlab.kitware.com/cmake/cmake/-/issues/21708
- https://stackoverflow.com/questions/44719963/cmake-default-value-for-options-doesnt-work/44720601#44720601
- https://gitlab.kitware.com/cmake/cmake/-/issues/14756#note_258579