### PR TITLE
Latest WAMR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -131,7 +131,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitiser: [None, Address, Thread, Undefined, Leak]
+        # 08/06/2022 - Disable Thread sanitiser build as it exhausts all the
+        # memory available in GHA runners
+        sanitiser: [None, Address, Undefined, Leak]
     env:
       CGROUP_MODE: off
       HOST_TYPE: ci
@@ -141,7 +143,6 @@ jobs:
       REDIS_STATE_HOST: redis
       ASAN_OPTIONS: "halt_on_error=1"
       LSAN_OPTIONS: "suppressions=/usr/local/code/faasm/leak-sanitizer-ignorelist.txt"
-      TSAN_OPTIONS: "halt_on_error=1:suppressions=/usr/local/code/faasm/thread-sanitizer-ignorelist.txt:history_size=7:second_deadlock_stack=1"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
     container:
       image: faasm/cli:0.8.12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,6 +158,41 @@ jobs:
         ports:
           - 9000:9000
     steps:
+      # Some sanitised jobs run out of memory in the GH runner, so we increase
+      # the swap space here
+      - name: "Sudo test"
+        run: sudo ls
+      - name: Swap space report before modification
+        run: |
+          echo "Memory and swap:"
+          free -h
+          echo
+          swapon --show
+          echo
+      - name: "Get the SWAP file"
+        run: echo "SWAP_FILE=$(swapon --show=NAME | tail -n 1)" >> $GITHUB_ENV
+      - name: "Try once"
+        run: sudo swapoff ${{ env.SWAP_FILE }}
+      - name: Set Swap
+        run: |
+            export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
+            sudo swapoff $SWAP_FILE
+            sudo rm $SWAP_FILE
+            sudo fallocate -l ${{ inputs.swap-size-gb }}G $SWAP_FILE
+            sudo chmod 600 $SWAP_FILE
+            sudo mkswap $SWAP_FILE
+            sudo swapon $SWAP_FILE
+      - name: Swap space report after modification
+        run: |
+          echo "Memory and swap:"
+          free -h
+          echo
+          swapon --show
+          echo
+        #       - name: "Increase swap space"
+        #         uses: pierotofy/set-swap-space@master
+        #         with:
+        #           swap-size-gb: 4
       - name: "Conan cache"
         uses: faasm/conan-cache-action@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -158,41 +158,6 @@ jobs:
         ports:
           - 9000:9000
     steps:
-      # Some sanitised jobs run out of memory in the GH runner, so we increase
-      # the swap space here
-      - name: "Sudo test"
-        run: sudo ls
-      - name: Swap space report before modification
-        run: |
-          echo "Memory and swap:"
-          free -h
-          echo
-          swapon --show
-          echo
-      - name: "Get the SWAP file"
-        run: echo "SWAP_FILE=$(swapon --show=NAME | tail -n 1)" >> $GITHUB_ENV
-      - name: "Try once"
-        run: sudo swapoff ${{ env.SWAP_FILE }}
-      - name: Set Swap
-        run: |
-            export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
-            sudo swapoff $SWAP_FILE
-            sudo rm $SWAP_FILE
-            sudo fallocate -l ${{ inputs.swap-size-gb }}G $SWAP_FILE
-            sudo chmod 600 $SWAP_FILE
-            sudo mkswap $SWAP_FILE
-            sudo swapon $SWAP_FILE
-      - name: Swap space report after modification
-        run: |
-          echo "Memory and swap:"
-          free -h
-          echo
-          swapon --show
-          echo
-        #       - name: "Increase swap space"
-        #         uses: pierotofy/set-swap-space@master
-        #         with:
-        #           swap-size-gb: 4
       - name: "Conan cache"
         uses: faasm/conan-cache-action@v1
         with:

