### PR TITLE
Pass `--cmdline` to `func_runner` and parse CL args

### DIFF
--- a/faasmcli/faasmcli/tasks/run.py
+++ b/faasmcli/faasmcli/tasks/run.py
@@ -5,13 +5,15 @@ from faasmcli.util.shell import run_command
 
 
 @task(default=True)
-def run(ctx, user, function, data=None):
+def run(ctx, user, function, data=None, cmdline=None):
     """
     Execute a specific function
     """
     args = [user, function]
     if data:
-        args.append(data)
+        args.append("--input-data '{}'".format(data))
+    if cmdline:
+        args.append("--cmdline '{}'".format(cmdline))
 
     wasm_vm = getenv("WASM_VM", default="wavm")
     extra_env = {"WASM_VM": wasm_vm}

--- a/src/runner/func_runner.cpp
+++ b/src/runner/func_runner.cpp
@@ -26,12 +26,16 @@ int doRunner(int argc, char* argv[])
     std::string inputData;
     std::string cmdLine;
     po::options_description desc("Allowed options");
-    desc.add_options()
-      ("help", "print help message")
-      ("user", po::value<std::string>(&user), "function's user name (required)")
-      ("function", po::value<std::string>(&function), "function name (required)")
-      ("input-data", po::value<std::string>(&inputData), "input data for the function")
-      ("cmdline", po::value<std::string>(&inputData), "command line arguments to pass the function");
+    desc.add_options()(
+      "user", po::value<std::string>(&user), "function's user name (required)")(
+      "function",
+      po::value<std::string>(&function),
+      "function name (required)")("input-data",
+                                  po::value<std::string>(&inputData),
+                                  "input data for the function")(
+      "cmdline",
+      po::value<std::string>(&cmdLine),
+      "command line arguments to pass the function");
 
     // Mark user and function as positional arguments
     po::positional_options_description p;
@@ -40,30 +44,10 @@ int doRunner(int argc, char* argv[])
 
     // Parse command line arguments
     po::variables_map vm;
-    po::store(po::command_line_parser(argc, argv).
-              options(desc).positional(p).run(), vm);
+    po::store(
+      po::command_line_parser(argc, argv).options(desc).positional(p).run(),
+      vm);
     po::notify(vm);
-
-	if (vm.empty() || vm.count("help")) {
-        std::cout << "usage: func_runner <user> <function> [--input-data ...] [--cmdline ...]" << std::endl;
-        std::cout << desc << std::endl;
-		return 1;
-	}
-
-    if (!vm.count("user") || !vm.count("function")) {
-        std::cout << "User and function are required variables" << std::endl;
-		return 1;
-    }
-
-    return 0;
-
-
-    // Set up the call
-    bool hasInput = false;
-    if (argc == 4) {
-        inputData = argv[3];
-        hasInput = true;
-    }
 
     std::shared_ptr<faabric::BatchExecuteRequest> req =
       faabric::util::batchExecFactory(user, function, 1);
@@ -105,11 +89,14 @@ int doRunner(int argc, char* argv[])
         SPDLOG_INFO("Running function {}/{}", user, function);
     }
 
-    if (hasInput) {
-        std::string inputData = argv[3];
+    if (vm.count("input-data")) {
         msg.set_inputdata(inputData);
-
         SPDLOG_INFO("Adding input data: {}", inputData);
+    }
+
+    if (vm.count("cmdline")) {
+        msg.set_cmdline(cmdLine);
+        SPDLOG_INFO("Adding command line arguments: {}", cmdLine);
     }
 
     // Set up the system


### PR DESCRIPTION
In this PR I modify the `func_runner` to optionally take a string to set as command line for the running function. I also take the oportunity to make the argc/argv parsing in `func_runner` more modular.

In summary, we can now do the following:

```bash
# Will print "hello echo"
inv run demo echo --data "hello echo"

# Will print 'hello' and 'world' as arguments
inv run demo argc_argv --cmdline "hello world"
```

As I am writing this examples, I'm thinking it would be a good idea to have integration tests for the FaasmCLI... :thinking: 