### PR TITLE
Push WASM memory management to `WasmModule`

### DIFF
--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -24,6 +24,8 @@ WAMR_ALLOWED_FUNCS = [
     ["errors", "ret_one"],
     # Memory
     ["demo", "brk"],
+    ["demo", "mmap"],
+    ["demo", "mmap_big"],
     # Filesystem
     ["demo", "fcntl"],
     ["demo", "file"],

--- a/include/enclave/outside/EnclaveInterface.h
+++ b/include/enclave/outside/EnclaveInterface.h
@@ -32,11 +32,9 @@ class EnclaveInterface final : public WasmModule
 
     int32_t executeFunction(faabric::Message& msg) override;
 
-    uint32_t growMemory(size_t nBytes) override;
-
-    uint32_t shrinkMemory(size_t nBytes) override;
-
     size_t getMemorySizeBytes() override;
+
+    size_t getMaxMemoryPages() override;
 
     uint8_t* getMemoryBase() override;
 

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -49,19 +49,13 @@ class WAMRWasmModule final
     uint8_t* wasmPointerToNative(uint32_t wasmPtr) override;
 
     // ----- Memory management -----
-    uint32_t growMemory(size_t nBytes) override;
-
-    uint32_t shrinkMemory(size_t nBytes) override;
-
-    uint32_t mmapMemory(size_t nBytes) override;
-
     uint32_t mmapFile(uint32_t fp, size_t length) override;
 
     size_t getMemorySizeBytes() override;
 
     uint8_t* getMemoryBase() override;
 
-    size_t getMaxMemoryPages();
+    size_t getMaxMemoryPages() override;
 
     WASMModuleInstanceCommon* getModuleInstance();
 
@@ -79,6 +73,8 @@ class WAMRWasmModule final
     int executeWasmFunctionFromPointer(int wasmFuncPtr);
 
     void bindInternal(faabric::Message& msg);
+
+    bool doGrowMemory(uint32_t pageChange) override;
 };
 
 WAMRWasmModule* getExecutingWAMRModule();

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -99,15 +99,15 @@ class WasmModule
 
     virtual void setMemorySize(size_t nBytes);
 
-    virtual uint32_t growMemory(size_t nBytes);
+    uint32_t growMemory(size_t nBytes);
 
-    virtual uint32_t shrinkMemory(size_t nBytes);
+    uint32_t shrinkMemory(size_t nBytes);
 
-    virtual uint32_t mmapMemory(size_t nBytes);
+    uint32_t mmapMemory(size_t nBytes);
 
     virtual uint32_t mmapFile(uint32_t fp, size_t length);
 
-    virtual void unmapMemory(uint32_t offset, size_t nBytes);
+    void unmapMemory(uint32_t offset, size_t nBytes);
 
     uint32_t createMemoryGuardRegion(uint32_t wasmOffset);
 
@@ -119,6 +119,8 @@ class WasmModule
     virtual uint8_t* wasmPointerToNative(uint32_t wasmPtr);
 
     virtual size_t getMemorySizeBytes();
+
+    virtual size_t getMaxMemoryPages();
 
     virtual uint8_t* getMemoryBase();
 
@@ -214,6 +216,9 @@ class WasmModule
 
     // Module-specific binding
     virtual void doBindToFunction(faabric::Message& msg, bool cache);
+
+    // WASM-runtime specific method to actually grow the internal WASM memories
+    virtual bool doGrowMemory(uint32_t pageChange);
 
     // Snapshots
     faabric::snapshot::SnapshotRegistry& reg;

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -64,19 +64,13 @@ class WAVMWasmModule final
     void reset(faabric::Message& msg, const std::string& snapshotKey) override;
 
     // ----- Memory management -----
-    uint32_t growMemory(size_t nBytes) override;
-
-    uint32_t shrinkMemory(size_t nBytes) override;
-
-    uint32_t mmapMemory(size_t nBytes) override;
-
     uint32_t mmapFile(uint32_t fd, size_t length) override;