--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -116,7 +116,7 @@ FetchContent_Declare(wavm_ext
 
 FetchContent_Declare(wamr_ext
     GIT_REPOSITORY "https://github.com/faasm/wasm-micro-runtime"
-    GIT_TAG "5ac9493230902dd6ffdcbef0eeb6d5cc20fa81df"
+    GIT_TAG "78274abbaa34a9b68af7d1fbe71e7b66d9d3ca02"
 )
 
 # WAMR and WAVM both link to LLVM

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -22,6 +22,8 @@ WAMR_ALLOWED_FUNCS = [
     ["demo", "exit"],
     ["demo", "getenv"],
     ["errors", "ret_one"],
+    # Memory
+    ["demo", "brk"],
     # Filesystem
     ["demo", "fcntl"],
     ["demo", "file"],

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -29,6 +29,8 @@ class WAMRWasmModule final
     ~WAMRWasmModule();
 
     // ----- Module lifecycle -----
+    void reset(faabric::Message& msg, const std::string& snapshotKey) override;
+
     void doBindToFunction(faabric::Message& msg, bool cache) override;
 
     int32_t executeFunction(faabric::Message& msg) override;
@@ -68,15 +70,16 @@ class WAMRWasmModule final
   private:
     char errorBuffer[ERROR_BUFFER_SIZE];
 
+    std::vector<uint8_t> wasmBytes;
     WASMModuleCommon* wasmModule;
     WASMModuleInstanceCommon* moduleInstance;
 
     int executeWasmFunction(const std::string& funcName);
 
     int executeWasmFunctionFromPointer(int wasmFuncPtr);
+
+    void bindInternal(faabric::Message& msg);
 };
 
 WAMRWasmModule* getExecutingWAMRModule();
-
-void tearDownWAMRGlobally();
 }

--- a/leak-sanitizer-ignorelist.txt
+++ b/leak-sanitizer-ignorelist.txt
@@ -5,3 +5,5 @@ leak:EVP_CIPHER_CTX_new
 leak:EVP_EncryptInit_ex
 # Global WAVM modules
 leak:wasm::instantiateBaseModules
+# WAMR leaks
+leak:/build/faasm/_deps/wamr_ext-src/core/shared/platform/common/posix/posix_malloc.c

--- a/src/wamr/CMakeLists.txt
+++ b/src/wamr/CMakeLists.txt
@@ -7,6 +7,9 @@ set(WAMR_BUILD_PLATFORM "linux")
 set(WAMR_BUILD_TARGET X86_64)
 set(WAMR_BUILD_SPEC_TEST 0)
 
+# Top-level Faasm flag for WAMR
+add_definitions(-DWAMR_FAASM=1)
+
 # Set AOT mode and JIT for code generation
 set(WAMR_BUILD_AOT 1)
 set(WAMR_BUILD_JIT 1)
@@ -25,8 +28,10 @@ set(WAMR_BUILD_MULTI_MODULE 1)
 # management model
 set(WAMR_BUILD_BULK_MEMORY 0)
 
-# Explicitely set to 0. If set to 1, WAMR will allocate the module's instance
-# memory using `malloc` instead of `mmap` and calls to `mprotect` fail.
+# We must enable WAMR hardware bounds check here, otherwise WAMR uses malloc to
+# allocate memory, which is not page-aligned. This seems like a blunt instrument
+# to solve a smal problem, but this parameter is deeply embedded in the WAMR
+# code, and it's difficult to change it surgically.
 set(WAMR_DISABLE_HW_BOUND_CHECK 0)
 # This definition prevents a buffer underflow during code generation
 add_definitions(-DWASM_ENABLE_WAMR_COMPILER=1)

