### PR TITLE
Writeable shared files

### DIFF
--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -27,6 +27,7 @@ WAMR_ALLOWED_FUNCS = [
     ["demo", "filedescriptor"],
     ["demo", "fstat"],
     ["demo", "fread"],
+    ["demo", "shared_file"],
     # Input output
     ["demo", "check_input"],
     ["demo", "echo"],

--- a/faasmcli/faasmcli/tasks/files.py
+++ b/faasmcli/faasmcli/tasks/files.py
@@ -1,5 +1,5 @@
 from invoke import task
-from subprocess import run
+import requests
 
 from faasmcli.util.endpoints import get_upload_host_port
 from faasmcli.util.upload_util import curl_file
@@ -17,7 +17,7 @@ def upload(ctx, in_path, shared_path):
     Uploads a shared file
     """
     url = get_file_url()
-    print("Uploading {} to {} ({})".format(in_path, shared_path, url))
+    print("Uploading {} to {} (at {})".format(in_path, shared_path, url))
 
     curl_file(
         url,
@@ -34,10 +34,14 @@ def download(ctx, shared_path, out_path):
     Downloads a shared file
     """
     url = get_file_url()
-    print("Downloading {} to {} ({})".format(shared_path, out_path, url))
+    print("Downloading {} to {} (from {})".format(shared_path, out_path, url))
 
-    cmd = ["curl", "-X", "GET", url, "-o", out_path]
-    cmd = " ".join(cmd)
+    resp = requests.get(
+        url,
+        headers={
+            "FilePath": shared_path,
+        },
+    )
 
-    print(cmd)
-    run(cmd, shell=True, check=True)
+    with open(out_path, "wb") as fh:
+        fh.write(resp.content)

--- a/faasmcli/faasmcli/tasks/files.py
+++ b/faasmcli/faasmcli/tasks/files.py
@@ -25,3 +25,10 @@ def upload(ctx, in_path, shared_path):
             "FilePath": shared_path,
         },
     )
+
+
+@task
+def download(ctx, shared_path, out_path):
+    host, port = get_upload_host_port()
+
+    # TODO - implement

--- a/faasmcli/faasmcli/tasks/files.py
+++ b/faasmcli/faasmcli/tasks/files.py
@@ -1,22 +1,23 @@
 from invoke import task
-
-from os.path import basename
+from subprocess import run
 
 from faasmcli.util.endpoints import get_upload_host_port
 from faasmcli.util.upload_util import curl_file
 
 
+def get_file_url():
+    host, port = get_upload_host_port()
+    url = "http://{}:{}/file/".format(host, port)
+    return url
+
+
 @task(default=True)
 def upload(ctx, in_path, shared_path):
     """
-    Upload a shared file to Faasm
+    Uploads a shared file
     """