-
-    void unmapMemory(uint32_t offset, size_t nBytes) override;
 
     uint8_t* wasmPointerToNative(uint32_t wasmPtr) override;
 
     size_t getMemorySizeBytes() override;
+
+    size_t getMaxMemoryPages() override;
 
     uint8_t* getMemoryBase() override;
 
@@ -186,6 +180,9 @@ class WAVMWasmModule final
     std::unordered_map<std::string, WAVM::Uptr> globalOffsetTableMap;
     std::unordered_map<std::string, std::pair<int, bool>> globalOffsetMemoryMap;
     std::unordered_map<std::string, int> missingGlobalOffsetEntries;
+
+    // Memory management
+    bool doGrowMemory(uint32_t pageChange) override;
 
     // OpenMP
     std::vector<WAVM::Runtime::Context*> openMPContexts;

--- a/src/enclave/outside/EnclaveInterface.cpp
+++ b/src/enclave/outside/EnclaveInterface.cpp
@@ -103,29 +103,15 @@ int32_t EnclaveInterface::executeFunction(faabric::Message& msg)
     return 0;
 }
 
-uint32_t EnclaveInterface::growMemory(size_t nBytes)
-{
-    SPDLOG_DEBUG("SGX-WAMR growing memory by {}", nBytes);
-
-    uint32_t memBase = currentBrk.load(std::memory_order_acquire);
-
-    uint32_t nPages = getNumberOfWasmPagesForBytes(nBytes);
-    SPDLOG_WARN("Growing memory in SGX-WAMR never allocates new memory");
-
-    currentBrk.store(memBase + (nPages * WASM_BYTES_PER_PAGE),
-                     std::memory_order_release);
-    return memBase;
-}
-
-uint32_t EnclaveInterface::shrinkMemory(size_t nBytes)
-{
-    SPDLOG_WARN("SGX-WAMR ignoring shrink memory");
-    return 0;
-}
-
 size_t EnclaveInterface::getMemorySizeBytes()
 {
     SPDLOG_WARN("SGX-WAMR getMemorySizeBytes not implemented");
+    return 0;
+}
+
+size_t EnclaveInterface::getMaxMemoryPages()
+{
+    SPDLOG_WARN("SGX-WAMR getMaxMemoryPages not implemented");
     return 0;
 }
 

--- a/src/enclave/outside/ocalls.cpp
+++ b/src/enclave/outside/ocalls.cpp
@@ -75,18 +75,13 @@ extern "C"
     int32_t ocallSbrk(int32_t increment)
     {
         SPDLOG_TRACE("S - __sbrk - {}", increment);
-        wasm::WasmModule* module = wasm::getExecutingModule();
-        uint32_t oldBrk = module->getCurrentBrk();
-
-        if (increment == 0) {
-            return oldBrk;
-        } else if (increment < 0) {
-            module->shrinkMemory(-1 * increment);
-            return oldBrk;
-        } else {
-            return module->growMemory(increment);
-        }
+        SPDLOG_WARN("SGX-WAMR sbrk does not allocate more memory");
+        return 0;
     }
+
+    // ---------------------------------------
+    // Logging
+    // ---------------------------------------
 
     void ocallLogDebug(const char* msg) { SPDLOG_DEBUG("[enclave] {}", msg); }
 

--- a/src/wamr/memory.cpp
+++ b/src/wamr/memory.cpp
@@ -33,7 +33,6 @@ static int32_t mmap_wrapper(wasm_exec_env_t exec_env,
                             int32_t fd,
                             int64_t offset)
 {
-    // TODO - reduce code duplication with WAVM's mmap
     SPDLOG_DEBUG(
       "S - mmap - {} {} {} {} {} {}", addr, length, prot, flags, fd, offset);
 

--- a/src/wamr/memory.cpp
+++ b/src/wamr/memory.cpp
@@ -25,8 +25,56 @@ static int32_t __sbrk_wrapper(wasm_exec_env_t exec_env, int32_t increment)
     }
 }
 
