### PR TITLE
Latest faabric

### DIFF
--- a/include/faaslet/Faaslet.h
+++ b/include/faaslet/Faaslet.h
@@ -25,8 +25,6 @@ class Faaslet final : public faabric::scheduler::Executor
       int msgIdx,
       std::shared_ptr<faabric::BatchExecuteRequest> req) override;
 
-    void restore(const std::string& snapshotKey) override;
-
     std::string getLocalResetSnapshotKey();
 
   protected:

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -3,6 +3,7 @@
 #include "WasmEnvironment.h"
 
 #include <faabric/proto/faabric.pb.h>
+#include <faabric/snapshot/SnapshotRegistry.h>
 #include <faabric/state/State.h>
 #include <faabric/util/memory.h>
 #include <faabric/util/queue.h>
@@ -215,6 +216,8 @@ class WasmModule
     virtual void doBindToFunction(faabric::Message& msg, bool cache);
 
     // Snapshots
+    faabric::snapshot::SnapshotRegistry& reg;
+
     void snapshotWithKey(const std::string& snapKey);
 
     void ignoreThreadStacksInSnapshot(const std::string& snapKey);

--- a/src/faaslet/Faaslet.cpp
+++ b/src/faaslet/Faaslet.cpp
@@ -141,22 +141,6 @@ void Faaslet::setMemorySize(size_t newSize)
     module->setMemorySize(newSize);
 }
 
-void Faaslet::restore(const std::string& snapshotKey)
-{
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-
-    // Restore from snapshot if necessary
-    if (conf.wasmVm == "wavm") {
-        if (!snapshotKey.empty()) {
-            SPDLOG_DEBUG("Restoring {} from snapshot {} before execution",
-                         id,
-                         snapshotKey);
-
-            module->restore(snapshotKey);
-        }
-    }
-}
-
 std::string Faaslet::getLocalResetSnapshotKey()
 {
     return localResetSnapshotKey;

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -62,6 +62,7 @@ WasmModule::WasmModule()
 
 WasmModule::WasmModule(int threadPoolSizeIn)
   : threadPoolSize(threadPoolSizeIn)
+  , reg(faabric::snapshot::getSnapshotRegistry())
 {}
 
 WasmModule::~WasmModule() {}


### PR DESCRIPTION
Changes:

- Use default `Executor` restore method for Faaslets.