### PR TITLE
Codegen: proper command line argument parsing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,10 +200,8 @@ jobs:
           name: codegen-bin
           path: /build/faasm/bin
       # Environment set-up
-      - name: "Run codegen"
-        run: ./bin/inv_wrapper.sh codegen.local
-      - name: "Run python codegen"
-        run: ./bin/inv_wrapper.sh python.codegen
+      - name: "Run codegen for the tests"
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
@@ -280,10 +278,8 @@ jobs:
       - name: "Build dev tools"
         run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
       # Environment set-up
-      - name: "Run codegen"
-        run: ./bin/inv_wrapper.sh codegen.local
-      - name: "Run python codegen"
-        run: ./bin/inv_wrapper.sh python.codegen
+      - name: "Run codegen for the tests"
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Test run

--- a/bin/entrypoint_codegen.sh
+++ b/bin/entrypoint_codegen.sh
@@ -10,7 +10,7 @@ OBJ_DIR="/usr/local/faasm/object"
 if [[ "${PYTHON_CODEGEN}" == "on" ]]; then
   if [[ ! -f "$OBJ_DIR/python/py_func/function.wasm.o" ]]; then
     echo "Generating python object files"
-    ./bin/codegen_func python py_func
+    ./bin/codegen_func python --func py_func
     ./bin/codegen_shared_obj /usr/local/faasm/runtime_root/lib/python3.8
   fi
 fi

--- a/docs/source/development.md
+++ b/docs/source/development.md
@@ -83,7 +83,7 @@ inv func func.upload-all --local
 inv dev.tools
 
 # Run codegen (this may take a while the first time it's run)
-inv codegen.local python.codegen
+inv codegen.tests
 
 # Set up cgroup
 ./bin/cgroup.sh

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -6,7 +6,12 @@ from os import environ
 from os.path import join
 
 from faasmcli.util.codegen import find_codegen_func, find_codegen_shared_lib
