### PR TITLE
Bump WAMR's dependency to the most up-to-date version

### DIFF
--- a/cmake/ExternalProjects.cmake
+++ b/cmake/ExternalProjects.cmake
@@ -112,7 +112,7 @@ FetchContent_Declare(wavm_ext
 
 FetchContent_Declare(wamr_ext
     GIT_REPOSITORY "https://github.com/faasm/wasm-micro-runtime"
-    GIT_TAG "78274abbaa34a9b68af7d1fbe71e7b66d9d3ca02"
+    GIT_TAG "caef0bc4db394b2d603066cc8b1a1cf5731e1b62"
 )
 
 # WAMR and WAVM both link to LLVM


### PR DESCRIPTION
WAMR is very much under development, and some of the patches we need to do are obsolete after some time. In addition, we periodically rebase our patches on the latest upstream head to get the newest features/fixes. As a consequence, I've squashed all our patches into a single commit in our [fork](https://github.com/faasm/wasm-micro-runtime). Now the [diff](https://github.com/faasm/wasm-micro-runtime/commit/caef0bc4db394b2d603066cc8b1a1cf5731e1b62) is very easy to track, and I will try to keep squashing the commits as I make progress.