+static int32_t mmap_wrapper(wasm_exec_env_t exec_env,
+                            int32_t addr,
+                            int32_t length,
+                            int32_t prot,
+                            int32_t flags,
+                            int32_t fd,
+                            int64_t offset)
+{
+    // TODO - reduce code duplication with WAVM's mmap
+    SPDLOG_DEBUG(
+      "S - mmap - {} {} {} {} {} {}", addr, length, prot, flags, fd, offset);
+
+    if (offset != 0) {
+        SPDLOG_WARN("WARNING: ignoring non-zero mmap offset ({})", offset);
+    }
+
+    // Likewise with the address hint
+    if (addr != 0) {
+        SPDLOG_WARN("WARNING: ignoring mmap hint at {}", addr);
+    }
+
+    WAMRWasmModule* module = getExecutingWAMRModule();
+
+    if (fd != -1) {
+        // If fd is provided, we're mapping a file into memory
+        storage::FileDescriptor& fileDesc =
+          module->getFileSystem().getFileDescriptor(fd);
+        return module->mmapFile(fileDesc.getLinuxFd(), length);
+    }
+
+    // If fd not provided, map memory directly
+    return module->mmapMemory(length);
+}
+
+static int32_t munmap_wrapper(wasm_exec_env_t exec_env,
+                              int32_t addr,
+                              int32_t length)
+{
+    SPDLOG_DEBUG("S - munmap - {} {}", addr, length);
+
+    WAMRWasmModule* executingModule = getExecutingWAMRModule();
+    executingModule->unmapMemory(addr, length);
+
+    return 0;
+}
+
 static NativeSymbol ns[] = {
     REG_NATIVE_FUNC(__sbrk, "(i)i"),
+    REG_NATIVE_FUNC(mmap, "(iiiiiI)i"),
+    REG_NATIVE_FUNC(munmap, "(ii)i"),
 };
 
 uint32_t getFaasmMemoryApi(NativeSymbol** nativeSymbols)

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -699,11 +699,11 @@ uint32_t WasmModule::growMemory(size_t nBytes)
     size_t maxPages = getMaxMemoryPages();
 
     if (newBytes > UINT32_MAX || newPages > maxPages) {
-        SPDLOG_ERROR(
-          "Growing memory would exceed max of {} pages (current {}, requested {})",
-          maxPages,
-          oldPages,
-          newPages);
+        SPDLOG_ERROR("Growing memory would exceed max of {} pages (current {}, "
+                     "requested {})",
+                     maxPages,
+                     oldPages,
+                     newPages);
         throw std::runtime_error("Memory growth exceeding max");
     }
 
@@ -730,7 +730,6 @@ uint32_t WasmModule::growMemory(size_t nBytes)
 
         return oldBrk;
     }
