### PR TITLE
Bare metal k8s deployments

### DIFF
--- a/docs/source/kubernetes.md
+++ b/docs/source/kubernetes.md
@@ -55,6 +55,8 @@ number of replicas.
 
 The deploy can take up to a couple of minutes.
 
+## Faasm config file
+
 Once everything has started up, Faasm should also generate a config file,
 `faasm.ini` at root of this project. This contains the relevant endpoints for
 accessing the Faasm deployment.
@@ -64,6 +66,24 @@ If you need to regenerate this, you can run:
 ```bash
 inv knative.ini-file
 ```
+
+*If you are running on a bare metal cluster (i.e. not as part of a managed k8s
+service like AKS), you'll need to run the following instead:*
+
+```bash
+inv knative.ini-file --publicip <ip of one of your hosts>
+```
+
+This is because Faasm normally assumes different public IPs for the upload and
+invocation services, which are created as k8s `LoadBalancer`s in a cloud
+provider. The command above instead uses the underlying `NodePort`s from those
+`LoadBalancers`, by hitting one of the underlying hosts directly.
+
+Unfortunately it's often not possible to query this public IP from within
+`kubectl` itself, so you have to tell Faasm what it is explicitly.
+
+Also make sure that all the ports mentioned in the Faasm config file are
+accessible via your hosts' firewall rules.
 
 ## Uploading and invoking functions
 

--- a/faasmcli/faasmcli/tasks/knative.py
+++ b/faasmcli/faasmcli/tasks/knative.py
@@ -323,8 +323,11 @@ def ini_file(ctx, local=False, publicip=None):
     print("Overwriting config file at {}\n".format(FAASM_CONFIG_FILE))
 
     with open(FAASM_CONFIG_FILE, "w") as fh:
-        fh.write("# Auto-generated at {}\n".format(datetime.now()))
         fh.write("[Faasm]\n")
+
+        # This comment line can't be outside of the Faasm section
+        fh.write("# Auto-generated at {}\n".format(datetime.now()))
+
         fh.write("invoke_host = {}\n".format(invoke_ip))
         fh.write("invoke_port = {}\n".format(invoke_port))
         fh.write("upload_host = {}\n".format(upload_ip))


### PR DESCRIPTION
Small changes around Faasm config file for deployment outside of a managed k8s service (i.e. one where `LoadBalancer`s that expose public IPs don't exist).