-    host, port = get_upload_host_port()
-
-    url = "http://{}:{}/file/".format(host, port)
-
-    local_filename = basename(in_path)
-    print("Uploading {} to {}".format(local_filename, shared_path))
+    url = get_file_url()
+    print("Uploading {} to {} ({})".format(in_path, shared_path, url))
 
     curl_file(
         url,
@@ -29,6 +30,14 @@ def upload(ctx, in_path, shared_path):
 
 @task
 def download(ctx, shared_path, out_path):
-    host, port = get_upload_host_port()
+    """
+    Downloads a shared file
+    """
+    url = get_file_url()
+    print("Downloading {} to {} ({})".format(shared_path, out_path, url))
 
-    # TODO - implement
+    cmd = ["curl", "-X", "GET", url, "-o", out_path]
+    cmd = " ".join(cmd)
+
+    print(cmd)
+    run(cmd, shell=True, check=True)

--- a/include/storage/FileDescriptor.h
+++ b/include/storage/FileDescriptor.h
@@ -115,6 +115,8 @@ class FileDescriptor
 
     bool updateFlags(int32_t fdFlags);
 
+    ssize_t write(std::vector<::iovec>& nativeIovecs, int iovecCount);
+
     void close() const;
 
     bool mkdir(const std::string& dirPath);

--- a/include/storage/FileLoader.h
+++ b/include/storage/FileLoader.h
@@ -94,6 +94,8 @@ class FileLoader
 
     std::vector<uint8_t> loadSharedFile(const std::string& path);
 
+    void deleteSharedFile(const std::string& path);
+
     void uploadSharedFile(const std::string& path,
                           const std::vector<uint8_t>& fileBytes);
 
@@ -139,6 +141,14 @@ class FileLoader
 FileLoader& getFileLoader();
 
 FileLoader& getFileLoaderWithoutLocalCache();
+
+class SharedFileNotExistsException : public faabric::util::FaabricException
+{
+  public:
+    explicit SharedFileNotExistsException(const std::string& filePath)
+      : faabric::util::FaabricException(filePath + " does not exist")
+    {}
+};
 
 class SharedFileIsDirectoryException : public faabric::util::FaabricException
 {

--- a/include/storage/SharedFiles.h
+++ b/include/storage/SharedFiles.h
@@ -11,11 +11,15 @@ class SharedFiles
     static int syncSharedFile(const std::string& sharedPath,
                               const std::string& localPath = "");
 
+    static void clearCacheForSharedFile(const std::string& sharedPath);
+
     static std::string realPathForSharedFile(const std::string& sharedPath);
 
     static std::string stripSharedPrefix(const std::string& sharedPath);
 
     static bool isPathShared(const std::string& p);
+
+    static void deleteSharedFile(const std::string& p);
 
     static void syncPythonFunctionFile(const faabric::Message& msg);
 

--- a/include/storage/SharedFiles.h
+++ b/include/storage/SharedFiles.h
@@ -21,6 +21,8 @@ class SharedFiles
 
     static void deleteSharedFile(const std::string& p);
 
+    static void updateSharedFile(const std::string& p);
+
     static void syncPythonFunctionFile(const faabric::Message& msg);
 
     static void clear();

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -499,10 +499,8 @@ std::vector<uint8_t> FileLoader::loadSharedFile(const std::string& path)
 void FileLoader::deleteSharedFile(const std::string& path)
 {
     std::string pathCopy = trimLeadingSlashes(path);
-    SPDLOG_TRACE("Deleting shared file {} in S3 at {}/{}",
-                 path,
-                 conf.s3Bucket,
-                 pathCopy);
+    SPDLOG_TRACE(
+      "Deleting shared file {} in S3 at {}/{}", path, conf.s3Bucket, pathCopy);
     s3.deleteKey(conf.s3Bucket, pathCopy);
 
     const std::string localCachePath = getSharedFileFile(path);

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -2,8 +2,6 @@
 #include <storage/FileLoader.h>
 #include <storage/SharedFiles.h>
 
-#include <stdexcept>
-
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/files.h>
@@ -11,6 +9,7 @@
 #include <faabric/util/testing.h>
 
 #include <filesystem>
+#include <stdexcept>
 
 using namespace faabric::util;
 
@@ -486,7 +485,30 @@ std::string FileLoader::getSharedFileFile(const std::string& path)
 
 std::vector<uint8_t> FileLoader::loadSharedFile(const std::string& path)
 {
-    return loadFileBytes(path, getSharedFileFile(path));
+    // Tolerate missing, throw exception if file doesn't exist
+    std::vector<uint8_t> bytes =
+      loadFileBytes(path, getSharedFileFile(path), true);
+
+    if (bytes.empty()) {
+        throw SharedFileNotExistsException(path);
+    }
+
+    return bytes;
+}
+
+void FileLoader::deleteSharedFile(const std::string& path)
+{
+    std::string pathCopy = trimLeadingSlashes(path);
+    SPDLOG_TRACE("Caching deleting shared file {} in S3 at {}/{}",
+                 path,
+                 conf.s3Bucket,
+                 pathCopy);
+    s3.deleteKey(conf.s3Bucket, pathCopy);
+
+    const std::string localCachePath = getSharedFileFile(path);
+    if (useLocalFsCache && !localCachePath.empty()) {
+        std::filesystem::remove(localCachePath);
+    }
 }
 
 void FileLoader::uploadSharedFile(const std::string& path,

--- a/src/storage/FileLoader.cpp
+++ b/src/storage/FileLoader.cpp
@@ -499,7 +499,7 @@ std::vector<uint8_t> FileLoader::loadSharedFile(const std::string& path)
 void FileLoader::deleteSharedFile(const std::string& path)
 {
     std::string pathCopy = trimLeadingSlashes(path);
-    SPDLOG_TRACE("Caching deleting shared file {} in S3 at {}/{}",
+    SPDLOG_TRACE("Deleting shared file {} in S3 at {}/{}",
                  path,
                  conf.s3Bucket,
                  pathCopy);

--- a/src/storage/SharedFiles.cpp
+++ b/src/storage/SharedFiles.cpp
@@ -49,6 +49,15 @@ bool SharedFiles::isPathShared(const std::string& p)
     return faabric::util::startsWith(p, SHARED_FILE_PREFIX);
 }
 
+void SharedFiles::deleteSharedFile(const std::string& p)
+{
+    FileLoader& loader = getFileLoader();
+    std::string relativePath = stripSharedPrefix(p);
+    loader.deleteSharedFile(relativePath);
+
+    clearCacheForSharedFile(relativePath);
+}
+
 int getReturnValueForSharedFileState(const std::string& sharedPath)
 {
     FileState& state = sharedFileMap[sharedPath];
@@ -66,14 +75,30 @@ int getReturnValueForSharedFileState(const std::string& sharedPath)
     }
 }
 
+void SharedFiles::clearCacheForSharedFile(const std::string& sharedPath)
+{
+    SPDLOG_TRACE("Clearing shared file cache for {}", sharedPath);
+    faabric::util::FullLock lock(sharedFileMapMutex);
+
+    sharedFileMap.erase(sharedPath);
+}
+
 int SharedFiles::syncSharedFile(const std::string& sharedPath,
                                 const std::string& localPath)
 {
     // See if file already synced
     {
         faabric::util::SharedLock lock(sharedFileMapMutex);
-        if (sharedFileMap.count(sharedPath) > 0) {
-            SPDLOG_TRACE("Not syncing {}, cached at {}", sharedPath, localPath);
+        if (sharedFileMap.find(sharedPath) != sharedFileMap.end()) {
+            if (localPath.empty()) {
+                SPDLOG_TRACE("Not syncing shared file {}, already checked",
+                             sharedPath);
+            } else {
+                SPDLOG_TRACE("Not syncing shared file {}, cached at {}",
+                             sharedPath,
+                             localPath);
+            }
+
             return getReturnValueForSharedFileState(sharedPath);
         }
     }
@@ -87,7 +112,11 @@ int SharedFiles::syncSharedFile(const std::string& sharedPath,
         return getReturnValueForSharedFileState(sharedPath);
     }
 
-    SPDLOG_TRACE("Syncing {} to {}", sharedPath, localPath);
+    if (localPath.empty()) {
+        SPDLOG_TRACE("Syncing shared file {}", sharedPath);
+    } else {
+        SPDLOG_TRACE("Syncing shared file {} to {}", sharedPath, localPath);
+    }
 
     // Work out the real path
     std::string strippedPath =
@@ -119,6 +148,8 @@ int SharedFiles::syncSharedFile(const std::string& sharedPath,
             bytes = loader.loadSharedFile(strippedPath);
         } catch (storage::SharedFileIsDirectoryException& e) {
             isDir = true;
+        } catch (storage::SharedFileNotExistsException& e) {
+            // Tolerate not existing
         }
 
         // Handle directories and files accordingly

--- a/src/storage/SharedFiles.cpp
+++ b/src/storage/SharedFiles.cpp
@@ -58,6 +58,15 @@ void SharedFiles::deleteSharedFile(const std::string& p)
     clearCacheForSharedFile(relativePath);
 }
 
+void SharedFiles::updateSharedFile(const std::string& p)
+{
+    FileLoader& loader = getFileLoader();
+    std::string relativePath = stripSharedPrefix(p);
+
+    std::vector<uint8_t> bytes = loader.loadSharedFile(relativePath);
+    loader.uploadSharedFile(relativePath, bytes);
+}
+
 int getReturnValueForSharedFileState(const std::string& sharedPath)
 {
     FileState& state = sharedFileMap[sharedPath];

--- a/src/wamr/filesystem.cpp
+++ b/src/wamr/filesystem.cpp
@@ -258,11 +258,12 @@ static int32_t wasi_fd_write(wasm_exec_env_t exec_env,
 
     SPDLOG_DEBUG("S - fd_write {} ({})", fd, path);
 
-    storage::FileDescriptor& fileDesc = fileSystem.getFileDescriptor(fd);
-
-    // Translate the app iovecs into native iovecs
+    // Check pointers
     module->validateNativePointer(reinterpret_cast<void*>(ioVecBuffWasm),
                                   sizeof(iovec_app_t) * ioVecCountWasm);
+    module->validateNativePointer(bytesWritten, sizeof(int32_t));
+
+    // Translate the app iovecs into native iovecs
     std::vector<::iovec> ioVecBuffNative(ioVecCountWasm, (::iovec){});
     for (int i = 0; i < ioVecCountWasm; i++) {
         module->validateWasmOffset(ioVecBuffWasm[i].buffOffset,
@@ -275,14 +276,16 @@ static int32_t wasi_fd_write(wasm_exec_env_t exec_env,
         };
     }
 
-    // Write to fd
-    module->validateNativePointer(bytesWritten, sizeof(int32_t));
-    *bytesWritten =
-      ::writev(fileDesc.getLinuxFd(), ioVecBuffNative.data(), ioVecCountWasm);
-    if (*bytesWritten < 0) {
+    // Do the write
+    storage::FileDescriptor& fileDesc = fileSystem.getFileDescriptor(fd);
+    ssize_t n = fileDesc.write(ioVecBuffNative, ioVecCountWasm);
+    if (n < 0) {
         SPDLOG_ERROR(
           "writev failed on fd {}: {}", fileDesc.getLinuxFd(), strerror(errno));
     }
+
+    // Write number of bytes to wasm
+    *bytesWritten = n;
 
     // Capture stdout if needed
     conf::FaasmConfig& conf = conf::getFaasmConfig();

--- a/tests/test/faaslet/test_shared_files.cpp
+++ b/tests/test/faaslet/test_shared_files.cpp
@@ -24,31 +24,26 @@ TEST_CASE_METHOD(LocalFixture,
                  "Test accessing shared files from wasm",
                  "[faaslet]")
 {
-    // Set up a dummy file location
-    std::string relativePath = "test/shared-wasm.txt";
+    // Make sure file is deleted locally first
+    std::string relativePath = "some_dir/test_file.txt";
     std::string fullPath = loader.getSharedFileFile(relativePath);
     boost::filesystem::remove(fullPath);
 
-    // Upload some data
-    std::string expected = "I am some test content\r";
-    std::vector<uint8_t> expectedBytes = faabric::util::stringToBytes(expected);
-    loader.uploadSharedFile(relativePath, expectedBytes);
-
-    // Check file now exists, then delete
-    REQUIRE(boost::filesystem::exists(fullPath));
-    boost::filesystem::remove(fullPath);
-
-    // Set up the function
+    // Execute the function
     auto req = setUpContext("demo", "shared_file");
-    faabric::Message& msg = req->mutable_messages()->at(0);
-    std::string sharedPath = std::string(SHARED_FILE_PREFIX) + relativePath;
-    msg.set_inputdata(sharedPath);
-
-    // Invoke the function and make sure result is echoing the file content
-    std::string actual = execFunctionWithStringResult(msg);
-    REQUIRE(actual == expected);
+    execFunction(req);
 
     // Check file has been synced locally
     REQUIRE(boost::filesystem::exists(fullPath));
+
+    // Check contents locally
+    std::string expected = "This is some dummy content";
+    std::string actual = faabric::util::readFileToString(fullPath);
+    REQUIRE(actual == expected);
+
+    // Check contents from S3
+    REQUIRE(s3.listKeys(conf.s3Bucket).size() == 1);
+    std::string s3Actual = s3.getKeyStr(conf.s3Bucket, relativePath);
+    REQUIRE(s3Actual == expected);
 }
 }


### PR DESCRIPTION
Allow shared files to be:

- Non-existent (i.e. return proper error when trying to stat one that doesn't exist)
- Deletable
- Writeable

To support code like: https://github.com/faasm/cpp/pull/87