-
 
     uint32_t pageChange = newPages - oldPages;
     bool success = doGrowMemory(pageChange);

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -674,17 +674,125 @@ void WasmModule::writeWasmEnvToMemory(uint32_t envPointers, uint32_t envBuffer)
 
 uint32_t WasmModule::growMemory(size_t nBytes)
 {
-    throw std::runtime_error("growMemory not implemented");
+    if (nBytes == 0) {
+        return currentBrk.load(std::memory_order_acquire);
+    }
+
+    faabric::util::FullLock lock(moduleMutex);
+
+    uint32_t oldBytes = getMemorySizeBytes();
+    uint32_t oldBrk = currentBrk.load(std::memory_order_acquire);
+    uint32_t newBrk = oldBrk + nBytes;
+
+    if (!isWasmPageAligned(newBrk)) {
+        SPDLOG_ERROR("Growing memory by {} is not wasm page aligned"
+                     " (current brk: {}, new brk: {})",
+                     nBytes,
+                     oldBrk,
+                     newBrk);
+        throw std::runtime_error("Non-wasm-page-aligned memory growth");
+    }
+
+    size_t newBytes = oldBytes + nBytes;
+    uint32_t oldPages = getNumberOfWasmPagesForBytes(oldBytes);
+    uint32_t newPages = getNumberOfWasmPagesForBytes(newBytes);
+    size_t maxPages = getMaxMemoryPages();
+
+    if (newBytes > UINT32_MAX || newPages > maxPages) {
+        SPDLOG_ERROR(
+          "Growing memory would exceed max of {} pages (current {}, requested {})",
+          maxPages,
+          oldPages,
+          newPages);
+        throw std::runtime_error("Memory growth exceeding max");
+    }
+
+    // If we can reclaim old memory, just bump the break
+    if (newBrk <= oldBytes) {
+        SPDLOG_TRACE(
+          "MEM - Growing memory using already provisioned {} + {} <= {}",
+          oldBrk,
+          nBytes,
+          oldBytes);
+
+        currentBrk.store(newBrk, std::memory_order_release);
+
+        // Make sure permissions on memory are open
+        size_t newTop = faabric::util::getRequiredHostPages(currentBrk);
+        size_t newStart = faabric::util::getRequiredHostPagesRoundDown(oldBrk);
+        newTop *= faabric::util::HOST_PAGE_SIZE;
+        newStart *= faabric::util::HOST_PAGE_SIZE;
+        SPDLOG_TRACE("Reclaiming memory {}-{}", newStart, newTop);
+
+        uint8_t* memBase = getMemoryBase();
+        faabric::util::claimVirtualMemory(
+          { memBase + newStart, memBase + newTop });
+
+        return oldBrk;
+    }
+
+
+    uint32_t pageChange = newPages - oldPages;
+    bool success = doGrowMemory(pageChange);
+    if (!success) {
+        throw std::runtime_error("Failed to grow memory");
+    }
+
+    SPDLOG_TRACE("Growing memory from {} to {} pages (max {})",
+                 oldPages,
+                 newPages,
+                 maxPages);
+
+    size_t newMemorySize = getMemorySizeBytes();
+    currentBrk.store(newMemorySize, std::memory_order_release);
+
+    if (newMemorySize != newBytes) {
+        SPDLOG_ERROR(
+          "Expected new brk ({}) to be old memory plus new bytes ({})",
+          newMemorySize,
+          newBytes);
+        throw std::runtime_error("Memory growth discrepancy");
+    }
+
+    return oldBrk;
+}
+
+bool WasmModule::doGrowMemory(uint32_t pageChange)
+{
+    throw std::runtime_error("doGrowMemory not implemented");
 }
 
 uint32_t WasmModule::shrinkMemory(size_t nBytes)
 {
-    throw std::runtime_error("shrinkMemory not implemented");
+    if (!isWasmPageAligned(nBytes)) {
+        SPDLOG_ERROR("Shrink size not page aligned {}", nBytes);
+        throw std::runtime_error("New break not page aligned");
+    }
+
+    faabric::util::FullLock lock(moduleMutex);
+
+    uint32_t oldBrk = currentBrk.load(std::memory_order_acquire);
+
+    if (nBytes > oldBrk) {
+        SPDLOG_ERROR(
+          "Shrinking by more than current brk ({} > {})", nBytes, oldBrk);
+        throw std::runtime_error("Shrinking by more than current brk");
+    }
+
+    // Note - we don't actually free the memory, we just change the brk
+    uint32_t newBrk = oldBrk - nBytes;
+
+    SPDLOG_TRACE("MEM - shrinking memory {} -> {}", oldBrk, newBrk);
+    currentBrk.store(newBrk, std::memory_order_release);
+
+    return oldBrk;
 }
 
 uint32_t WasmModule::mmapMemory(size_t nBytes)
 {
-    throw std::runtime_error("mmapMemory not implemented");
+    // The mmap interface allows non page-aligned values, and rounds up
+    uint32_t pageAligned = roundUpToWasmPageAligned(nBytes);
+    return growMemory(pageAligned);
 }
 
 uint32_t WasmModule::mmapFile(uint32_t fp, size_t length)
