### PR TITLE
Remove LSAN

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,6 +134,7 @@ jobs:
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis
       ASAN_OPTIONS: "halt_on_error=1:quarantine_size_mb=16"
+      LSAN_OPTIONS: "suppressions=./leak-sanitizer-ignorelist.txt"
       TSAN_OPTIONS: "history_size=0 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt flush_memory_ms=5000"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=./ub-sanitizer-ignorelist.txt"
     container:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sanitiser: [None, Address, Thread, Undefined, Leak]
+        sanitiser: [None, Address, Thread, Undefined]
     env:
       CGROUP_MODE: off
       HOST_TYPE: ci
@@ -134,7 +134,6 @@ jobs:
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis
       ASAN_OPTIONS: "halt_on_error=1:quarantine_size_mb=16"
-      LSAN_OPTIONS: "suppressions=./leak-sanitizer-ignorelist.txt"
       TSAN_OPTIONS: "history_size=0 halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt flush_memory_ms=5000"
       UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1:suppressions=./ub-sanitizer-ignorelist.txt"
     container:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,7 +134,6 @@ services:
       - REDIS_STATE_HOST=redis-state
       - LD_LIBRARY_PATH=/build/faasm/third-party/lib:/usr/local/lib
       - ASAN_OPTIONS=halt_on_error=1:quarantine_size_mb=16
-      - LSAN_OPTIONS=suppressions=./leak-sanitizer-ignorelist.txt
       - TSAN_OPTIONS="halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=0 flush_memory_ms=5000"
       - UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:suppressions=./ub-sanitizer-ignorelist.txt
       - WASM_VM=${WASM_VM:-wavm}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
       - REDIS_STATE_HOST=redis-state
       - LD_LIBRARY_PATH=/build/faasm/third-party/lib:/usr/local/lib
       - ASAN_OPTIONS=halt_on_error=1:quarantine_size_mb=16
+      - LSAN_OPTIONS=suppressions=./leak-sanitizer-ignorelist.txt
       - TSAN_OPTIONS="halt_on_error=1 suppressions=./thread-sanitizer-ignorelist.txt history_size=0 flush_memory_ms=5000"
       - UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1:suppressions=./ub-sanitizer-ignorelist.txt
       - WASM_VM=${WASM_VM:-wavm}

--- a/leak-sanitizer-ignorelist.txt
+++ b/leak-sanitizer-ignorelist.txt
@@ -1,9 +1,0 @@
-# S3 SDK doesn't fully clean up after itself
-leak:Aws::Utils::Crypto::SecureRandomBytes_OpenSSLImpl
-leak:Aws::Crt::Io::TlsContext::TlsContext
-leak:EVP_CIPHER_CTX_new
-leak:EVP_EncryptInit_ex
-# Global WAVM modules
-leak:wasm::instantiateBaseModules
-# WAMR leaks
-leak:/build/faasm/_deps/wamr_ext-src/core/shared/platform/common/posix/posix_malloc.c

--- a/leak-sanitizer-ignorelist.txt
+++ b/leak-sanitizer-ignorelist.txt
@@ -1,0 +1,9 @@
+# S3 SDK doesn't fully clean up after itself
+leak:Aws::Utils::Crypto::SecureRandomBytes_OpenSSLImpl
+leak:Aws::Crt::Io::TlsContext::TlsContext
+leak:EVP_CIPHER_CTX_new
+leak:EVP_EncryptInit_ex
+# Global WAVM modules
+leak:wasm::instantiateBaseModules
+# WAMR leaks
+leak:/build/faasm/_deps/wamr_ext-src/core/shared/platform/common/posix/posix_malloc.c


### PR DESCRIPTION
See faasm/faabric#283

Note that [ASAN uses](https://clang.llvm.org/docs/AddressSanitizer.html#suppressing-memory-leaks) the env. variable `LSAN_OPTIONS` to configure its leak detection, so we keep the variable's definitions (in `docker-compose.yml` and `.github/workflows/tests.yml`) and the supression list.