### PR TITLE
Update experiment links on docs homepage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,8 +26,9 @@ Our paper from Usenix ATC '20 on Faasm can be found `here
 Experiments and benchmarks:
 
 - `Microbenchmarks (C++ and Python) <https://github.com/faasm/experiment-microbench/>`_
-- `MPI <https://github.com/faasm/experiment-mpi>`_
-- `OpenMP <https://github.com/faasm/experiment-openmp>`_
+- `MPI (LAMMPS + ParRes Kernels) <https://github.com/faasm/experiment-mpi>`_
+- `OpenMP (CovidSim + LULESH + ParRes Kernels) <https://github.com/faasm/experiment-openmp>`_
+- `SGX (Image pipeline) <https://github.com/faasm/experiment-sgx>`_
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Update listing on https://faasm.readthedocs.io/en/latest/.

This will become the single list of experiments (so that we only have to maintain it in one place).