### PR TITLE
Fix `refresh_local` to use ACR image tags

### DIFF
--- a/bin/refresh_local.sh
+++ b/bin/refresh_local.sh
@@ -21,9 +21,9 @@ FAASM_VERSION=$(cat VERSION)
 CPP_VERSION=$(cat clients/cpp/VERSION)
 PY_VERSION=$(cat clients/python/VERSION)
 
-IMAGE_TAG=faasm/cli:${FAASM_VERSION}
-CPP_IMAGE_TAG=faasm/cpp-sysroot:${CPP_VERSION}
-PY_IMAGE_TAG=faasm/cpython:${PY_VERSION}
+IMAGE_TAG=faasm.azurecr.io/cli:${FAASM_VERSION}
+CPP_IMAGE_TAG=faasm.azurecr.io/cpp-sysroot:${CPP_VERSION}
+PY_IMAGE_TAG=faasm.azurecr.io/cpython:${PY_VERSION}
 
 # This path needs to be absolute with no ..s
 TARGET_DIR=$(pwd)/dev/faasm-local


### PR DESCRIPTION
In addition, I think that the order in which we copy the contents into the mount folders matters, and it can break things.

For example, given that the cpp-sysroot container is the one used first, its libfaasm version will be overwritten by the ones in the other images (given that we just copy with a wildcard).

I have been wanting to migrate this to `inv` tasks, so will probably fix this at the same time.