### PR TITLE
`docker-compose` to `docker compose`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -374,36 +374,36 @@ jobs:
           path: ./dev/minio/data/faasm
           key: ${{ env.CPU_MODEL }}-s3-data-${{ secrets.CACHE_VERSION }}
       # Setup
-      - name: "Start docker-compose"
-        run: docker-compose up -d --scale worker=2 nginx
+      - name: "Start docker compose"
+        run: docker compose up -d --scale worker=2 nginx
       # This can fail when the container isn't ready, so we want to retry
       - name: "Wait for upload server to be available"
         run: |
-          (echo "Attempt 1" && docker-compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
-          (sleep 30s && echo "Attempt 2" && docker-compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
-          (sleep 30s && echo "Attempt 3" && docker-compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
-          (echo "Wait for upload failed after retries" && docker-compose logs upload && exit 1)
+          (echo "Attempt 1" && docker compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
+          (sleep 30s && echo "Attempt 2" && docker compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
+          (sleep 30s && echo "Attempt 3" && docker compose exec -T upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002) || \
+          (echo "Wait for upload failed after retries" && docker compose logs upload && exit 1)
       # Function upload
       - name: "Build and upload cpp function"
-        run: docker-compose run -T cpp inv func demo hello func.upload demo hello
+        run: docker compose run -T cpp inv func demo hello func.upload demo hello
       - name: "Build and upload python function"
-        run: docker-compose run -T python inv func func.upload func.uploadpy hello
+        run: docker compose run -T python inv func func.upload func.uploadpy hello
       # Function invocation
       - name: "Invoke cpp function"
-        run: docker-compose run -T cpp inv func.invoke demo hello | tee output_1.log
+        run: docker compose run -T cpp inv func.invoke demo hello | tee output_1.log
       - name: "Invoke python hello function"
-        run: docker-compose run -T python inv func.invoke python hello
+        run: docker compose run -T python inv func.invoke python hello
       # Re-invocation of same function with different code after flush
       - name: "Flush workers"
-        run: docker-compose run -T cpp inv func.flush
+        run: docker compose run -T cpp inv func.flush
       - name: "Build echo function and upload in place of hello function"
         run: ./deploy/local/replace_hello_with_echo.sh
       - name: "Invoke cpp function"
-        run: docker-compose run -T cpp inv func.invoke demo hello | tee output_2.log
+        run: docker compose run -T cpp inv func.invoke demo hello | tee output_2.log
       - name: "Check both outputs are different"
         run: (cmp output_1.log output_2.log && exit 1 || exit 0)
       # Print logs and finish
-      - name: "Docker-compose logs"
-        run: docker-compose logs
-      - name: "Stop docker-compose"
-        run: docker-compose down
+      - name: "docker compose logs"
+        run: docker compose logs
+      - name: "Stop docker compose"
+        run: docker compose down

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ Update submodules:
 git submodule update --init --recursive
 ```
 
-Start a Faasm cluster locally using `docker-compose`:
+Start a Faasm cluster locally using `docker compose`:
 
 ```bash
-docker-compose up -d --scale worker=2 nginx
+docker compose up -d --scale worker=2 nginx
 ```
 
 To compile, upload and invoke a C++ function using this local cluster you can
 use the [faasm/cpp](https://github.com/faasm/cpp) container:
 
 ```bash
-docker-compose run cpp /bin/bash
+docker compose run cpp /bin/bash
 
 # Compile the demo function
 inv func demo hello

--- a/bin/cli.sh
+++ b/bin/cli.sh
@@ -35,7 +35,7 @@ function start_sgx_aesmd_socket() {
         --opt device=tmpfs \
         --opt o=rw \
         aesmd-socket
-    docker-compose \
+    docker compose \
         up \
         --no-recreate \
         -d \
@@ -76,14 +76,14 @@ export FAASM_LOCAL_MOUNT=/usr/local/faasm
 
 # Make sure the CLI is running already in the background (avoids creating a new
 # container every time)
-docker-compose \
+docker compose \
     up \
     --no-recreate \
     -d \
     ${CLI_CONTAINER}
 
 # Attach to the CLI container
-docker-compose \
+docker compose \
     exec \
     ${CLI_CONTAINER} \
     ${INNER_SHELL}

--- a/deploy/dist-test/build.sh
+++ b/deploy/dist-test/build.sh
@@ -9,7 +9,7 @@ pushd ${PROJ_ROOT} >> /dev/null
 export FAASM_BUILD_MOUNT=/build/faasm
 
 # Run the build
-docker-compose \
+docker compose \
     run \
     --rm \
     faasm-cli \

--- a/deploy/dist-test/dev_server.sh
+++ b/deploy/dist-test/dev_server.sh
@@ -9,14 +9,14 @@ export FAASM_BUILD_MOUNT=/build/faasm
 export FAASM_LOCAL_MOUNT=/usr/local/faasm
 
 if [[ -z "$1" ]]; then
-    docker-compose up -d dist-test-server
+    docker compose up -d dist-test-server
 elif [[ "$1" == "restart" ]]; then
-    docker-compose restart dist-test-server
+    docker compose restart dist-test-server
 elif [[ "$1" == "stop" ]]; then
-    docker-compose stop dist-test-server
+    docker compose stop dist-test-server
 elif [[ "$1" == "rm" ]]; then
-    docker-compose stop dist-test-server
-    docker-compose rm dist-test-server
+    docker compose stop dist-test-server
+    docker compose rm dist-test-server
 else
     echo "Unrecognised argument: $1"
     echo ""

--- a/deploy/dist-test/run.sh
+++ b/deploy/dist-test/run.sh
@@ -9,13 +9,13 @@ export FAASM_BUILD_MOUNT=/build/faasm
 RETURN_VAL=0
 
 # Run the test server in the background
-docker-compose \
+docker compose \
     up \
     -d \
     dist-test-server
 
 # Run the tests
-docker-compose \
+docker compose \
     run \
     --rm \
     faasm-cli \
@@ -26,10 +26,10 @@ RETURN_VAL=$?
 echo "-------------------------------------------"
 echo "                SERVER LOGS                "
 echo "-------------------------------------------"
-docker-compose logs dist-test-server
+docker compose logs dist-test-server
 
 # Stop everything
-docker-compose stop
+docker compose stop
 
 popd >> /dev/null
 

--- a/deploy/dist-test/upload.sh
+++ b/deploy/dist-test/upload.sh
@@ -9,7 +9,7 @@ pushd ${PROJ_ROOT} > /dev/null
 export FAASM_BUILD_MOUNT=/build/faasm
 
 # Make sure upload server is running
-docker-compose \
+docker compose \
     up \
     -d \
     upload
@@ -18,7 +18,7 @@ docker-compose \
 sleep 5
 
 # Run the function build and upload
-docker-compose \
+docker compose \
     run \
     --rm \
     cpp \

--- a/deploy/local/replace_hello_with_echo.sh
+++ b/deploy/local/replace_hello_with_echo.sh
@@ -10,7 +10,7 @@ ECHO_WASM=/code/cpp/build/func/demo/echo.wasm
 HELLO_WASM=/code/cpp/build/func/demo/hello.wasm
 CP_BIN=/usr/bin/cp
 
-docker-compose run -T cpp bash -c \
+docker compose run -T cpp bash -c \
     "inv func demo echo && ${CP_BIN} ${ECHO_WASM} ${HELLO_WASM} && inv func.upload demo hello"
 
 popd > /dev/null

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -20,7 +20,7 @@ The Faasm development environment is containerised, as defined in the [Docker
 compose config](docker-compose.yml).
 
 We mount local checkouts of all the code into these containers, so first you'll
-need to update all the submodules (may take a while):
+need to update the project submodules (may take a while):
 
 ```bash
 git submodule update --init --recursive
@@ -34,16 +34,27 @@ can initialise with:
 ./bin/refresh_local.sh
 ```
 
-You then need to set up a suitable Python virtual envrionment with:
-
-```bash
-./bin/create_venv.sh
-```
-
 ## Use
 
-Once you've set up the repo, you can start the CLI for whichever project you
-want to work on:
+Once you've set up the repo, you should first run the Faasm CLI to make sure
+things work:
+
+```bash
+./bin/cli.sh faasm
+
+# Wait for 30s while it sets up the Python environment in the background
+
+# Check the python environment is up (should list commands)
+inv -l
+
+# Run the CMake build
+inv dev.cmake
+inv dev.tools
+```
+
+From there you can compile and run functions using the language-specific
+containers (running the following from the local machine, not inside the Faasm
+CLI container):
 
 ```bash
 # C++ functions
@@ -51,15 +62,12 @@ want to work on:
 
 # Python functions
 ./bin/cli.sh python
-
-# Faasm (for building Faasm itself)
-./bin/cli.sh faasm
 ```
 
 ## Tests
 
-To check everything works, you can run the tests as follows (note which
-container you need to be in for each step):
+To run the tests, you can execute the following (note that you have to switch
+between containers for the first few steps):
 
 ```bash
 # --- CPP CLI ---

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -34,15 +34,7 @@ can initialise with:
 ./bin/refresh_local.sh
 ```
 
-If you want to nuke your existing `dev/faasm-local` in the process:
-
-```bash
-./bin/refresh_local.sh -d
-```
-
-It may also be useful to run Python scripts outside the containerised
-environments, for which you can set up a suitable Python virtual envrionment
-with:
+You then need to set up a suitable Python virtual envrionment with:
 
 ```bash
 ./bin/create_venv.sh
@@ -54,13 +46,13 @@ Once you've set up the repo, you can start the CLI for whichever project you
 want to work on:
 
 ```bash
-# C++ applications
+# C++ functions
 ./bin/cli.sh cpp
 
-# Python applications
+# Python functions
 ./bin/cli.sh python
 
-# Faasm
+# Faasm (for building Faasm itself)
 ./bin/cli.sh faasm
 ```
 

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -204,7 +204,7 @@ From a different terminal, restart the worker and check the logs:
 ```bash
 inv cluster.restart-worker
 
-docker-compose logs -f
+docker compose logs -f
 ```
 
 ### Running distributed tests locally
@@ -216,7 +216,7 @@ First of all, you need to make sure everything else is shut down to avoid
 interfering with the tests:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 Make sure your local setup is built, along with the distributed tests:
@@ -374,11 +374,11 @@ container is running, and reachable from outside the container.
 
 ```
 # Stop anything that may be running in the background
-docker-compose down
+docker compose down
 
-docker-compose up -d redis-state redis-queue minio
+docker compose up -d redis-state redis-queue minio
 
-docker-compose ps
+docker compose ps
 ```
 
 To tell Faasm outside the container to use the containerised Minio, set the

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -1,20 +1,37 @@
 # Getting started
 
-Faasm can be accessed from the commandline via the containerised Faasm
-environment:
+Note that if you want to develop Faasm and make changes, you need to run through
+the setup in the [development docs](development.md).
 
-```bash
-./bin/cli.sh faasm
-```
+## Containers
 
-This will mount your local project checkout into the containerised development
-setup (more info on developing Faasm can be found in the [dev
-docs](development.md).
+Faasm runs a few different containers as defined in
+[docker-compose.yml](../docker-compose.yml). The most important are:
+
+- `cpp` - used to compile and upload C/C++ functions (see the [`cpp`
+  repo](https://github.com/faasm/cpp)).
+- `python` - used to compile the CPython runtime and libraries, and
+  upload Python functions (see the [`python`
+  repo](https://github.com/faasm/python)).
+- `upload` - the server that receives all function, state and shared file
+  uploads.
+- `worker` - one or more instances of the Faasm runtime that execute functions.
+- `minio` - [Minio](https://min.io/) instance that holds uploaded functions and
+  shared files.
+- `redis` - [Redis](https://redis.io/) instance that holds internal scheduler
+  state, and state shared between functions.
+- `nginx` - [NGINX](https://www.nginx.com/) instance that load-balances requests
+  between multiple workers.
+
+Faasm generates machine code for all WebAssembly it needs to run (e.g. C/C++
+functions, CPython, Python C-extensions). This, along with other local
+development artifacts, is stored in the `dev` dir at the root of your local
+checkout.
 
 ## Commandline interface
 
-The Faasm CLI uses [Invoke](https://www.pyinvoke.org/), which means you can do
-the following:
+All Faasm projects use [Invoke](https://www.pyinvoke.org/), which means you can
+do the following:
 
 ```bash
 # List all commands
@@ -24,7 +41,7 @@ inv -l
 inv -l knative
 
 # Show help for a given command
-inv -h invoke
+inv -h knative.ini-file
 
 # Chain commands
 inv flush invoke demo hello
@@ -38,23 +55,19 @@ To start a local deployment, you can run:
 docker compose up
 ```
 
-which creates the containers defined in
-[docker-compose.yml](../docker-compose.yml):
-
-Faasm will generate machine code from all WebAssembly it encounters. This, along
-with other local development artifacts are stored in the `dev` dir at the root
-of your local checkout.
-
 ## Writing and deploying functions
 
-See the language-specific docs for [C/C++](cpp.md) and [Python](python.md),
+See the language-specific docs:
+
+- [C/C++](cpp.md)
+- [Python](python.md),
 
 ### Flushing
 
 Faasm does a lot of caching, so if you want to update a function, you must flush
 the system before invoking it again. This is done using the `flush` command.
 Each language-specific container has its own way of flushing (e.g. `inv
-func.flush` in the `cpp` container), but you can also do it from the CLI.
+func.flush` in the `cpp` container), but you can also do it from the Faasm CLI.
 
 ```bash
 inv flush

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -39,7 +39,7 @@ docker compose up
 ```
 
 which creates the containers defined in
-[docker-compose.yml](../docker compose.yml):
+[docker-compose.yml](../docker-compose.yml):
 
 Faasm will generate machine code from all WebAssembly it encounters. This, along
 with other local development artifacts are stored in the `dev` dir at the root

--- a/docs/source/getting_started.md
+++ b/docs/source/getting_started.md
@@ -35,11 +35,11 @@ inv flush invoke demo hello
 To start a local deployment, you can run:
 
 ```
-docker-compose up
+docker compose up
 ```
 
 which creates the containers defined in
-[docker-compose.yml](../docker-compose.yml):
+[docker-compose.yml](../docker compose.yml):
 
 Faasm will generate machine code from all WebAssembly it encounters. This, along
 with other local development artifacts are stored in the `dev` dir at the root

--- a/docs/source/kubernetes.md
+++ b/docs/source/kubernetes.md
@@ -93,8 +93,8 @@ in this repo as normal, for example:
 
 ```bash
 # Start the cpp container (make sure you've stopped all other Faasm containers)
-docker-compose -f docker-compose-k8s.yml up -d --no-recreate cpp-cli
-docker-compose -f docker-compose-k8s.yml exec cpp-cli /bin/bash
+docker compose -f docker-compose-k8s.yml up -d --no-recreate cpp-cli
+docker compose -f docker-compose-k8s.yml exec cpp-cli /bin/bash
 
 # Compile and upload a function
 inv func demo hello
@@ -108,8 +108,8 @@ For Python:
 
 ```bash
 # Start the python container
-docker-compose -f docker-compose-k8s.yml up -d --no-recreate python-cli
-docker-compose -f docker-compose-k8s.yml exec python-cli /bin/bash
+docker compose -f docker-compose-k8s.yml up -d --no-recreate python-cli
+docker compose -f docker-compose-k8s.yml exec python-cli /bin/bash
 
 inv func.uploadpy python hello
 

--- a/docs/source/profiling.md
+++ b/docs/source/profiling.md
@@ -58,7 +58,7 @@ To set up:
 - Install PCP (`apt install pcp -y`)
 - Check that `pmproxy` is running and listening on `44323` (e.g. `tail
   /var/log/pcp/pmproxy/pmproxy.log`). May require a restart
-- Run the Vector container in our dev set-up, e.g. `docker-compose -f
+- Run the Vector container in our dev set-up, e.g. `docker compose -f
   docker-compose-dev.yml vector`
 - Go to http://localhost:80 in your browser
 - Add a connection to host `localhost` on port `44323`

--- a/docs/source/python.md
+++ b/docs/source/python.md
@@ -20,17 +20,17 @@ Start a cluster with:
 ```bash
 export PYTHON_CODEGEN=on
 
-docker-compose up -d nginx
+docker compose up -d nginx
 
 # Await machine code generation
-docker-compose exec upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002
+docker compose exec upload /usr/local/code/faasm/deploy/local/wait_for_upload.sh localhost 8002
 ```
 
 Upload and invoke a Python function with:
 
 ```
 # Run the Python CLI
-docker-compose run python /bin/bash
+docker compose run python /bin/bash
 
 # Build and upload the Python runtime
 inv func

--- a/faasmcli/faasmcli/tasks/cluster.py
+++ b/faasmcli/faasmcli/tasks/cluster.py
@@ -38,7 +38,7 @@ def start(ctx, workers=2, sgx=FAASM_SGX_MODE_DISABLED):
         env["WASM_VM"] = "sgx"
 
     cmd = [
-        "docker-compose up -d",
+        "docker compose up -d",
         "--scale worker={}".format(workers),
         "nginx",
     ]
@@ -66,7 +66,7 @@ def stop(ctx, workers=2):
     """
     Stop the local dev cluster
     """
-    run("docker-compose stop", shell=True, check=True, cwd=PROJ_ROOT)
+    run("docker compose stop", shell=True, check=True, cwd=PROJ_ROOT)
 
 
 @task
@@ -74,7 +74,7 @@ def restart(ctx):
     """
     Restart the whole dev cluster
     """
-    run("docker-compose restart", shell=True, check=True, cwd=PROJ_ROOT)
+    run("docker compose restart", shell=True, check=True, cwd=PROJ_ROOT)
 
 
 @task
@@ -82,7 +82,7 @@ def restart_worker(ctx):
     """
     Restart the workers in the dev cluster
     """
-    run("docker-compose restart worker", shell=True, check=True, cwd=PROJ_ROOT)
+    run("docker compose restart worker", shell=True, check=True, cwd=PROJ_ROOT)
 
 
 @task
@@ -90,7 +90,7 @@ def logs(ctx):
     """
     Follow the logs of the dev cluster
     """
-    run("docker-compose logs -f", shell=True, check=True, cwd=PROJ_ROOT)
+    run("docker compose logs -f", shell=True, check=True, cwd=PROJ_ROOT)
 
 
 @task
@@ -100,7 +100,7 @@ def flush_redis(ctx):
     """
     for r in ["redis-state", "redis-queue"]:
         run(
-            "docker-compose exec {} redis-cli flushall".format(r),
+            "docker compose exec {} redis-cli flushall".format(r),
             shell=True,
             check=True,
             cwd=PROJ_ROOT,
@@ -113,7 +113,7 @@ def available_workers(ctx):
     Return the list of available workers in Redis
     """
     run(
-        "docker-compose exec redis-queue redis-cli smembers {}".format(
+        "docker compose exec redis-queue redis-cli smembers {}".format(
             AVAILABLE_HOSTS_SET
         ),
         shell=True,


### PR DESCRIPTION
`docker-compose` has been deprecated in favour of `docker compose` in newer versions: https://docs.docker.com/compose/

Also includes some updates to the getting started and dev docs that were unclear.

Closes #647 