### PR TITLE
Remove globbing from tests

### DIFF
--- a/tests/dist/CMakeLists.txt
+++ b/tests/dist/CMakeLists.txt
@@ -1,4 +1,9 @@
-file(GLOB_RECURSE TEST_FILES ${CMAKE_CURRENT_LIST_DIR} test_*.cpp)
+# Add the different test directories. Each subdirectory will populate the
+# TEST_FILES variable, adding the source files for the tests
+add_subdirectory(chaining)
+add_subdirectory(mpi)
+add_subdirectory(state)
+add_subdirectory(threads)
 
 # Tests
 add_executable(

--- a/tests/dist/chaining/CMakeLists.txt
+++ b/tests/dist/chaining/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_functions.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_hosts.cpp
+    PARENT_SCOPE
+)

--- a/tests/dist/mpi/CMakeLists.txt
+++ b/tests/dist/mpi/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_migration.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_multi_tenant.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_remote_execution.cpp
+    PARENT_SCOPE
+)

--- a/tests/dist/state/CMakeLists.txt
+++ b/tests/dist/state/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_state.cpp
+    PARENT_SCOPE
+)

--- a/tests/dist/threads/CMakeLists.txt
+++ b/tests/dist/threads/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_openmp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_pthreads.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/CMakeLists.txt
+++ b/tests/test/CMakeLists.txt
@@ -1,11 +1,22 @@
-file(GLOB_RECURSE TEST_FILES test_*.cpp)
-file(GLOB_RECURSE ENCLAVE_TEST_FILES enclave/test_*.cpp)
-file(GLOB_RECURSE ATTESTATION_TEST_FILES attestation/test_*.cpp)
+# Add the different test directories. Each subdirectory will populate the
+# TEST_FILES variable, adding the source files for the tests
+add_subdirectory(codegen)
+add_subdirectory(conf)
+add_subdirectory(faaslet)
+add_subdirectory(ported_libs)
+add_subdirectory(runner)
+add_subdirectory(storage)
+add_subdirectory(system)
+add_subdirectory(threads)
+add_subdirectory(upload)
+add_subdirectory(wamr)
+add_subdirectory(wasm)
+add_subdirectory(wavm)
 
-# Remove SGX tests if SGX disabled or not found
-if (FAASM_SGX_MODE STREQUAL "Disabled")
-    list(REMOVE_ITEM TEST_FILES ${ENCLAVE_TEST_FILES})
-    list(REMOVE_ITEM TEST_FILES ${ATTESTATION_TEST_FILES})
+# Add SGX tests if enabled
+if (NOT FAASM_SGX_MODE STREQUAL "Disabled")
+    add_subdirectory(attestation)
+    add_subdirectory(enclave)
 endif()
 
 add_executable(

--- a/tests/test/attestation/CMakeLists.txt
+++ b/tests/test/attestation/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_aas_client.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_enclave_info.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_quote_validation.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/codegen/CMakeLists.txt
+++ b/tests/test/codegen/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_machine_code_generator.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/conf/CMakeLists.txt
+++ b/tests/test/conf/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_conf.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/enclave/CMakeLists.txt
+++ b/tests/test/enclave/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_enclave.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_enclave_internals.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/faaslet/CMakeLists.txt
+++ b/tests/test/faaslet/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_chaining.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_dynamic_linking.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_env.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_errors.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_exec_graph.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_filesystem.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_flushing.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_io.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_lang.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_memory.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_mpi.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_python.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_shared_files.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_state.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_threads.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_time.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_zygote.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/ported_libs/CMakeLists.txt
+++ b/tests/test/ported_libs/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_ffmpeg.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_kernels.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_lammps.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_lulesh.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/ported_libs/CMakeLists.txt
+++ b/tests/test/ported_libs/CMakeLists.txt
@@ -1,7 +1,4 @@
 set(TEST_FILES ${TEST_FILES}
     ${CMAKE_CURRENT_LIST_DIR}/test_ffmpeg.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_kernels.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_lammps.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/test_lulesh.cpp
     PARENT_SCOPE
 )

--- a/tests/test/runner/CMakeLists.txt
+++ b/tests/test/runner/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_microbench_runner.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/storage/CMakeLists.txt
+++ b/tests/test/storage/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_file_descriptor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_file_loader.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_s3_wrapper.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_shared_files.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/system/CMakeLists.txt
+++ b/tests/test/system/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_cgroup.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_network.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/threads/CMakeLists.txt
+++ b/tests/test/threads/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_levels.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/upload/CMakeLists.txt
+++ b/tests/test/upload/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_upload.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/wamr/CMakeLists.txt
+++ b/tests/test/wamr/CMakeLists.txt
@@ -1,0 +1,4 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_wamr.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/wasm/CMakeLists.txt
+++ b/tests/test/wasm/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_cloning.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_dynamic_modules.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_execution_context.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_io.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_memory.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_openmp.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_snapshots.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_wasm.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_wasm_state.cpp
+    PARENT_SCOPE
+)

--- a/tests/test/wavm/CMakeLists.txt
+++ b/tests/test/wavm/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_FILES ${TEST_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/test_ir_registry.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_module_cache.cpp
+    PARENT_SCOPE
+)


### PR DESCRIPTION
This had been a long standing to-do that I address here. Remove the globbing for files and add them manually instead.