--- a/src/wamr/CMakeLists.txt
+++ b/src/wamr/CMakeLists.txt
@@ -47,6 +47,11 @@ faasm_private_lib(wamrlib "${WAMR_RUNTIME_LIB_SOURCE}")
 target_compile_options(wamrlib PRIVATE
     -Wno-typedef-redefinition
     -Wno-unused-command-line-argument
+    # We comment out some problematic LLVM code in WAMR. Commenting out triggers
+    # compilation warnings that we suppress
+    -Wno-ambiguous-reversed-operator
+    -Wno-unused-function
+    -Wno-deprecated-enum-enum-conversion
 )
 
 # -----------------------------

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -22,35 +22,30 @@ namespace wasm {
 // The high level API for WAMR can be found here:
 // https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/core/iwasm/include/wasm_export.h
 static bool wamrInitialised = false;
-std::mutex wamrInitMx;
+
+// WAMR maintains some global state, which we must be careful not to modify
+// concurrently from our side. We are deliberately cautious with this locking,
+// so it may cause performance issues under high churn of short-lived functions.
+static std::mutex wamrGlobalsMutex;
 
 void WAMRWasmModule::initialiseWAMRGlobally()
 {
+    faabric::util::UniqueLock lock(wamrGlobalsMutex);
+
     if (wamrInitialised) {
         return;
-    } else {
-        faabric::util::UniqueLock lock(wamrInitMx);
-
-        if (wamrInitialised) {
-            return;
-        }
-
-        // Initialise WAMR runtime
-        bool success = wasm_runtime_init();
-        if (!success) {
-            throw std::runtime_error("Failed to initialise WAMR");
-        }
-
-        SPDLOG_DEBUG("Successfully initialised WAMR");
-
-        // Initialise Faasm's own native symbols
-        initialiseWAMRNatives();
     }
-}
 
-void tearDownWAMRGlobally()
-{
-    wasm_runtime_destroy();
+    // Initialise WAMR runtime
+    bool success = wasm_runtime_init();
+    if (!success) {
+        throw std::runtime_error("Failed to initialise WAMR");
+    }
+
+    SPDLOG_DEBUG("Successfully initialised WAMR");
+
+    // Initialise Faasm's own native symbols
+    initialiseWAMRNatives();
 }
 
 WAMRWasmModule::WAMRWasmModule()
@@ -66,6 +61,11 @@ WAMRWasmModule::WAMRWasmModule(int threadPoolSizeIn)
 
 WAMRWasmModule::~WAMRWasmModule()
 {
+    SPDLOG_TRACE(
+      "Destructing WAMR wasm module {}/{}", boundUser, boundFunction);
+
+    faabric::util::UniqueLock lock(wamrGlobalsMutex);
+
     wasm_runtime_deinstantiate(moduleInstance);
     wasm_runtime_unload(wasmModule);
 }
@@ -76,38 +76,74 @@ WAMRWasmModule* getExecutingWAMRModule()
 }
 
 // ----- Module lifecycle -----