@@ -694,7 +802,36 @@ uint32_t WasmModule::mmapFile(uint32_t fp, size_t length)
 
 void WasmModule::unmapMemory(uint32_t offset, size_t nBytes)
 {
-    throw std::runtime_error("unmapMemory not implemented");
+    if (nBytes == 0) {
+        return;
+    }
+
+    // Munmap expects the offset itself to be page-aligned, but will round up
+    // the number of bytes
+    if (!isWasmPageAligned(offset)) {
+        SPDLOG_ERROR("Non-page aligned munmap address {}", offset);
+        throw std::runtime_error("Non-page aligned munmap address");
+    }
+
+    uint32_t pageAligned = roundUpToWasmPageAligned(nBytes);
+    size_t maxPages = getMaxMemoryPages();
+    size_t maxSize = maxPages * WASM_BYTES_PER_PAGE;
+    uint32_t unmapTop = offset + pageAligned;
+
+    if (unmapTop > maxSize) {
+        SPDLOG_ERROR(
+          "Munmapping outside memory max ({} > {})", unmapTop, maxSize);
+        throw std::runtime_error("munmapping outside memory max");
+    }
+
+    if (unmapTop == currentBrk.load(std::memory_order_acquire)) {
+        SPDLOG_TRACE("MEM - munmapping top of memory by {}", pageAligned);
+        shrinkMemory(pageAligned);
+    } else {
+        SPDLOG_WARN("MEM - unable to reclaim unmapped memory {} at {}",
+                    pageAligned,
+                    offset);
+    }
 }
 
 uint8_t* WasmModule::wasmPointerToNative(uint32_t wasmPtr)
@@ -710,6 +847,11 @@ void WasmModule::printDebugInfo()
 size_t WasmModule::getMemorySizeBytes()
 {
     throw std::runtime_error("getMemorySizeBytes not implemented");
+}
+
+size_t WasmModule::getMaxMemoryPages()
+{
+    throw std::runtime_error("getMaxMemoryPages not implemented");
 }
 
 uint8_t* WasmModule::getMemoryBase()

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -1025,14 +1025,12 @@ bool WAVMWasmModule::doGrowMemory(uint32_t pageChange)
                          strerror(errno),
                          pageChange,
                          oldPages);
-        }
-        else if (result == Runtime::GrowResult::outOfMaxSize) {
+        } else if (result == Runtime::GrowResult::outOfMaxSize) {
             SPDLOG_ERROR("No WAVM memory for mapping (growing by {} from {} "
                          "pages)",
                          pageChange,
                          oldPages);
-        }
-        else if (result == Runtime::GrowResult::outOfQuota) {
+        } else if (result == Runtime::GrowResult::outOfQuota) {
             SPDLOG_ERROR(
               "WAVM memory resource quota exceeded (growing by {} from {})",
               pageChange,

--- a/tests/test/wasm/test_memory.cpp
+++ b/tests/test/wasm/test_memory.cpp
@@ -183,15 +183,9 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
     std::shared_ptr<wasm::WasmModule> module = nullptr;
 
     std::string expectedMessage = "Memory growth exceeding max";
-    SECTION("WAVM")
-    {
-        module = std::make_shared<wasm::WAVMWasmModule>();
-    }
+    SECTION("WAVM") { module = std::make_shared<wasm::WAVMWasmModule>(); }
 
-    SECTION("WAMR")
-    {
-        module = std::make_shared<wasm::WAMRWasmModule>();
-    }
+    SECTION("WAMR") { module = std::make_shared<wasm::WAMRWasmModule>(); }
 
     module->bindToFunction(call);
 


### PR DESCRIPTION
In this PR I introduce support for `mmap/munmap` in WAMR. In the process, I push most of the memory management implementation from `WAVMWasmModule` to `WasmModule` to avoid duplication between WAMR and WAVM.

The implementation is still quite generic, and we can get away with few calls to the actual WASM runtime.