### PR TITLE
Task to bump tracked submodule version and check submodule tracked branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Cancel Workflow Action
         uses: styfle/cancel-workflow-action@0.11.0
 
-  formatting:
+  checks:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
@@ -32,10 +32,21 @@ jobs:
         # We need to set the safe git directory as formatting relies on git-ls
         # See actions/checkout#766
       - name: "Set the GH workspace as a safe git directory"
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/faabric"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/cpp"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE/python"
       # Formatting checks
       - name: "Code formatting check"
         run: ./bin/inv_wrapper.sh format-code --check
+      # Sanity checks
+      - name: "Check that the python and cpp versions tracked are correct"
+        run: |
+          ./bin/inv_wrapper.sh git.bump --python --cpp
+          git diff --exit-code
+      - name: "Check that all the submodules point to their 'main' branch"
+        run: inv git.check-submodule-branch
 
   docs:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: faasm/cpp-sysroot:0.2.0
+      image: faasm/cpp-sysroot:0.2.1
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: faasm/cpython:0.2.1
+      image: faasm/cpython:0.2.2
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
         # We need to set the safe git directory as formatting relies on git-ls
         # See actions/checkout#766
       - name: "Set the GH workspace as a safe git directory"
@@ -41,10 +42,6 @@ jobs:
       - name: "Code formatting check"
         run: ./bin/inv_wrapper.sh format-code --check
       # Sanity checks
-      - name: "Check that the python and cpp versions tracked are correct"
-        run: |
-          ./bin/inv_wrapper.sh git.bump --python --cpp
-          git diff --exit-code
       - name: "Check that all the submodules point to their 'main' branch"
         run: ./bin/inv_wrapper.sh git.check-submodule-branch
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           ./bin/inv_wrapper.sh git.bump --python --cpp
           git diff --exit-code
       - name: "Check that all the submodules point to their 'main' branch"
-        run: inv git.check-submodule-branch
+        run: ./bin/inv_wrapper.sh git.check-submodule-branch
 
   docs:
     if: github.event.pull_request.draft == false

