### PR TITLE
K8s deployment files for WAMR

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -13,8 +13,6 @@ defaults:
 jobs:
   aks:
     runs-on: self-hosted
-    env:
-      CLUSTER_NAME_BASE: gha-cluster
     strategy:
       fail-fast: true
       # Running two Kubernetes clusters side-by-side from the same user in the
@@ -25,7 +23,10 @@ jobs:
       # run one after the other, so we don't implement the fix.
       max-parallel: 1
       matrix:
-        sgx: [True, False]
+        wasm_vm: [wamr, wavm, sgx]
+    env:
+      CLUSTER_NAME_BASE: gha-cluster
+      WASM_VM: ${{ matrix.wasm_vm }}
     steps:
       - name: "Check out the experiment-base code"
         uses: actions/checkout@v3
@@ -34,14 +35,14 @@ jobs:
           path: experiment-base
       - name: "Create a unique cluster name"
         run: |
-          [[ "${{ matrix.sgx }}" == "true" ]] && SUFFIX_SGX="-sgx" || SUFFIX_SGX=""
-          echo "CLUSTER_NAME=${CLUSTER_NAME_BASE}${SUFFIX_SGX}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=${CLUSTER_NAME_BASE}-${{ matrix.wasm_vm }}-${{ github.job }}-${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: "Install kubectl"
         run: ./bin/inv_wrapper.sh k8s.install-kubectl
         working-directory: ${{ github.workspace }}/experiment-base
       - name: "Start a managed k8s cluster on Azure's Kubernetes Service"
         run: |
-          ./bin/inv_wrapper.sh cluster.provision --name ${{ env.CLUSTER_NAME }} --vm Standard_DC4s_v3 --nodes 4 --location eastus2 --sgx ${{ matrix.sgx }}
+          [[ "${{ matrix.wasm_vm }}" == "sgx" ]] && SUFFIX_SGX="True" || SUFFIX_SGX="False"
+          ./bin/inv_wrapper.sh cluster.provision --name ${{ env.CLUSTER_NAME }} --vm Standard_DC4s_v3 --nodes 4 --location eastus2 --sgx ${SUFFIX_SGX}
           ./bin/inv_wrapper.sh cluster.credentials --name ${{ env.CLUSTER_NAME }}
         working-directory: ${{ github.workspace }}/experiment-base
       - name: "Check out faasm code"
@@ -50,7 +51,7 @@ jobs:
           submodules: true
           path: faasm
       - name: "Deploy Faasm on k8s cluster"
-        run: ./bin/inv_wrapper.sh k8s.deploy --workers=4 --sgx ${{ matrix.sgx }}
+        run: ./bin/inv_wrapper.sh k8s.deploy --workers=4
         working-directory: ${{ github.workspace }}/faasm
       - name: "Build, upload and run a simple CPP function"
         run: docker compose -f docker-compose-k8s.yml run -T cpp-cli ./bin/inv_wrapper.sh func demo hello func.upload demo hello func.invoke demo hello

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -3,8 +3,16 @@ name: "Azure Integration Tests"
 # These tests provision resources on Faasm's Azure subscription to run
 # integration tests on a production environment. To limit the cost of running
 # them, we only trigger them on workflow dispatch. In order to run them, you
-# need to navigate to the Actions tab on GitHub, and click the run button
-on: workflow_dispatch
+# need to navigate to the Actions tab on GitHub, and click the run button.
+# Additionally, we also run them when we change the deployment files, to check
+# that we don't break anything
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "deploy/**yml"
 
 defaults:
   run:

--- a/deploy/k8s-wamr/upload.yml
+++ b/deploy/k8s-wamr/upload.yml
@@ -1,0 +1,30 @@
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: upload
+  namespace: faasm
+  labels:
+    app: faasm
+    role: upload
+spec:
+  containers:
+    - name: upload
+      image: faasm.azurecr.io/upload:0.9.5
+      ports:
+        - containerPort: 8002
+        - containerPort: 5000
+      env:
+        - name: REDIS_STATE_HOST
+          value: "redis-state"
+        - name: REDIS_QUEUE_HOST
+          value: "redis-queue"
+        - name: LOG_LEVEL
+          value: "info"
+        - name: LD_LIBRARY_PATH
+          value: "/build/faasm/third-party/lib:/usr/local/lib"
+        - name: PYTHON_CODEGEN
+          value: "off"
+        - name: WASM_VM
+          value: "wamr"

