### PR TITLE
gha: azure integration tests manual action (part 1)

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -16,5 +16,3 @@ jobs:
     steps:
       - name: "Checck out the experiment-base code"
         uses: actions/checkout@v3
-        with:
-          repository: faasm/experiment-base

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -4,8 +4,7 @@ name: "Azure Integration Tests"
 # integration tests on a production environment. To limit the cost of running
 # them, we only trigger them on workflow dispatch. In order to run them, you
 # need to navigate to the Actions tab on GitHub, and click the run button
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 defaults:
   run:

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -4,7 +4,8 @@ name: "Azure Integration Tests"
 # integration tests on a production environment. To limit the cost of running
 # them, we only trigger them on workflow dispatch. In order to run them, you
 # need to navigate to the Actions tab on GitHub, and click the run button
-on: workflow_dispatch
+on:
+  workflow_dispatch:
 
 defaults:
   run:

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -18,15 +18,3 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: faasm/experiment-base
-            #       - name: "Start a managed k8s cluster on Azure's Kubernetes Service"
-            #         run: ./bin/inv_wrapper.sh \
-            #           # TODO: deploy with a different name (as a parameter) and allow --sgx=False
-            #           cluster.provision --vm Standard_DC4s_v3 --nodes 4 --location eastus2 --sgx \
-            #         # TODO: consider using a special path for `.kubeconfig`
-            #           cluster.credentials
-            #       - name: "Deploy the Faasm cluster"
-            #         # TODO: make the number of workers a GHA parameter and allow --sgx=False
-            #         run: ./bin/inv_wrapper.sh k8s.deploy --workers=4 --sgx
-            #       - name: "Check that the cluster was provisioned succesfully"
-            #         run: kubectl get pods -n kube-system | grep sgx
-            #         # TODO: delete the cluster inconditionally

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -1,0 +1,32 @@
+name: "Azure Integration Tests"
+
+# These tests provision resources on Faasm's Azure subscription to run
+# integration tests on a production environment. To limit the cost of running
+# them, we only trigger them on workflow dispatch. In order to run them, you
+# need to navigate to the Actions tab on GitHub, and click the run button
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sgx-hw:
+    runs-on: self-hosted
+    steps:
+      - name: "Checck out the experiment-base code"
+        uses: actions/checkout@v3
+        with:
+          repository: faasm/experiment-base
+            #       - name: "Start a managed k8s cluster on Azure's Kubernetes Service"
+            #         run: ./bin/inv_wrapper.sh \
+            #           # TODO: deploy with a different name (as a parameter) and allow --sgx=False
+            #           cluster.provision --vm Standard_DC4s_v3 --nodes 4 --location eastus2 --sgx \
+            #         # TODO: consider using a special path for `.kubeconfig`
+            #           cluster.credentials
+            #       - name: "Deploy the Faasm cluster"
+            #         # TODO: make the number of workers a GHA parameter and allow --sgx=False
+            #         run: ./bin/inv_wrapper.sh k8s.deploy --workers=4 --sgx
+            #       - name: "Check that the cluster was provisioned succesfully"
+            #         run: kubectl get pods -n kube-system | grep sgx
+            #         # TODO: delete the cluster inconditionally


### PR DESCRIPTION
I want to add a GHA that runs a kubernetes cluster on Azure and tests at least the hello world example (i.e. like a quick start test but on a production environment).

In order to minimise the associated costs, I set up the PR to be triggered on [`workflow_dispatch`](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow). This means that to run the Action, one needs to navigate to the "Actions" tab, and click a button.

However, in order to be able to test the GHA (i.e. click on the "Run the workflow" button), the workflow [needs to exist on the default branch](https://stackoverflow.com/questions/58933155/manual-workflow-triggers-in-github-actions/62768214#comment111440150_62768214).

Thus, in this PR I merge a basic workflow configured to run on workflow dispatch, and will edit it in a subsequent PR.