--- a/docs/source/releases.md
+++ b/docs/source/releases.md
@@ -19,6 +19,10 @@ inv git.bump
 inv git.bump --ver=1.2.3
 ```
 
+> If you are updating the version of a client submodule (i.e. `clients/cpp`
+> or `clients/python`) you can bump the version of the files that track it
+> using `inv git.bump [--python] [--cpp]`
+
 Check the diff to make sure this hasn't edited anything we don't expect.
 
 Push all the changes to your branch.

--- a/faasmcli/faasmcli/tasks/cluster.py
+++ b/faasmcli/faasmcli/tasks/cluster.py
@@ -11,7 +11,7 @@ from faasmcli.util.env import (
     FAASM_SGX_MODE_SIM,
     PROJ_ROOT,
 )
-from faasmcli.util.version import get_faasm_version
+from faasmcli.util.version import get_version
 from faasmcli.util.env import AVAILABLE_HOSTS_SET
 
 
@@ -27,7 +27,7 @@ def start(ctx, workers=2, sgx=FAASM_SGX_MODE_DISABLED):
     env["FAASM_BUILD_MOUNT"] = "/build/faasm"
     env["FAASM_LOCAL_MOUNT"] = "/usr/local/faasm"
 
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
     if sgx == FAASM_SGX_MODE_SIM:
         env["FAASM_CLI_IMAGE"] = "faasm/cli-sgx-sim:{}".format(faasm_ver)
         env["FAASM_WORKER_IMAGE"] = "faasm/worker-sgx-sim:{}".format(faasm_ver)

--- a/faasmcli/faasmcli/tasks/docker_tasks.py
+++ b/faasmcli/faasmcli/tasks/docker_tasks.py
@@ -14,7 +14,7 @@ from faasmcli.util.env import (
     FAASM_SGX_MODE_SIM,
     PROJ_ROOT,
 )
-from faasmcli.util.version import get_faasm_version
+from faasmcli.util.version import get_version
 
 SGX_HW_CONTAINER_SUFFIX = "-sgx"
 SGX_SIMULATION_CONTAINER_SUFFIX = "-sgx-sim"
@@ -85,7 +85,7 @@ def build(ctx, c, nocache=False, push=False):
 
     _check_valid_containers(c)
 
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
 
     for container_name in c:
         # Prepare dockerfile and tag name
@@ -141,7 +141,7 @@ def push(ctx, c):
     """
     Push container images
     """
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
 
     _check_valid_containers(c)
 
@@ -154,7 +154,7 @@ def pull(ctx, c):
     """
     Pull container images
     """
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
 
     _check_valid_containers(c)
 
@@ -172,7 +172,7 @@ def delete_old(ctx):
     """
     Deletes old Docker images
     """
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
 
     dock = docker.from_env()
     images = dock.images.list()

--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -211,3 +211,22 @@ def publish_release(ctx):
     """
     rel = _get_release()
     rel.update_release(rel.title, rel.raw_data["body"], draft=False)
+
+
+@task
+def check_submodule_branch(ctx):
+    submodules = [
+        join(PROJ_ROOT, "faabric"),
+        join(PROJ_ROOT, "clients", "cpp"),
+        join(PROJ_ROOT, "clients", "python"),
+    ]
+    git_cmd = "git rev-parse --abbrev-ref HEAD"
+    for submodule in submodules:
+        out = (
+            run(git_cmd, shell=True, capture_output=True, cwd=submodule)
+            .stdout.decode("utf-8")
+            .strip()
+        )
+        if out != "main":
+            print("Submodule {} does not point to 'main' branch!")
+            raise RuntimeError("Submodule pointint to dangling commit")

--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -5,14 +5,15 @@ from os.path import join
 
 from faasmcli.util.env import PROJ_ROOT
 from faasmcli.util.config import get_faasm_config
-from faasmcli.util.version import get_faasm_version
+from faasmcli.util.version import get_version
 
 REPO_NAME = "faasm/faasm"
 
-VERSIONED_FILES = [
-    ".env",
-    "VERSION",
-]
+VERSIONED_FILES = {
+    "faasm": [".env", "VERSION"],
+    "cpp": [".env", ".github/workflows/tests.yml"],
+    "python": [".env", ".github/workflows/tests.yml"],
+}
 
 VERSIONED_DIRS = [
     join(PROJ_ROOT, ".github"),
@@ -25,7 +26,7 @@ def _tag_name(version):
 
 
 def _get_tag():
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
     tag_name = _tag_name(faasm_ver)
     return tag_name
 
@@ -87,38 +88,63 @@ def _create_tag(tag_name, force=False):
 
 
 @task
-def bump(ctx, ver=None):
+def bump(ctx, ver=None, python=False, cpp=False):
     """
     Increase the version (defaults to bumping a single minor version)
     """
-    old_ver = get_faasm_version()
+    bump_faasm_ver = (not python) and (not cpp)
+    if bump_faasm_ver:
+        old_ver = get_version()
+        if ver:
+            new_ver = ver
+        else:
+            # Just bump the last minor version part
+            new_ver_parts = old_ver.split(".")
+            new_ver_minor = int(new_ver_parts[-1]) + 1
+            new_ver_parts[-1] = str(new_ver_minor)
+            new_ver = ".".join(new_ver_parts)
 
-    if ver:
-        new_ver = ver
+        # Replace version in all files
+        for f in VERSIONED_FILES["faasm"]:
+            sed_cmd = "sed -i 's/{}/{}/g' {}".format(old_ver, new_ver, f)
+            run(sed_cmd, shell=True, check=True)
+
+        # Replace version in dirs (only for faasm)
+        for d in VERSIONED_DIRS:
+            sed_cmd = [
+                "find {}".format(d),
+                "-type f",
+                "-exec sed -i -e 's/{}/{}/g'".format(old_ver, new_ver),
+                "{} \\;",
+            ]
+            sed_cmd = " ".join(sed_cmd)
+            print(sed_cmd)
+
+            run(sed_cmd, shell=True, check=True)
     else:
-        # Just bump the last minor version part
-        new_ver_parts = old_ver.split(".")
-        new_ver_minor = int(new_ver_parts[-1]) + 1
-        new_ver_parts[-1] = str(new_ver_minor)
-        new_ver = ".".join(new_ver_parts)
-
-    # Replace version in all files
-    for f in VERSIONED_FILES:
-        sed_cmd = "sed -i 's/{}/{}/g' {}".format(old_ver, new_ver, f)
-        run(sed_cmd, shell=True, check=True)
-
-    # Replace version in dirs
-    for d in VERSIONED_DIRS:
-        sed_cmd = [
-            "find {}".format(d),
-            "-type f",
-            "-exec sed -i -e 's/{}/{}/g'".format(old_ver, new_ver),
-            "{} \\;",
-        ]
-        sed_cmd = " ".join(sed_cmd)
-        print(sed_cmd)
-
-        run(sed_cmd, shell=True, check=True)
+        # The python and cpp versions might be the same, so we need to be more
+        # careful when we increment each of them to make sure we only increment
+        # the version of the client we are interested in
+        if python:
+            old_ver, new_ver = get_version("python")
+            strings_to_check = [r"faasm\/cpython:", "PYTHON_VERSION="]
+            for f in VERSIONED_FILES["python"]:
+                for string in strings_to_check:
+                    sed_cmd = "sed -i 's/{}{}/{}{}/g' {}".format(
+                        string, old_ver, string, new_ver, f
+                    )
+                    print(sed_cmd)
+                    run(sed_cmd, shell=True, check=True)
+        if cpp:
+            old_ver, new_ver = get_version("cpp")
+            strings_to_check = [r"faasm\/cpp-sysroot:", "CPP_VERSION="]
+            for f in VERSIONED_FILES["python"]:
+                for string in strings_to_check:
+                    sed_cmd = "sed -i 's/{}{}/{}{}/g' {}".format(
+                        string, old_ver, string, new_ver, f
+                    )
+                    print(sed_cmd)
+                    run(sed_cmd, shell=True, check=True)
 
 
 @task
@@ -148,7 +174,7 @@ def get_release_body():
         "orhunp/git-cliff:latest",
         "--config cliff.toml",
         "--repository .",
-        "{}..v{}".format(_get_release().tag_name, get_faasm_version()),
+        "{}..v{}".format(_get_release().tag_name, get_version()),
     ]
 
     cmd = " ".join(docker_cmd)
@@ -165,7 +191,7 @@ def create_release(ctx):
     Create a draft release on Github
     """
     # Work out the tag
-    faasm_ver = get_faasm_version()
+    faasm_ver = get_version()
     tag_name = _tag_name(faasm_ver)
 
     # Create a release in github from this tag

--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -217,18 +217,20 @@ def publish_release(ctx):
 def check_submodule_branch(ctx):
     """
     Check that the commit hash for HEAD (i.e. where the submodule points to)
-    and the main branch match
+    matches the main branch as tracked from faasm (not the main branch in
+    general)
     """
     submodules = [
         join(PROJ_ROOT, "faabric"),
         join(PROJ_ROOT, "clients", "cpp"),
         join(PROJ_ROOT, "clients", "python"),
     ]
-    git_cmd = "git rev-list -n 1 "
+    # git_cmd = "git rev-list -n 1 "
     for submodule in submodules:
         head_commit = (
             run(
-                git_cmd + " HEAD",
+                # git_cmd + " HEAD",
+                "git rev-parse HEAD",
                 shell=True,
                 capture_output=True,
                 cwd=submodule,
@@ -238,17 +240,18 @@ def check_submodule_branch(ctx):
         )
         main_commit = (
             run(
-                git_cmd + " main",
+                # git_cmd + " main",
+                "git rev-parse main:{}".format(submodule),
                 shell=True,
                 capture_output=True,
-                cwd=submodule,
+                cwd=PROJ_ROOT,
             )
             .stdout.decode("utf-8")
             .strip()
         )
         if head_commit != main_commit:
             print(
-                "Submodule {}'s head and main don't match: {}!={})".format(
+                "Submodule {}'s head and main don't match: {} != {})".format(
                     submodule, head_commit, main_commit
                 )
             )

--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -228,5 +228,9 @@ def check_submodule_branch(ctx):
             .strip()
         )
         if out != "main":
-            print("Submodule {} does not point to 'main' branch!")
+            print(
+                "Submodule {} does not point to 'main' branch! ({})".format(
+                    submodule, out
+                )
+            )
             raise RuntimeError("Submodule pointint to dangling commit")

--- a/faasmcli/faasmcli/util/version.py
+++ b/faasmcli/faasmcli/util/version.py
@@ -1,20 +1,38 @@
+from faasmcli.util.env import PROJ_ROOT
 from os.path import join
 
-from faasmcli.util.env import PROJ_ROOT
 
-_version = None
+def get_version(project="faasm"):
+    def read_version_from_file(filename):
+        with open(filename, "r") as fh:
+            version = fh.read()
+            version = version.strip()
+        return version
 
+    def read_version_from_env_file(env_file, var_name):
+        with open(env_file, "r") as fh:
+            lines = fh.readlines()
+            lines = [line.strip() for line in lines if var_name in line]
+            if len(lines) != 1:
+                raise RuntimeError("Inconsistent env. file state")
+            return lines[0].split("=")[1]
 
-def get_faasm_version():
-    global _version
+    if project == "faasm":
+        ver_file = join(PROJ_ROOT, "VERSION")
+        return read_version_from_file(ver_file)
 
-    ver_file = join(PROJ_ROOT, "VERSION")
+    env_file = join(PROJ_ROOT, ".env")
+    if project == "cpp":
+        old_ver = read_version_from_env_file(env_file, "CPP_VERSION")
+        new_ver_file = join(PROJ_ROOT, "clients", "cpp", "VERSION")
+        new_ver = read_version_from_file(new_ver_file)
+        return old_ver, new_ver
 
-    if not _version:
-        with open(ver_file, "r") as fh:
-            _version = fh.read()
-            _version = _version.strip()
+    if project == "python":
+        old_ver = read_version_from_env_file(env_file, "PYTHON_VERSION")
+        new_ver_file = join(PROJ_ROOT, "clients", "python", "VERSION")
+        new_ver = read_version_from_file(new_ver_file)
+        return old_ver, new_ver
 
-        print("Read Faasm version: {}".format(_version))
-
-    return _version
+    print("Unrecognised project name to get version from: {}".format(project))
+    raise RuntimeError("Unrecognised project name")


### PR DESCRIPTION
We want to make sure that the value of `./clients/[python,cpp]/VERSION` is the same than the one we use (i) in the gha file, and (ii) in `docker compose` (and transitively in the `quick-start` tests).

This PR adds:
* A function to bump the tracked version of the cpp or the python submodule.
* A check in GHA's that makes sure that the aforementioned versions are in sync.

I include the new check in the old `formatting` job, that I now re-factor to `checks`.

Whilst I am at it, I also include a check that makes sure that all submodules point to the `main` branch. On the down side, this means that a PR spanning multiple repos (as it happens often) will never be fully green until all submodules have been merged in. On the up side, this will prevent the very frequent issue of forgetting to update the branch after merge, which is quite non-intuitive.