### PR TITLE
Argc/Argv support for SGX

### DIFF
--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -39,6 +39,8 @@ SGX_ALLOWED_FUNCS = [
     ["demo", "chain_named_a"],
     ["demo", "chain_named_b"],
     ["demo", "chain_named_c"],
+    # Environment
+    ["demo", "argc_argv_test"],
 ]
 
 

--- a/faasmcli/faasmcli/tasks/dev.py
+++ b/faasmcli/faasmcli/tasks/dev.py
@@ -65,7 +65,7 @@ def tools(ctx, clean=False, build="Debug", parallel=0, sanitiser="None"):
     """
     Builds all the targets commonly used for development
     """
-    nosgx = True if sanitiser is not None else False
+    nosgx = sanitiser != "None"
     cmake(ctx, clean=clean, build=build, sanitiser=sanitiser, nosgx=nosgx)
 
     targets = " ".join(DEV_TARGETS)

--- a/faasmcli/faasmcli/tasks/dev.py
+++ b/faasmcli/faasmcli/tasks/dev.py
@@ -65,7 +65,8 @@ def tools(ctx, clean=False, build="Debug", parallel=0, sanitiser="None"):
     """
     Builds all the targets commonly used for development
     """
-    cmake(ctx, clean=clean, build=build, sanitiser=sanitiser)
+    nosgx = True if sanitiser is not None else False
+    cmake(ctx, clean=clean, build=build, sanitiser=sanitiser, nosgx=nosgx)
 
     targets = " ".join(DEV_TARGETS)
 

--- a/include/enclave/inside/EnclaveWasmModule.h
+++ b/include/enclave/inside/EnclaveWasmModule.h
@@ -3,6 +3,11 @@
 #include <iwasm/aot/aot_runtime.h>
 #include <wasm_runtime_common.h>
 
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
 #define ONE_KB_BYTES 1024
 #define ONE_MB_BYTES (1024 * 1024)
 
@@ -16,12 +21,9 @@
 
 namespace wasm {
 
-static uint8_t wamrHeapBuffer[FAASM_SGX_WAMR_HEAP_SIZE];
-
 /*
  * Abstraction around a WebAssembly module running inside an SGX enclave with
- * the WAMR runtime.
- */
+ * the WAMR runtime.  */
 class EnclaveWasmModule
 {
   public:
@@ -33,12 +35,43 @@ class EnclaveWasmModule
 
     bool loadWasm(void* wasmOpCodePtr, uint32_t wasmOpCodeSize);
 
-    bool callFunction();
+    bool callFunction(uint32_t argcIn, char** argvIn);
+
+    bool validateNativeAddress(void* nativePtr, size_t size);
+
+    WASMModuleInstanceCommon* moduleInstance;
+
+    // ---- argc/arv ----
+    uint32_t getArgc();
+
+    size_t getArgvBufferSize();
+
+    void writeArgvToWamrMemory(uint32_t wasmArgvPointers,
+                               uint32_t wasmArgvBuffer);
 
   private:
     char errorBuffer[FAASM_SGX_WAMR_MODULE_ERROR_BUFFER_SIZE];
 
     WASMModuleCommon* wasmModule;
-    WASMModuleInstanceCommon* moduleInstance;
+
+    // Argc/argv
+    uint32_t argc;
+    std::vector<std::string> argv;
+    size_t argvBufferSize;
+
+    void prepareArgcArgv(uint32_t argcIn, char** argvIn);
 };
+
+/*
+ * Data structure to keep track of the modules currently loaded in the enclave.
+ * And mutex to control concurrent accesses. Both objects have external
+ * definition as they have to be accessed both when running an ECall, and
+ * resolving a WAMR native symbol.
+ */
+extern std::unordered_map<uint32_t, std::shared_ptr<wasm::EnclaveWasmModule>>
+  moduleMap;
+extern std::mutex moduleMapMutex;
+
+std::shared_ptr<wasm::EnclaveWasmModule> getExecutingEnclaveWasmModule(
+  wasm_exec_env_t execEnv);
 }

--- a/include/enclave/inside/EnclaveWasmModule.h
+++ b/include/enclave/inside/EnclaveWasmModule.h
@@ -37,17 +37,25 @@ class EnclaveWasmModule
 
     bool callFunction(uint32_t argcIn, char** argvIn);
 
