### PR TITLE
Temporarily remove CGroup mode in docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To compile, upload and invoke a C++ function using this local cluster you can
 use the [faasm/cpp](https://github.com/faasm/cpp) container:
 
 ```bash
-docker compose run cpp /bin/bash
+docker compose run --rm cpp /bin/bash
 
 # Compile the demo function
 inv func demo hello

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,11 @@ services:
       - ${SGX_DEVICE_MOUNT_DIR:-./dev/faasm-local/sgx}:/dev/sgx
     environment:
       - CAPTURE_STDOUT=on
-      - CGROUP_MODE=on
+      # 02/11/2022 - Temporarily disable CGroup mode, to mitigate a potential
+      # mismatch between the host OS and the container image. Ubuntu 20.04
+      # uses CGroup v1, whereas Ubuntu 22.04 uses CGroup v2. This change will
+      # be reverted once we upgrade container images to 22.04
+      - CGROUP_MODE=off
       - GLOBAL_MESSAGE_TIMEOUT=600000
       - LOG_LEVEL=info
       - NETNS_MODE=off


### PR DESCRIPTION
As reported in #695, there seems to be a problem with CGroups when the host OS is 22.04 and the container image is running 20.04. This is because 22.04 has moved to CGroup v2, whereas 20.04 uses CGroup v1.

We temporarily disable CGroup's in `docker compose` which fixes #695. This had also been reported by @eleftheriamap before.

Hopefully moving our container images to 22.04 fixes the issue, but we want to make sure we don't break 20.04 installations then.

Related:
* https://askubuntu.com/questions/1376093/is-cgroup-tools-using-cgroup-v1-or-v2