--- a/deploy/k8s-wamr/worker.yml
+++ b/deploy/k8s-wamr/worker.yml
@@ -31,18 +31,10 @@ spec:
               weight: 100
 
       containers:
-        - image: faasm.azurecr.io/worker-sgx:0.9.5
+        - image: faasm.azurecr.io/worker:0.9.5
           name: faasm-worker
           ports:
             - containerPort: 8080
-          resources:
-            limits:
-              sgx.intel.com/epc: "10Mi"
-            requests:
-              sgx.intel.com/epc: "10Mi"
-          volumeMounts:
-            - name: var-run-aesmd
-              mountPath: /var/run/aesmd # hardcoded in intels libarary, volume name must match that of the daemonset
           env:
             - name: REDIS_STATE_HOST
               value: "redis-state"
@@ -70,8 +62,3 @@ spec:
               value: "eth0"
             - name: WASM_VM
               value: "wamr"
-
-      volumes:
-      - name: var-run-aesmd
-        hostPath:
-          path: /var/run/aesmd

--- a/deploy/k8s-wamr/worker.yml
+++ b/deploy/k8s-wamr/worker.yml
@@ -1,0 +1,77 @@
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: faasm-worker
+  namespace: faasm
+  labels:
+    app: faasm
+spec:
+  selector:
+    matchLabels:
+      run: faasm-worker
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        run: faasm-worker
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: run
+                      operator: In
+                      values:
+                      - faasm-worker
+                topologyKey: kubernetes.io/hostname
+              weight: 100
+
+      containers:
+        - image: faasm.azurecr.io/worker-sgx:0.9.5
+          name: faasm-worker
+          ports:
+            - containerPort: 8080
+          resources:
+            limits:
+              sgx.intel.com/epc: "10Mi"
+            requests:
+              sgx.intel.com/epc: "10Mi"
+          volumeMounts:
+            - name: var-run-aesmd
+              mountPath: /var/run/aesmd # hardcoded in intels libarary, volume name must match that of the daemonset
+          env:
+            - name: REDIS_STATE_HOST
+              value: "redis-state"
+            - name: REDIS_QUEUE_HOST
+              value: "redis-queue"
+            - name: LOG_LEVEL
+              value: "info"
+            - name: CAPTURE_STDOUT
+              value: "on"
+            - name: CGROUP_MODE
+              value: "off"
+            - name: NETNS_MODE
+              value: "off"
+            - name: MAX_NET_NAMESPACES
+              value: "100"
+            - name: PYTHON_PRELOAD
+              value: "off"
+            - name: PYTHON_CODEGEN
+              value: "off"
+            - name: BOUND_TIMEOUT
+              value: "600000"
+            - name: GLOBAL_MESSAGE_TIMEOUT
+              value: "700000"
+            - name: ENDPOINT_INTERFACE
+              value: "eth0"
+            - name: WASM_VM
+              value: "worker"
+
+      volumes:
+      - name: var-run-aesmd
+        hostPath:
+          path: /var/run/aesmd

--- a/deploy/k8s-wamr/worker.yml
+++ b/deploy/k8s-wamr/worker.yml
@@ -69,7 +69,7 @@ spec:
             - name: ENDPOINT_INTERFACE
               value: "eth0"
             - name: WASM_VM
-              value: "worker"
+              value: "wamr"
 
       volumes:
       - name: var-run-aesmd

--- a/faasmcli/faasmcli/tasks/k8s.py
+++ b/faasmcli/faasmcli/tasks/k8s.py
@@ -62,7 +62,7 @@ def _get_faasm_worker_pods(label):
     return names, ips
 
 
-@task(optional=["sgx"])
+@task
 def deploy(ctx, workers):
     """
     Deploy Faasm to a k8s cluster


### PR DESCRIPTION
In this PR I add support to start a WAMR k8s deployment.

We follow the design choice for other command line options like `inv run` or `inv codegen`; when running `inv k8s.deploy` we pick up the value of the `WASM_VM` env. variable.

This way, the following would deploy a Faasm k8s cluster using WAVM, WAMR, or SGX WASM runtimes:

```bash
WASM_VM={wavm,wamr,sgx} inv k8s.deploy --workers=4
```