-    bool validateNativeAddress(void* nativePtr, size_t size);
+    // ---- Native address - WASM offset translation and bound-checks ----
+
+    // Validate that a memory range defined by a pointer and a size is a valid
+    // offset in the module's WASM linear memory.
+    bool validateNativePointer(void* nativePtr, size_t size);
+
+    // Convert a native pointer to the corresponding offset in the WASM linear
+    // memory.
+    uint32_t nativePointerToWasmOffset(void* nativePtr);
 
     WASMModuleInstanceCommon* moduleInstance;
 
     // ---- argc/arv ----
+
     uint32_t getArgc();
 
     size_t getArgvBufferSize();
 
-    void writeArgvToWamrMemory(uint32_t wasmArgvPointers,
-                               uint32_t wasmArgvBuffer);
+    void writeArgvToWamrMemory(uint32_t* argvOffsetsWasm, char* argvBuffWasm);
 
   private:
     char errorBuffer[FAASM_SGX_WAMR_MODULE_ERROR_BUFFER_SIZE];
@@ -60,18 +68,39 @@ class EnclaveWasmModule
     size_t argvBufferSize;
 
     void prepareArgcArgv(uint32_t argcIn, char** argvIn);
+
+    // Helper function to write a string array to a buffer in the WASM linear
+    // memory, and record the offsets where each new string begins (note that
+    // in WASM this strings are now interpreted as char pointers).
+    void writeStringArrayToMemory(const std::vector<std::string>& strings,
+                                  uint32_t* strOffsets,
+                                  char* strBuffer);
 };
 
-/*
- * Data structure to keep track of the modules currently loaded in the enclave.
- * And mutex to control concurrent accesses. Both objects have external
- * definition as they have to be accessed both when running an ECall, and
- * resolving a WAMR native symbol.
- */
+// Data structure to keep track of the modules currently loaded in the enclave.
+// And mutex to control concurrent accesses. Both objects have external
+// definition as they have to be accessed both when running an ECall, and
+// resolving a WAMR native symbol.
 extern std::unordered_map<uint32_t, std::shared_ptr<wasm::EnclaveWasmModule>>
   moduleMap;
 extern std::mutex moduleMapMutex;
 
+// Return the EnclaveWasmModule that is executing in a given WASM execution
+// environment. This method relies on `wasm_exec_env_t` having a `module_inst`
+// property, pointint to the instantiated module.
 std::shared_ptr<wasm::EnclaveWasmModule> getExecutingEnclaveWasmModule(
   wasm_exec_env_t execEnv);
 }
+
+// Given that we can not throw exceptions, we wrap the call to the method to
+// get the executing enclave with a check for success. This macro is meant to
+// be used in the implementation of native symbols, where returning 1 is
+// interpreted as a failure.
+#define GET_EXECUTING_MODULE_AND_CHECK(exec_env)                               \
+    std::shared_ptr<wasm::EnclaveWasmModule> module =                          \
+      wasm::getExecutingEnclaveWasmModule(exec_env);                           \
+    if (module == nullptr) {                                                   \
+        ocallLogError(                                                         \
+          "Error linking execution environment to registered modules");        \
+        return 1;                                                              \
+    }

--- a/include/enclave/inside/native.h
+++ b/include/enclave/inside/native.h
@@ -30,6 +30,24 @@
     *((uint32_t*)&((AOTModuleInstance*)exec_env->module_inst)                  \
         ->cur_exception[sizeof(_FAASM_SGX_ERROR_PREFIX)]) = (X);
 
