### PR TITLE
Remove `BOOST_NO_TYPEID` which snuck back in during one of the PR merges

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,9 +210,6 @@ target_include_directories(faasm_common_deps INTERFACE
     ${FAASM_GENERATED_INCLUDE_DIR}
     ${FAASM_PYTHON_LIB_DIR}
 )
-target_compile_definitions(faasm_common_deps INTERFACE
-    BOOST_NO_TYPEID=1 # Prevent odd crashes within asio implementation
-)
 
 # Faasm SGX support
 if (SGX_FOUND)


### PR DESCRIPTION
I added these 3 lines during experiments with #683, and later removed them with a rebase but they got merged in afterwards from the old version anyway. RTTI is fully enabled in the codebase now, so this is not needed and could lead to odd linker errors (odr violation) in the future.