### PR TITLE
Replace VLA usage with heap-allocated buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(FAASM_SGX_MODE "Type of SGX support: Disabled, Simulation or Hardware" "S
 option(FAASM_TARGET_CPU "CPU to optimise for, e.g. skylake, icelake or native" OFF)
 
 # Top-level CMake config
-set(CMAKE_CXX_FLAGS "-Wall")
+set(CMAKE_CXX_FLAGS "-Wall -Werror=vla")
 set(CMAKE_CXX_FLAGS_DEBUG "-g")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/tests/test/threads/test_levels.cpp
+++ b/tests/test/threads/test_levels.cpp
@@ -40,12 +40,11 @@ TEST_CASE("Check level serialisation and deserialisation", "[threads]")
     req->set_contextdata(serialised.data(), serialised.size());
 
     // Serialise and deserialise the protobuf object
-    size_t bufferSize = req->ByteSizeLong();
-    uint8_t buffer[bufferSize];
-    req->SerializeToArray(buffer, bufferSize);
+    std::string buffer;
+    REQUIRE(req->SerializeToString(&buffer));
 
     auto reqB = std::make_shared<faabric::BatchExecuteRequest>();
-    reqB->ParseFromArray(buffer, bufferSize);
+    reqB->ParseFromString(buffer);
     REQUIRE(reqB->contextdata().size() == expectedSize);
 
     // Deserialise the nested level object


### PR DESCRIPTION
Variable length arrays are a compiler extension and not part of the base c++ language, they cause dynamic stack allocations which can silently overflow the stack, causing hard-to-debug errors at runtime which I have ran into a couple of times with large network messages.

The corresponding faabric pr <https://github.com/faasm/faabric/pull/284> should be merged first.