+
+void WAMRWasmModule::reset(faabric::Message& msg,
+                           const std::string& snapshotKey)
+{
+    if (!_isBound) {
+        return;
+    }
+
+    std::string funcStr = faabric::util::funcToString(msg, true);
+    SPDLOG_DEBUG("WAMR resetting after {} (snap key {})", funcStr, snapshotKey);
+
+    bindInternal(msg);
+}
+
 void WAMRWasmModule::doBindToFunction(faabric::Message& msg, bool cache)
 {
+    SPDLOG_TRACE("WAMR binding to {}/{} via message {}",
+                 msg.user(),
+                 msg.function(),
+                 msg.id());
+
     // Prepare the filesystem
     filesystem.prepareFilesystem();
 
     // Load the wasm file
     storage::FileLoader& functionLoader = storage::getFileLoader();
-    std::vector<uint8_t> wasmBytes =
-      functionLoader.loadFunctionWamrAotFile(msg);
+    wasmBytes = functionLoader.loadFunctionWamrAotFile(msg);
 
-    // Load wasm module
-    wasmModule = wasm_runtime_load(
-      wasmBytes.data(), wasmBytes.size(), errorBuffer, ERROR_BUFFER_SIZE);
+    {
+        faabric::util::UniqueLock lock(wamrGlobalsMutex);
+        SPDLOG_TRACE("WAMR loading {} wasm bytes\n", wasmBytes.size());
+        wasmModule = wasm_runtime_load(
+          wasmBytes.data(), wasmBytes.size(), errorBuffer, ERROR_BUFFER_SIZE);
 
-    if (wasmModule == nullptr) {
-        std::string errorMsg = std::string(errorBuffer);
-        SPDLOG_ERROR("Failed to load WAMR module: \n{}", errorMsg);
-        throw std::runtime_error("Failed to load WAMR module");
+        if (wasmModule == nullptr) {
+            std::string errorMsg = std::string(errorBuffer);
+            SPDLOG_ERROR("Failed to load WAMR module: \n{}", errorMsg);
+            throw std::runtime_error("Failed to load WAMR module");
+        }
     }
 
+    bindInternal(msg);
+}
+
+void WAMRWasmModule::bindInternal(faabric::Message& msg)
+{
     // Instantiate module
     moduleInstance = wasm_runtime_instantiate(
       wasmModule, STACK_SIZE_KB, HEAP_SIZE_KB, errorBuffer, ERROR_BUFFER_SIZE);
+
+    // Sense-check the module
+    auto* aotModule = reinterpret_cast<AOTModuleInstance*>(moduleInstance);
+    AOTMemoryInstance* aotMem =
+      ((AOTMemoryInstance**)aotModule->memories.ptr)[0];
+
+    if (aotMem->num_bytes_per_page != WASM_BYTES_PER_PAGE) {
+        SPDLOG_ERROR("WAMR module bytes per page wrong, {} != {}, overriding",
+                     aotMem->num_bytes_per_page,
+                     WASM_BYTES_PER_PAGE);
+        throw std::runtime_error("WAMR module bytes per page wrong");
+    }
 
     if (moduleInstance == nullptr) {
         std::string errorMsg = std::string(errorBuffer);
         SPDLOG_ERROR("Failed to instantiate WAMR module: \n{}", errorMsg);
         throw std::runtime_error("Failed to instantiate WAMR module");
     }
-
     currentBrk.store(getMemorySizeBytes(), std::memory_order_release);
-
     // Set up thread stacks
     createThreadStacks();
 }
@@ -344,16 +380,18 @@ uint32_t WAMRWasmModule::mmapMemory(size_t nBytes)
 
 size_t WAMRWasmModule::getMemorySizeBytes()
 {
-    auto aotModule = reinterpret_cast<AOTModuleInstance*>(moduleInstance);
+    auto* aotModule = reinterpret_cast<AOTModuleInstance*>(moduleInstance);
     AOTMemoryInstance* aotMem =
       ((AOTMemoryInstance**)aotModule->memories.ptr)[0];
-    return aotMem->cur_page_count * aotMem->num_bytes_per_page;
+    return aotMem->cur_page_count * WASM_BYTES_PER_PAGE;
 }
 
 uint8_t* WAMRWasmModule::getMemoryBase()
 {
-    SPDLOG_WARN("WAMR getMemoryBase not implemented");
-    return nullptr;
+    auto aotModule = reinterpret_cast<AOTModuleInstance*>(moduleInstance);
+    AOTMemoryInstance* aotMem =
+      ((AOTMemoryInstance**)aotModule->memories.ptr)[0];
+    return reinterpret_cast<uint8_t*>(aotMem->memory_data.ptr);
 }
 
 size_t WAMRWasmModule::getMaxMemoryPages()

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -13,6 +13,8 @@
 namespace wasm {
 std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
 {
+    SPDLOG_TRACE("Starting WAMR codegen on {} bytes", wasmBytes.size());
+
     // Make sure WAMR is initialised
     WAMRWasmModule::initialiseWAMRGlobally();
 
@@ -20,63 +22,66 @@ std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
         throw std::runtime_error("File is not a wasm binary");
     }
 
+    // WAMR logging, set this to 4+ if debugging issues
+    bh_log_set_verbose_level(2);
+
     // Load the module
     char errorBuffer[128];
-    // Sadly, non-pointer types are not portably provided by the WASM headers
-    using wasm_module = std::pointer_traits<wasm_module_t>::element_type;
-    std::unique_ptr<wasm_module, decltype(&wasm_runtime_unload)> wasmModule(
-      wasm_runtime_load(
-        wasmBytes.data(), wasmBytes.size(), errorBuffer, sizeof(errorBuffer)),
-      &wasm_runtime_unload);
+    wasm_module_t wasmModule = wasm_runtime_load(
+      wasmBytes.data(), wasmBytes.size(), errorBuffer, sizeof(errorBuffer));
 
     if (wasmModule == nullptr) {
-        SPDLOG_ERROR("Failed to import module: {}", errorBuffer);
-        throw std::runtime_error("Failed to load module");
+        SPDLOG_ERROR("Failed to load wasm module: {}", errorBuffer);
+        throw std::runtime_error("Failed to load wasm module");
     }
 
-    using aot_comp_data = std::pointer_traits<aot_comp_data_t>::element_type;
-    std::unique_ptr<aot_comp_data, decltype(&aot_destroy_comp_data)>
-      compileData(aot_create_comp_data(wasmModule.get()),
-                  &aot_destroy_comp_data);
-    if (compileData == nullptr) {
-        SPDLOG_ERROR("Failed to generat AOT data: {}", aot_get_last_error());
-        throw std::runtime_error("Failed to generate AOT data");
+    SPDLOG_TRACE("WAMR codegen imported {} bytes of wasm file",
+                 wasmBytes.size());
+
+    aot_comp_data_t compData;
+    if ((compData = aot_create_comp_data(wasmModule)) == nullptr) {
+        SPDLOG_ERROR("WAMR failed to create compilation data: {}",
+                     aot_get_last_error());
+        throw std::runtime_error("Failed to create compilation data");
     }
+
+    SPDLOG_TRACE("WAMR codegen generated compilation data");
 
     AOTCompOption option = { 0 };
     option.opt_level = 3;
     option.size_level = 3;
     option.output_format = AOT_FORMAT_FILE;
     option.bounds_checks = 2;
+    option.is_jit_mode = false;
+    option.enable_simd = false;
 
     if (isSgx) {
         option.size_level = 1;
         option.is_sgx_platform = true;
     }
 
-    using aot_comp_context =
-      std::pointer_traits<aot_comp_context_t>::element_type;
-    std::unique_ptr<aot_comp_context, decltype(&aot_destroy_comp_context)>
-      compileContext(aot_create_comp_context(compileData.get(), &option),
-                     &aot_destroy_comp_context);
-
-    if (compileContext == nullptr) {
-        SPDLOG_ERROR("Failed to generat AOT context: {}", aot_get_last_error());
-        throw std::runtime_error("Failed to generate AOT context");
+    aot_comp_context_t compContext;
+    if ((compContext = aot_create_comp_context(compData, &option)) == nullptr) {
+        SPDLOG_ERROR("WAMR failed to create compilation context: {}",
+                     aot_get_last_error());
+        throw std::runtime_error("Failed to create WAMR compilation context");
     }
 
-    bool compileSuccess = aot_compile_wasm(compileContext.get());
+    SPDLOG_TRACE("WAMR codegen created compilation context");
+
+    bool compileSuccess = aot_compile_wasm(compContext);
     if (!compileSuccess) {
         SPDLOG_ERROR("Failed to run codegen on wasm: {}", aot_get_last_error());
         throw std::runtime_error("Failed to run codegen");
     }
 
+    SPDLOG_TRACE("WAMR codegen successfully compiled wasm");
+
     // TODO - avoid using a temp file here
-    // Note - WAMR doesn't let us generate an array of bytes, so we have to
-    // write to a temp file, then load the bytes again
+    // WAMR doesn't let us generate an array of bytes, so we have to write to a
+    // temp file, then load the bytes again
     boost::filesystem::path temp = boost::filesystem::unique_path();
-    bool aotSuccess =
-      aot_emit_aot_file(compileContext.get(), compileData.get(), temp.c_str());
+    bool aotSuccess = aot_emit_aot_file(compContext, compData, temp.c_str());
     if (!aotSuccess) {
         SPDLOG_ERROR("Failed to write AOT file to {}", temp.string());
         throw std::runtime_error("Failed to emit AOT file");

--- a/tests/test/faaslet/test_filesystem.cpp
+++ b/tests/test/faaslet/test_filesystem.cpp
@@ -81,8 +81,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test fread", "[faaslet]")
 
     SECTION("WAVM") { execFunction(msg); }
 
-    // 11/04/22 - WAMR fread implementation broken
-    // SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { execWamrFunction(msg); }
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,

--- a/tests/test/faaslet/test_shared_files.cpp
+++ b/tests/test/faaslet/test_shared_files.cpp
@@ -45,9 +45,7 @@ TEST_CASE_METHOD(SharedFilesExecTestFixture,
     auto req = setUpContext("demo", "shared_file");
     SECTION("WAVM") { execFunction(req); }
 
-    // 11/04/2022 - WAMR shared files implementation seems to be broken, so we
-    // comment out for now
-    // SECTION("WAMR") { execWamrFunction(req->mutable_messages()->at(0)); }
+    SECTION("WAMR") { execWamrFunction(req->mutable_messages()->at(0)); }
 
     // Check file has been synced locally
     REQUIRE(boost::filesystem::exists(fullPath));

--- a/tests/test/wamr/test_wamr.cpp
+++ b/tests/test/wamr/test_wamr.cpp
@@ -13,23 +13,65 @@ using namespace wasm;
 
 namespace tests {
 
-TEST_CASE_METHOD(FunctionExecTestFixture,
-                 "Test executing echo function with WAMR",
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
+                 "Test executing simple function with WAMR",
                  "[wamr]")
 {
-    auto req = setUpContext("demo", "echo");
-    faabric::Message& call = req->mutable_messages()->at(0);
-    std::string inputData = "hello there";
-    call.set_inputdata(inputData);
+    int nExecs = 0;
+    std::string function;
 
-    wasm::WAMRWasmModule module;
-    module.bindToFunction(call);
+    SECTION("echo function")
+    {
+        function = "echo";
 
-    int returnValue = module.executeFunction(call);
-    REQUIRE(returnValue == 0);
+        SECTION("Once") { nExecs = 1; }
 
-    std::string outputData = call.outputdata();
-    REQUIRE(outputData == inputData);
+        SECTION("Multiple") { nExecs = 5; }
+    }
+
+    // We must also check a function that changes the memory size to check that
+    // it doesn't mess up
+    SECTION("brk function")
+    {
+        function = "brk";
+
+        SECTION("Once") { nExecs = 1; }
+
+        SECTION("Multiple") { nExecs = 5; }
+    }
+
+    // Set to run WAMR
+    conf.wasmVm = "wamr";
+
+    // Create a Faaslet
+    std::shared_ptr<faabric::BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("demo", function, 1);
+    faabric::Message& msg = req->mutable_messages()->at(0);
+    faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+    faaslet::Faaslet f(msg);
+
+    // Execute the function using another message
+    for (int i = 0; i < nExecs; i++) {
+        std::shared_ptr<faabric::BatchExecuteRequest> req =
+          faabric::util::batchExecFactory("demo", function, 1);
+        faabric::Message& msg = req->mutable_messages()->at(0);
+        faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+
+        std::string inputData = fmt::format("hello there {}", i);
+        msg.set_inputdata(inputData);
+
+        int returnValue = f.executeTask(0, 0, req);
+        REQUIRE(returnValue == 0);
+
+        REQUIRE(msg.returnvalue() == 0);
+
+        if (function == "echo") {
+            std::string outputData = msg.outputdata();
+            REQUIRE(outputData == inputData);
+        }
+    }
+
+    f.shutdown();
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test WAMR sbrk", "[wamr]")


### PR DESCRIPTION
In this PR I bump the WAMR fork to the latest commit as of [today](3fd763a95c0493a0767e0aa54a77598e30a1d661), and cherry pick the codegen fixes from #642. This changes fix the broken tests in #635.

I also cleanup our [diff](https://github.com/bytecodealliance/wasm-micro-runtime/compare/main...faasm:faasm) with the upstream WAMR, minimising the changes to only those we need.

I have had to comment out one of the additions in #642, see [here](core/iwasm/compilation/aot_llvm.c). I will get on with the memory growth/shrinking in a separate PR.

Closes #635 