### PR TITLE
gha: add template for SGX HW tests

### DIFF
--- a/.github/workflows/sgx_hw.yml
+++ b/.github/workflows/sgx_hw.yml
@@ -1,0 +1,23 @@
+name: "SGX Hardware Mode Tests"
+
+# This workflow runs the set of tests in SGX Hardware mode. We run them on a
+# latest-generation IceLake VM on Azure, so we only run them either on dispatch
+# or when a new commit is pushed to the _main_ branch. Even though this will
+# not catch regressions before merging them in, testing only on commits to main
+# strikes a compromise between testing often and not spending too much money
+# on Azure.
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  sgx-hw:
+    runs-on: self-hosted
+    steps:
+      - name: "Check out the experiment-base code"
+        uses: actions/checkout@v3


### PR DESCRIPTION
Similarly to #725, I want to add a _new_ workflow that runs on `workflow_dispatch`.

In order to be able to test it against a branch, the workflow needs to appear in the default branch. Thus, in this PR I just add the skeleton, and populate it in #726.