### PR TITLE
Share codegen binaries between all test runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "Conan cache"
         uses: faasm/conan-cache-action@v1
       - name: "Build Conan dependencies to be shared by all runs"
-        run: ./bin/inv_wrapper.sh dev.cmake --build Debug --clean
+        run: ./bin/inv_wrapper.sh dev.cmake --build Debug
       - name: "Build codegen without sanitisers for all test runs"
         run: ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
       - name: "Upload codegen binaries"
@@ -208,7 +208,7 @@ jobs:
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
       - name: "Re-run CMake with sanitiser set"
-        run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
+        run: ./bin/inv_wrapper.sh dev.cmake --build Debug --sanitiser ${{ matrix.sanitiser }}
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run tests
@@ -278,7 +278,7 @@ jobs:
           key: ${{ env.CPU_MODEL }}-machine-code-${{ secrets.CACHE_VERSION }}
       # Code build (Debug required for tests)
       - name: "Build dev tools"
-        run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
+        run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation
       # Environment set-up
       - name: "Run codegen"
         run: ./bin/inv_wrapper.sh codegen.local

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,13 @@ jobs:
         uses: faasm/conan-cache-action@v1
       - name: "Build Conan dependencies to be shared by all runs"
         run: ./bin/inv_wrapper.sh dev.cmake --build Debug --clean
+      - name: "Build codegen without sanitisers for all test runs"
+        run: ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
+      - name: "Upload codegen binaries"
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          name: codegen-bin
+          path: /build/faasm/bin
 
   tests:
     if: github.event.pull_request.draft == false
@@ -187,13 +194,11 @@ jobs:
         with:
           path: /usr/local/faasm/object
           key: ${{ env.CPU_MODEL }}-machine-code-${{ secrets.CACHE_VERSION }}
-      # Codegen build without sanitisers
-      - name: "Build codegen - CMake"
-        run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser None
-      - name: "Build codegen - Codegen Func"
-        run: ./bin/inv_wrapper.sh dev.cc codegen_func
-      - name: "Build codegen - Codegen Shared Obj"
-        run: ./bin/inv_wrapper.sh dev.cc codegen_shared_obj
+      - name: "Download codegen binaries shared between test runs"
+        uses: actions/download-artifact@v3.0.1
+        with:
+          name: codegen-bin
+          path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen"
         run: ./bin/inv_wrapper.sh codegen.local

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,7 +116,7 @@ jobs:
       - name: "Conan cache"
         uses: faasm/conan-cache-action@v1
       - name: "Build Conan dependencies to be shared by all runs"
-        run: ./bin/inv_wrapper.sh dev.cmake --build Debug
+        run: ./bin/inv_wrapper.sh dev.cmake --build Debug --clean
       - name: "Build codegen without sanitisers for all test runs"
         run: ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
       - name: "Upload codegen binaries"
@@ -208,7 +208,7 @@ jobs:
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
       - name: "Re-run CMake with sanitiser set"
-        run: ./bin/inv_wrapper.sh dev.cmake --build Debug --sanitiser ${{ matrix.sanitiser }}
+        run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run tests
@@ -278,7 +278,7 @@ jobs:
           key: ${{ env.CPU_MODEL }}-machine-code-${{ secrets.CACHE_VERSION }}
       # Code build (Debug required for tests)
       - name: "Build dev tools"
-        run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation
+        run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
       # Environment set-up
       - name: "Run codegen"
         run: ./bin/inv_wrapper.sh codegen.local

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,10 +206,12 @@ jobs:
         run: ./bin/inv_wrapper.sh python.codegen
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
-      # Code build (Debug required for tests)
-      - name: "Build dev tools"
-        run: ./bin/inv_wrapper.sh dev.tools --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
-      # Test run
+      # Tests build (Debug required for tests)
+      - name: "Re-run CMake with sanitiser set"
+        run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
+      - name: "Build only the tests target"
+        run: ./bin/inv_wrapper.sh dev.cc tests
+      # Run tests
       - name: "Run the tests"
         run: /build/faasm/bin/tests
 


### PR DESCRIPTION
In GHA, we build `codegen_func` and `codegen_shared_obj` without sanitisers to generate machine code for test runs. Currently, we do it once for every test run in the matrix. This PR changes the behaviour to build it once per workflow run.

Different jobs in the matrix run in parallel, so _theoretically_ this change should not reduce overall runtime as the time we save in `tests(<Sanitiser>)` is now spent in `conan-cache` making `conan-cache + tests(<Sanitiser>)` the same. However, this does reduce considerably the aggregate runtime.

Take as an example [a run without this fix](https://github.com/faasm/faasm/actions/runs/3873241313/usage) and [a run with this fix](https://github.com/faasm/faasm/actions/runs/3875215210/usage) .