+// ---------- WAMR Symbol Registration ----------
+// The function signature to register native symbols is made up of a parenthesis
+// with the type of each input argument, and the type of the return value
+// immediately after. E.g: (ii)i # two int32 input arguments, returns an int32
+// The different supported types are:
+// - i/I,f/F: int32/64 and float32/64
+// - *: the parameter is an offset in WASM memory. **Important** if we use `*`
+//      instead of `i` the runtime automatically translates the address and does
+//      bound checks. Otherwise, we need to translate the address ourselves.
+// - ~: following a `*`, a `~` means that the parameter is the size of the
+//      preceeding pointer (indicated by a `*`). The runtime does the
+//      corresponding bound and address checks.
+// - $: string parameter also with runtime checks.
+//
+// Link to WAMR docs:
+// https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/export_native_api.md#buffer-address-conversion-and-boundary-check
+// ----------------------------------------------
+
 namespace sgx {
 void initialiseSGXWAMRNatives();
 

--- a/include/enclave/inside/native.h
+++ b/include/enclave/inside/native.h
@@ -30,23 +30,10 @@
     *((uint32_t*)&((AOTModuleInstance*)exec_env->module_inst)                  \
         ->cur_exception[sizeof(_FAASM_SGX_ERROR_PREFIX)]) = (X);
 
-// ---------- WAMR Symbol Registration ----------
-// The function signature to register native symbols is made up of a parenthesis
-// with the type of each input argument, and the type of the return value
-// immediately after. E.g: (ii)i # two int32 input arguments, returns an int32
-// The different supported types are:
-// - i/I,f/F: int32/64 and float32/64
-// - *: the parameter is an offset in WASM memory. **Important** if we use `*`
-//      instead of `i` the runtime automatically translates the address and does
-//      bound checks. Otherwise, we need to translate the address ourselves.
-// - ~: following a `*`, a `~` means that the parameter is the size of the
-//      preceeding pointer (indicated by a `*`). The runtime does the
-//      corresponding bound and address checks.
-// - $: string parameter also with runtime checks.
-//
-// Link to WAMR docs:
-// https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/export_native_api.md#buffer-address-conversion-and-boundary-check
-// ----------------------------------------------
+/*
+ * See the WAMR native header file for a detailed explanation on WAMR's native
+ * signatures.
+ */
 
 namespace sgx {
 void initialiseSGXWAMRNatives();

--- a/include/enclave/inside/ocalls.h
+++ b/include/enclave/inside/ocalls.h
@@ -10,7 +10,12 @@ extern "C"
 {
     extern sgx_status_t SGX_CDECL ocallLogError(const char* msg);
 
+// In enclave release mode (i.e NDEBUG set) we disable debug logging
+#ifdef NDEBUG
+    void ocallLogDebug(const char* msg) { ; };
+#else
     extern sgx_status_t SGX_CDECL ocallLogDebug(const char* msg);
+#endif
 
     extern sgx_status_t SGX_CDECL ocallFaasmReadInput(int* returnValue,
                                                       uint8_t* buffer,

--- a/include/enclave/inside/ocalls.h
+++ b/include/enclave/inside/ocalls.h
@@ -10,7 +10,8 @@ extern "C"
 {
     extern sgx_status_t SGX_CDECL ocallLogError(const char* msg);
 
-// In enclave release mode (i.e NDEBUG set) we disable debug logging
+// In enclave release mode (i.e NDEBUG set) we disable debug logging, and
+// prevent it from doing an ocall (hence the different signature).
 #ifdef NDEBUG
     void ocallLogDebug(const char* msg) { ; };
 #else

--- a/include/enclave/outside/ecalls.h
+++ b/include/enclave/outside/ecalls.h
@@ -25,7 +25,9 @@ extern "C"
 
     extern sgx_status_t ecallCallFunction(sgx_enclave_id_t enclave_id,
                                           faasm_sgx_status_t* ret_val,
-                                          uint32_t faaslet_id);
+                                          uint32_t faaslet_id,
+                                          uint32_t argc,
+                                          char** argv);
 
     extern sgx_status_t ecallCryptoChecks(sgx_enclave_id_t enclave_id,
                                           faasm_sgx_status_t* ret_val);

--- a/include/wamr/WAMRModuleMixin.h
+++ b/include/wamr/WAMRModuleMixin.h
@@ -5,6 +5,20 @@
 #include <string>
 #include <vector>
 
+/*
+ * This mixin implements common methods shared between the WAMRWasmModule class
+ * and the EnclaveWasmModule class. Both classes abstract a WAMR WebAssembly
+ * module: the former runs in a regular Faaslet and the latter inside an SGX
+ * enclave (the former knows nothing about SGX whatsoever).
+ *
+ * The reason we need a mixin and can not use a common shared super class is
+ * because all transitive dependencies that are to be run inside an SGX enclave
+ * need to be self-contained in said enclave. The SGX SDK provides transparent
+ * replacements for headers like <string> and <vector> through their custom
+ * (in-house) implementation of libc and libc++. However, having a class such
+ * as WasmModule inside an enclave is unfeasible given the amount of include
+ * dependencies.
+ */
 template<typename T>
 struct WAMRModuleMixin
 {

--- a/include/wamr/WAMRModuleMixin.h
+++ b/include/wamr/WAMRModuleMixin.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <wasm_export.h>
+
+#include <string>
+#include <vector>
+
+template<typename T>
+struct WAMRModuleMixin
+{
+    T& underlying() { return static_cast<T&>(*this); }
+
+    // ---- Native address - WASM offset translation and bound-checks ----
+
+    // Validate that a memory range defined by a pointer and a size is a valid
+    // offset in the module's WASM linear memory.
+    // bool validateNativePointer(void* nativePtr, size_t size);
+    bool validateNativePointer(void* nativePtr, int size)
+    {
+        auto moduleInstance = this->underlying().getModuleInstance();
+        return wasm_runtime_validate_native_addr(
+          moduleInstance, nativePtr, size);
+    }
+
+    // Convert a native pointer to the corresponding offset in the WASM linear
+    // memory.
+    uint32_t nativePointerToWasmOffset(void* nativePtr)
+    {
+        auto moduleInstance = this->underlying().getModuleInstance();
+        return wasm_runtime_addr_native_to_app(moduleInstance, nativePtr);
+    }
+
+    // Helper function to write a string array to a buffer in the WASM linear
+    // memory, and record the offsets where each new string begins (note that
+    // in WASM this strings are now interpreted as char pointers).
+    void writeStringArrayToMemory(const std::vector<std::string>& strings,
+                                  uint32_t* strOffsets,
+                                  char* strBuffer)
+    {
+        // Validate that the offset array has enough capacity to hold all
+        // offsets (one per string)
+        validateNativePointer(strOffsets, strings.size() * sizeof(uint32_t));
+
+        char* nextBuffer = strBuffer;
+        for (size_t i = 0; i < strings.size(); i++) {
+            const std::string& thisStr = strings.at(i);
+
+            // Validate that the WASM offset we are going to write to is within
+            // the bounds of the linear memory
+            validateNativePointer(nextBuffer, thisStr.size() + 1);
+
+            std::copy(thisStr.begin(), thisStr.end(), nextBuffer);
+            strOffsets[i] = nativePointerToWasmOffset(nextBuffer);
+
+            nextBuffer += thisStr.size() + 1;
+        }
+    }
+
+    // ---- argc/arv ----
+
+    void writeArgvToWamrMemory(uint32_t* argvOffsetsWasm, char* argvBuffWasm)
+    {
+        writeStringArrayToMemory(
+          this->underlying().getArgv(), argvOffsetsWasm, argvBuffWasm);
+    }
+};

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <wamr/WAMRModuleMixin.h>
 #include <wasm/WasmModule.h>
 #include <wasm_runtime_common.h>
 
@@ -11,7 +12,9 @@ namespace wasm {
 
 std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx);
 
-class WAMRWasmModule final : public WasmModule
+class WAMRWasmModule final
+  : public WasmModule
+  , public WAMRModuleMixin<WAMRWasmModule>
 {
   public:
     static void initialiseWAMRGlobally();
@@ -30,27 +33,15 @@ class WAMRWasmModule final : public WasmModule
     // ----- Helper functions -----
     void writeStringToWasmMemory(const std::string& strHost, char* strWasm);
 
-    void writeStringArrayToMemory(const std::vector<std::string>& strings,
-                                  uint32_t* strOffsets,
-                                  char* strBuffer);
-
-    void writeArgvToWamrMemory(uint32_t* argvOffsetsWasm, char* argvBuffWasm);
-
     void writeWasmEnvToWamrMemory(uint32_t* envOffsetsWasm, char* envBuffWasm);
 
     // ----- Address translation and validation -----
-    // Validate that the native address belongs to the module's instance address
-    // space
-    void validateNativeAddress(void* nativePtr, size_t size);
 
     // Check if WASM offset belongs to WASM memory
     void validateWasmOffset(uint32_t wasmOffset, size_t size);
 
     // Convert relative address to absolute address (pointer to memory)
     uint8_t* wasmPointerToNative(uint32_t wasmPtr) override;
-
-    // Convert absolute address to relative address (offset in WASM memory)
-    uint32_t nativePointerToWasm(void* nativePtr);
 
     // ----- Memory management -----
     uint32_t growMemory(size_t nBytes) override;
@@ -68,6 +59,8 @@ class WAMRWasmModule final : public WasmModule
     size_t getMaxMemoryPages();
 
     WASMModuleInstanceCommon* getModuleInstance();
+
+    std::vector<std::string> getArgv();
 
   private:
     char errorBuffer[ERROR_BUFFER_SIZE];

--- a/include/wamr/native.h
+++ b/include/wamr/native.h
@@ -31,6 +31,15 @@
  * int32_t myBigIntFunc(int64_t i, char* s) = "(I$)i"
  * void fooBar(*int32_t i, char* s, float32_t f) = "(*$f)"
  * void nothing() = "()"
+ *
+ * Note that, when using `*`, `~`, or `$`, the WASM runtime checks that the
+ * offset is a pointer within the WASM linear memory, and translates it into a
+ * native pointer that we can use. I.e. you could also use `i` to indicate a
+ * offset into WASM memory, but it would not be bound-checked, nor translated
+ * to a native pointer.
+ *
+ * Link to WAMR docs:
+ * https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/export_native_api.md#buffer-address-conversion-and-boundary-check
  */
 
 namespace wasm {

--- a/src/enclave/inside/EnclaveWasmModule.cpp
+++ b/src/enclave/inside/EnclaveWasmModule.cpp
@@ -7,8 +7,7 @@
 namespace wasm {
 
 // Define the module map and its mutex
-std::unordered_map<uint32_t, std::shared_ptr<wasm::EnclaveWasmModule>>
-  moduleMap;
+std::unordered_map<uint32_t, std::shared_ptr<EnclaveWasmModule>> moduleMap;
 std::mutex moduleMapMutex;
 
 // Define the WAMR's heap buffer
@@ -126,8 +125,8 @@ std::shared_ptr<EnclaveWasmModule> getExecutingEnclaveWasmModule(
   wasm_exec_env_t execEnv)
 {
     // Acquiring a lock every time may be too conservative
-    std::unique_lock<std::mutex> lock(wasm::moduleMapMutex);
-    for (auto& it : wasm::moduleMap) {
+    std::unique_lock<std::mutex> lock(moduleMapMutex);
+    for (auto& it : moduleMap) {
         if (it.second->getModuleInstance() == execEnv->module_inst) {
             return it.second;
         }

--- a/src/enclave/inside/EnclaveWasmModule.cpp
+++ b/src/enclave/inside/EnclaveWasmModule.cpp
@@ -136,6 +136,9 @@ std::shared_ptr<EnclaveWasmModule> getExecutingEnclaveWasmModule(
     // execution environment to any of the registered modules. This is a fatal
     // error, but we expect the caller to handle it, as throwing exceptions
     // is not supported.
+    ocallLogError("Can not find any registered module corresponding to the "
+                  "supplied execution environment, this is a fatal error");
+
     return nullptr;
 }
 

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -25,7 +25,9 @@ enclave{
         );
 
         public faasm_sgx_status_t ecallCallFunction(
-            uint32_t faaslet_id
+                                uint32_t faaslet_id,
+                                uint32_t argc,
+            [in, count=argc]    char** argv
         );
 
         public faasm_sgx_status_t ecallCryptoChecks(void);

--- a/src/enclave/inside/env.cpp
+++ b/src/enclave/inside/env.cpp
@@ -5,9 +5,16 @@
 #include <string>
 
 namespace sgx {
-static int wasi_args_get(wasm_exec_env_t exec_env, int a, int b)
+static int wasi_args_get(wasm_exec_env_t exec_env,
+                         uint32_t* argvOffsetsWasm,
+                         char* argvBuffWasm)
 {
-    // module->writeArgvToWamrMemory(argvOffsetsWasm, argvBuffWasm);
+    ocallLogDebug("S - wasi_args_get");
+
+    GET_EXECUTING_MODULE_AND_CHECK(exec_env);
+
+    module->writeArgvToWamrMemory(argvOffsetsWasm, argvBuffWasm);
+
     return 0;
 }
 

--- a/src/enclave/inside/env.cpp
+++ b/src/enclave/inside/env.cpp
@@ -24,13 +24,7 @@ static int wasi_args_sizes_get(wasm_exec_env_t exec_env,
 {
     ocallLogDebug("S - wasi_args_sizes_get");
 
-    std::shared_ptr<wasm::EnclaveWasmModule> module =
-      wasm::getExecutingEnclaveWasmModule(exec_env);
-    if (module == nullptr) {
-        ocallLogError(
-          "Error linking execution environment to registered modules");
-        return 1;
-    }
+    GET_EXECUTING_MODULE_AND_CHECK(exec_env);
 
     *argcWasm = module->getArgc();
     *argvBuffSizeWasm = module->getArgvBufferSize();

--- a/src/enclave/inside/env.cpp
+++ b/src/enclave/inside/env.cpp
@@ -1,21 +1,41 @@
+#include <enclave/inside/EnclaveWasmModule.h>
 #include <enclave/inside/native.h>
+#include <enclave/inside/ocalls.h>
+
+#include <string>
 
 namespace sgx {
 static int wasi_args_get(wasm_exec_env_t exec_env, int a, int b)
 {
+    // module->writeArgvToWamrMemory(argvOffsetsWasm, argvBuffWasm);
     return 0;
 }
 
-static int wasi_args_sizes_get(wasm_exec_env_t exec_env, int a, int b)
+static int wasi_args_sizes_get(wasm_exec_env_t exec_env,
+                               uint32_t* argcWasm,
+                               uint32_t* argvBuffSizeWasm)
 {
+    ocallLogDebug("S - wasi_args_sizes_get");
+
+    std::shared_ptr<wasm::EnclaveWasmModule> module =
+      wasm::getExecutingEnclaveWasmModule(exec_env);
+    if (module == nullptr) {
+        ocallLogError(
+          "Error linking execution environment to registered modules");
+        return 1;
+    }
+
+    *argcWasm = module->getArgc();
+    *argvBuffSizeWasm = module->getArgvBufferSize();
+
     return 0;
 }
 
 static void wasi_proc_exit(wasm_exec_env_t exec_env, int returnCode) {}
 
 static NativeSymbol wasiNs[] = {
-    REG_WASI_NATIVE_FUNC(args_get, "(ii)i"),
-    REG_WASI_NATIVE_FUNC(args_sizes_get, "(ii)i"),
+    REG_WASI_NATIVE_FUNC(args_get, "(**)i"),
+    REG_WASI_NATIVE_FUNC(args_sizes_get, "(**)i"),
     REG_WASI_NATIVE_FUNC(proc_exit, "(i)"),
 };
 

--- a/src/wamr/env.cpp
+++ b/src/wamr/env.cpp
@@ -31,8 +31,8 @@ uint32_t wasi_args_sizes_get(wasm_exec_env_t exec_env,
 
     WAMRWasmModule* module = getExecutingWAMRModule();
 
-    module->validateNativeAddress(argcWasm, sizeof(uint32_t));
-    module->validateNativeAddress(argvBuffSizeWasm, sizeof(uint32_t));
+    module->validateNativePointer(argcWasm, sizeof(uint32_t));
+    module->validateNativePointer(argvBuffSizeWasm, sizeof(uint32_t));
 
     *argcWasm = module->getArgc();
     *argvBuffSizeWasm = module->getArgvBufferSize();
@@ -61,8 +61,8 @@ uint32_t wasi_environ_sizes_get(wasm_exec_env_t exec_env,
     WAMRWasmModule* module = getExecutingWAMRModule();
     WasmEnvironment& wasmEnv = module->getWasmEnvironment();
 
-    module->validateNativeAddress(envCountWasm, sizeof(uint32_t));
-    module->validateNativeAddress(envBufferSizeWasm, sizeof(uint32_t));
+    module->validateNativePointer(envCountWasm, sizeof(uint32_t));
+    module->validateNativePointer(envBufferSizeWasm, sizeof(uint32_t));
 
     *envCountWasm = wasmEnv.getEnvCount();
     *envBufferSizeWasm = wasmEnv.getEnvBufferSize();

--- a/src/wamr/filesystem.cpp
+++ b/src/wamr/filesystem.cpp
@@ -77,7 +77,7 @@ static int32_t wasi_fd_fdstat_get(wasm_exec_env_t exec_env,
         return __WASI_EBADF;
     }
 
-    module->validateNativeAddress(statWasm, sizeof(__wasi_fdstat_t));
+    module->validateNativePointer(statWasm, sizeof(__wasi_fdstat_t));
 
     storage::FileDescriptor& fileDesc = fs.getFileDescriptor(fd);
     storage::Stat statNative = fileDesc.stat();
@@ -119,7 +119,7 @@ static int32_t doFileStat(uint32_t fd,
         return statNative.wasiErrno;
     }
 
-    module->validateNativeAddress(statWasm, sizeof(__wasi_filestat_t));
+    module->validateNativePointer(statWasm, sizeof(__wasi_filestat_t));
     statWasm->st_dev = statNative.st_dev;
     statWasm->st_ino = statNative.st_ino;
     statWasm->st_filetype = statNative.wasiFiletype;
@@ -171,7 +171,7 @@ static int32_t wasi_fd_prestat_get(wasm_exec_env_t exec_env,
         return __WASI_EBADF;
     }
 
-    module->validateNativeAddress(prestatWasm, sizeof(wasi_prestat_app_t));
+    module->validateNativePointer(prestatWasm, sizeof(wasi_prestat_app_t));
 
     storage::FileDescriptor& fileDesc =
       module->getFileSystem().getFileDescriptor(fd);
@@ -210,7 +210,7 @@ static int32_t wasi_fd_read(wasm_exec_env_t exec_env,
     }
 
     // Read from fd
-    module->validateNativeAddress(bytesRead, sizeof(int32_t));
+    module->validateNativePointer(bytesRead, sizeof(int32_t));
     *bytesRead =
       ::readv(fileDesc.getLinuxFd(), ioVecBuffNative.data(), ioVecCountWasm);
 
@@ -237,7 +237,7 @@ static int32_t wasi_fd_seek(wasm_exec_env_t exec_env,
     SPDLOG_DEBUG("S - fd_seek {} {} {}", fd, offset, whence);
 
     WAMRWasmModule* module = getExecutingWAMRModule();
-    module->validateNativeAddress(newOffset, sizeof(__wasi_filesize_t));
+    module->validateNativePointer(newOffset, sizeof(__wasi_filesize_t));
 
     storage::FileDescriptor& fileDesc =
       module->getFileSystem().getFileDescriptor(fd);
@@ -261,7 +261,7 @@ static int32_t wasi_fd_write(wasm_exec_env_t exec_env,
     storage::FileDescriptor& fileDesc = fileSystem.getFileDescriptor(fd);
 
     // Translate the app iovecs into native iovecs
-    module->validateNativeAddress(reinterpret_cast<void*>(ioVecBuffWasm),
+    module->validateNativePointer(reinterpret_cast<void*>(ioVecBuffWasm),
                                   sizeof(iovec_app_t) * ioVecCountWasm);
     std::vector<::iovec> ioVecBuffNative(ioVecCountWasm, (::iovec){});
     for (int i = 0; i < ioVecCountWasm; i++) {
@@ -276,7 +276,7 @@ static int32_t wasi_fd_write(wasm_exec_env_t exec_env,
     }
 
     // Write to fd
-    module->validateNativeAddress(bytesWritten, sizeof(int32_t));
+    module->validateNativePointer(bytesWritten, sizeof(int32_t));
     *bytesWritten =
       ::writev(fileDesc.getLinuxFd(), ioVecBuffNative.data(), ioVecCountWasm);
     if (*bytesWritten < 0) {
@@ -311,7 +311,7 @@ static int32_t wasi_path_filestat_get(wasm_exec_env_t exec_env,
                                       __wasi_filestat_t* statWasm)
 {
     WAMRWasmModule* module = getExecutingWAMRModule();
-    module->validateNativeAddress(path, pathLen);
+    module->validateNativePointer(path, pathLen);
     const std::string pathStr(path, pathLen);
 
     SPDLOG_DEBUG("S - path_filestat_get {} ({})", fd, pathStr);
@@ -345,12 +345,12 @@ static int32_t wasi_path_open(wasm_exec_env_t exec_env,
 {
     WAMRWasmModule* module = getExecutingWAMRModule();
 
-    module->validateNativeAddress(path, pathLen);
+    module->validateNativePointer(path, pathLen);
     const std::string pathStr(path, pathLen);
 
     SPDLOG_DEBUG("S - path_open {} {} {}", fdNative, pathStr, pathLen);
 
-    module->validateNativeAddress(fdWasm, sizeof(int32_t));
+    module->validateNativePointer(fdWasm, sizeof(int32_t));
     *fdWasm = module->getFileSystem().openFileDescriptor(fdNative,
                                                          pathStr,
                                                          rightsBase,

--- a/tests/test/enclave/test_enclave.cpp
+++ b/tests/test/enclave/test_enclave.cpp
@@ -9,17 +9,23 @@
 using namespace wasm;
 
 namespace tests {
-TEST_CASE_METHOD(FunctionExecTestFixture,
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test executing hello function with SGX",
                  "[sgx]")
 {
-    executeWithSGX("demo", "hello");
+    auto req = setUpContext("demo", "hello");
+    faabric::Message& msg = req->mutable_messages()->at(0);
+
+    execSgxFunction(msg);
 }
 
-TEST_CASE_METHOD(FunctionExecTestFixture,
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test executing chaining by name with SGX",
                  "[sgx]")
 {
-    executeWithSGX("demo", "chain_named_a", 10000);
+    auto req = setUpContext("demo", "hello");
+    faabric::Message& msg = req->mutable_messages()->at(0);
+
+    execFuncWithSgxPool(msg, 10000);
 }
 }

--- a/tests/test/faaslet/test_env.cpp
+++ b/tests/test/faaslet/test_env.cpp
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test argc/argv",
-                 "[faaslet][wamr]")
+                 "[faaslet]")
 {
     auto req = setUpContext("demo", "argc_argv_test");
     faabric::Message& msg = req->mutable_messages()->at(0);
@@ -88,6 +88,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
     SECTION("WAVM") { execFunction(msg); }
 
     SECTION("WAMR") { execWamrFunction(msg); }
+
+    SECTION("SGX") { execSgxFunction(msg); }
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,

--- a/tests/utils/utils.h
+++ b/tests/utils/utils.h
@@ -29,9 +29,10 @@ void executeWithWamrPool(const std::string& user,
                          const std::string& func,
                          int timeout = 1000);
 
-void executeWithSGX(const std::string& user,
-                    const std::string& func,
-                    int timeout = 1000);
+void execSgxFunction(faabric::Message& call,
+                     const std::string& expectedOutput = "");
+
+void execFuncWithSgxPool(faabric::Message& call, int timeout = 1000);
 
 void checkMultipleExecutions(faabric::Message& msg, int nExecs);
 

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -14,7 +14,9 @@
 #include <faaslet/Faaslet.h>
 
 #include <conf/FaasmConfig.h>
+#if (FAASM_SGX)
 #include <enclave/outside/EnclaveInterface.h>
+#endif
 #include <wamr/WAMRWasmModule.h>
 #include <wavm/WAVMWasmModule.h>
 
@@ -222,6 +224,7 @@ void executeWithWamrPool(const std::string& user,
 
 void execSgxFunction(faabric::Message& call, const std::string& expectedOutput)
 {
+#if (FAASM_SGX)
     conf::FaasmConfig& conf = conf::getFaasmConfig();
     const std::string originalVm = conf.wasmVm;
     conf.wasmVm = "sgx";
@@ -239,10 +242,14 @@ void execSgxFunction(faabric::Message& call, const std::string& expectedOutput)
     REQUIRE(call.returnvalue() == 0);
 
     conf.wasmVm = originalVm;
+#else
+    SPDLOG_ERROR("Running SGX test but SGX is disabled");
+#endif
 }
 
 void execFuncWithSgxPool(faabric::Message& call, int timeout)
 {
+#if (FAASM_SGX)
     conf::FaasmConfig& conf = conf::getFaasmConfig();
     const std::string originalVm = conf.wasmVm;
     conf.wasmVm = "sgx";
@@ -251,6 +258,9 @@ void execFuncWithSgxPool(faabric::Message& call, int timeout)
     execFuncWithPool(call, false, timeout);
 
     conf.wasmVm = originalVm;
+#else
+    SPDLOG_ERROR("Running SGX test but SGX is disabled");
+#endif
 }
 
 void checkCallingFunctionGivesBoolOutput(const std::string& user,


### PR DESCRIPTION
In this PR I implement the WASI calls to access `argc` and `argv` inside SGX: `wasi_args_get` and `wasi_args_sizes_get`. The immediate consequence is that now the test function: `demo/argc_argv_test` also runs on SGX.

The bulk of the implementation is almost copied from WAMR's (`src/wamr/env.cpp`), and requires no OCalls. The only major change to the OCall/ECall interface is that we now pass `argc` and `argv` to the `ecallCallFunction` call. Note that the OCall/ECall interface forces us to serialise `argv` into a byte array, which means some more work.

In addition, I re-factor the utility functions to run SGX tests to match the WAVM and WAMR counterparts: now we have `execFunction`, `execWamrFunction`,  `execSgxFunction`, and `execFuncWithPool`, `execFuncWithWamrPool`, and `execFuncWithSgxPool`.