-from faasmcli.util.env import FAASM_RUNTIME_ROOT
+from faasmcli.util.env import (
+    FAASM_RUNTIME_ROOT,
+    PY_RUNTIME_ROOT,
+    PYTHON_FUNC,
+    PYTHON_USER,
+)
 
 LIB_FAKE_FILES = [
     join(FAASM_RUNTIME_ROOT, "lib", "fake", "libfakeLibA.so"),
@@ -104,7 +109,7 @@ def _do_codegen_user(user, clean=False):
     run(codegen_cmd, shell=True, env=env, check=True)
 
 
-def _do_codegen_file(path, clean=False):
+def _do_codegen_shared_lib(path, clean=False):
     binary = find_codegen_shared_lib()
 
     env = copy(environ)
@@ -124,35 +129,77 @@ def _do_codegen_file(path, clean=False):
 
 @task
 def libs(ctx, clean=False):
-    # Do codegen for libfake
+    """
+    Run codegen for shared libraries
+    """
+    env = copy(environ)
+    env.update({"WASM_VM": "wavm"})
     for so in LIB_FAKE_FILES:
-        _do_codegen_file(so, clean)
+        _do_codegen_shared_lib(so, clean)
 
 
 @task
-def local(ctx, clean=False):
+def wavm(ctx, clean=False):
     """
-    Runs codegen on functions used in tests
+    Run codegen for shared libraries
     """
+    env = copy(environ)
+    env.update({"WASM_VM": "wavm"})
     _do_codegen_user("demo", clean)
     _do_codegen_user("errors", clean)
     _do_codegen_user("mpi", clean)
     _do_codegen_user("omp", clean)
-    _do_codegen_user("python", clean)
 
-    # Do codegen for libfake
-    for so in LIB_FAKE_FILES:
-        _do_codegen_file(so)
 
-    # For WAMR and SGX codegen, we need to update the environment
+@task
+def wamr(ctx, clean=False):
+    """
+    Run WAMR codegen
+    """
     env = copy(environ)
-
-    # Run the WAMR codegen required by the tests
     env.update({"WASM_VM": "wamr"})
     for user, func in WAMR_ALLOWED_FUNCS:
         codegen(ctx, user, func, clean)
 
-    # Run the SGX codegen required by the tests
+
+@task
+def sgx(ctx, clean=False):
+    """
+    Run SGX codegen
+    """
+    env = copy(environ)
     env.update({"WASM_VM": "sgx"})
     for user, func in SGX_ALLOWED_FUNCS:
         codegen(ctx, user, func, clean)
+
+
+@task
+def python(ctx, clean=False):
+    """
+    Run Python codegen
+    """
+    env = copy(environ)
+    env.update({"WASM_VM": "wavm"})
+    codegen(ctx, PYTHON_USER, PYTHON_FUNC, clean)
+    _do_codegen_shared_lib(PY_RUNTIME_ROOT, clean)
+
+
+@task
+def tests(ctx, clean=False):
+    """
+    Runs codegen for all WASM needed for the tests
+    """
+    # Run the WAVM codegen
+    wavm(ctx, clean)
+
+    # Do codegen for shared libraries
+    libs(ctx, clean)
+
+    # Run the WAMR codegen required by the tests
+    wamr(ctx, clean)
+
+    # Run the SGX codegen required by the tests
+    sgx(ctx, clean)
+
+    # Run the Python codegen
+    python(ctx, clean)

--- a/faasmcli/faasmcli/tasks/python.py
+++ b/faasmcli/faasmcli/tasks/python.py
@@ -1,17 +1,8 @@
-from copy import copy
-from os import environ
+from faasmcli.util.env import FAASM_RUNTIME_ROOT
+from faasmcli.util.files import glob_remove
+from invoke import task
 from os.path import join, exists
 from shutil import rmtree
-from subprocess import run
-
-from invoke import task
-
-from faasmcli.util import codegen as cg
-from faasmcli.util.env import (
-    FAASM_RUNTIME_ROOT,
-    PY_RUNTIME_ROOT,
-)
-from faasmcli.util.files import glob_remove
 
 
 def _clear_pyc_files(dir_path):
@@ -35,32 +26,3 @@ def clear_runtime_pyc(ctx):
     """
     print("Clearing out runtime pyc files")
     _clear_pyc_files(FAASM_RUNTIME_ROOT)
-
-
-@task
-def codegen(ctx, clean=False):
-    """
-    Run Python codegen
-    """
-    # Update env
-    shell_env = copy(environ)
-    shell_env.update(
-        {
-            "LD_LIBRARY_PATH": "/usr/local/lib/",
-        }
-    )
-
-    binary = cg.find_codegen_shared_lib()
-    codegen_cmd = [
-        binary,
-        PY_RUNTIME_ROOT,
-        "--clean" if clean else "",
-    ]
-    codegen_cmd = " ".join(codegen_cmd)
-    print(codegen_cmd)
-    run(
-        codegen_cmd,
-        env=shell_env,
-        shell=True,
-        check=True,
-    )

--- a/src/runner/codegen_func.cpp
+++ b/src/runner/codegen_func.cpp
@@ -12,7 +12,6 @@
 #include <boost/program_options.hpp>
 
 using namespace boost::filesystem;
-
 namespace po = boost::program_options;
 
 po::variables_map parseCmdLine(int argc, char* argv[])

--- a/src/runner/codegen_func.cpp
+++ b/src/runner/codegen_func.cpp
@@ -1,20 +1,46 @@
-#include <boost/filesystem.hpp>
+#include <codegen/MachineCodeGenerator.h>
+#include <conf/FaasmConfig.h>
 #include <faabric/util/config.h>
 #include <faabric/util/environment.h>
 #include <faabric/util/func.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
-
-#include <codegen/MachineCodeGenerator.h>
-#include <conf/FaasmConfig.h>
 #include <storage/FileLoader.h>
 #include <storage/S3Wrapper.h>
 
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
 using namespace boost::filesystem;
+
+namespace po = boost::program_options;
+
+po::variables_map parseCmdLine(int argc, char* argv[])
+{
+    // Define command line arguments
+    po::options_description desc("Allowed options");
+    desc.add_options()(
+      "user", po::value<std::string>(), "function's user name (required)")(
+      "func", po::value<std::string>(), "function's name")(
+      "clean", "overwrite existing generated code");
+
+    // Mark user and function as positional arguments
+    po::positional_options_description p;
+    p.add("user", 1);
+
+    // Parse command line arguments
+    po::variables_map vm;
+    po::store(
+      po::command_line_parser(argc, argv).options(desc).positional(p).run(),
+      vm);
+    po::notify(vm);
+
+    return vm;
+}
 
 void codegenForFunc(const std::string& user,
                     const std::string& func,
-                    bool clean = false)
+                    bool clean)
 {
     codegen::MachineCodeGenerator& gen = codegen::getMachineCodeGenerator();
     storage::FileLoader& loader = storage::getFileLoader();
@@ -38,31 +64,21 @@ int main(int argc, char* argv[])
 {
     faabric::util::initLogging();
     storage::initFaasmS3();
-
     conf::FaasmConfig& conf = conf::getFaasmConfig();
-    if (argc == 3) {
-        std::string user = argv[1];
-        std::string func = argv[2];
+
+    auto vm = parseCmdLine(argc, argv);
+    std::string user = vm["user"].as<std::string>();
+    bool clean = vm.find("clean") != vm.end();
+
+    if (vm.find("func") != vm.end()) {
+        std::string func = vm["func"].as<std::string>();
 
         SPDLOG_INFO("Running codegen for function {}/{} (WASM VM: {})",
                     user,
                     func,
                     conf.wasmVm);
-        codegenForFunc(user, func);
-    } else if (argc == 4) {
-        std::string user = argv[1];
-        std::string func = argv[2];
-        bool clean = std::string(argv[3]) == "--clean";
-
-        SPDLOG_INFO("Running codegen for function {}/{} (WASM VM: {})",
-                    user,
-                    func,
-                    conf.wasmVm,
-                    clean);
         codegenForFunc(user, func, clean);
-    } else if (argc == 2) {
-        std::string user = argv[1];
-
+    } else {
         SPDLOG_INFO(
           "Running codegen for user {} on dir {}", user, conf.functionDir);
 
@@ -74,14 +90,15 @@ int main(int argc, char* argv[])
             return 1;
         }
 
-        boost::filesystem::directory_iterator iter(path), end;
+        boost::filesystem::directory_iterator iter(path);
+        boost::filesystem::directory_iterator end;
         std::mutex mx;
 
         unsigned int nThreads = faabric::util::getUsableCores();
         std::vector<std::thread> threads;
 
         for (unsigned int i = 0; i < nThreads; i++) {
-            threads.emplace_back([&iter, &mx, &end, &user] {
+            threads.emplace_back([&iter, &mx, &end, &user, clean] {
                 SPDLOG_INFO("Spawning codegen thread");
 
                 while (true) {
@@ -105,7 +122,7 @@ int main(int argc, char* argv[])
                     directory_entry subPath(thisPath);
                     std::string functionName =
                       subPath.path().filename().string();
-                    codegenForFunc(user, functionName);
+                    codegenForFunc(user, functionName, clean);
                 }
             });
         }
@@ -115,9 +132,6 @@ int main(int argc, char* argv[])
                 t.join();
             }
         }
-    } else {
-        SPDLOG_ERROR("Must provide function user and optional function name");
-        return 0;
     }
 
     storage::shutdownFaasmS3();

--- a/src/runner/codegen_shared_obj.cpp
+++ b/src/runner/codegen_shared_obj.cpp
@@ -8,7 +8,6 @@
 #include <boost/filesystem.hpp>
 #include <boost/program_options.hpp>
 
-
 using namespace boost::filesystem;
 namespace po = boost::program_options;
 
@@ -16,8 +15,9 @@ po::variables_map parseCmdLine(int argc, char* argv[])
 {
     // Define command line arguments
     po::options_description desc("Allowed options");
-    desc.add_options()(
-      "input-path", po::value<std::string>(), "directory of shared objects (required)")(
+    desc.add_options()("input-path",
+                       po::value<std::string>(),
+                       "directory of shared objects (required)")(
       "clean", "overwrite existing generated code");
 
     // Mark user and function as positional arguments

--- a/src/runner/codegen_shared_obj.cpp
+++ b/src/runner/codegen_shared_obj.cpp
@@ -1,14 +1,38 @@
-#include <boost/filesystem.hpp>
-
+#include <codegen/MachineCodeGenerator.h>
 #include <faabric/util/environment.h>
 #include <faabric/util/locks.h>
 #include <faabric/util/logging.h>
 #include <faabric/util/string_tools.h>
-
-#include <codegen/MachineCodeGenerator.h>
 #include <storage/S3Wrapper.h>
 
+#include <boost/filesystem.hpp>
+#include <boost/program_options.hpp>
+
+
 using namespace boost::filesystem;
+namespace po = boost::program_options;
+
+po::variables_map parseCmdLine(int argc, char* argv[])
+{
+    // Define command line arguments
+    po::options_description desc("Allowed options");
+    desc.add_options()(
+      "input-path", po::value<std::string>(), "directory of shared objects (required)")(
+      "clean", "overwrite existing generated code");
+
+    // Mark user and function as positional arguments
+    po::positional_options_description p;
+    p.add("input-path", 1);
+
+    // Parse command line arguments
+    po::variables_map vm;
+    po::store(
+      po::command_line_parser(argc, argv).options(desc).positional(p).run(),
+      vm);
+    po::notify(vm);
+
+    return vm;
+}
 
 void codegenForDirectory(std::string& inputPath, bool clean)
 {
@@ -71,17 +95,10 @@ int main(int argc, char* argv[])
     faabric::util::initLogging();
     storage::initFaasmS3();
 
-    if (argc < 2) {
-        SPDLOG_ERROR("Must provide path to shared object dir");
-        return 1;
-    }
+    auto vm = parseCmdLine(argc, argv);
+    std::string inputPath = vm["input-path"].as<std::string>();
+    bool clean = vm.find("clean") != vm.end();
 
-    bool clean = false;
-    if (argc == 3) {
-        clean = std::string(argv[2]) == "--clean";
-    }
-
-    std::string inputPath = argv[1];
     if (is_directory(inputPath)) {
         codegenForDirectory(inputPath, clean);
     } else {


### PR DESCRIPTION
I wanted to run `inv codegen.local` with a `--clean` flag (to overwrite all generated code).

Adding the flag to the existing runner code, where we manually parse command line variables, proved very cumbersome (and conflicted with the previous addition of the `--clean` flag for `inv codegen <user> <func>`).

So, once and for all, I use `boost::program_options` for the code generation binaries, the same way we did before for function runner binaries. 

In addition, hacking around with `wasi-libc` and the toolchain in general makes it necessary to re-run the codegen several times during debugging for different runtimes. As a consequence, I re-factor `codegen.local` to `codegen.tests` (more intuitive) and break it down into: `codegen.wavm`, `codegen.wamr`, `codegen.sgx`, `codegen.python`, and `codegen.libs`. Each of which can be called indepdently as a separate task.