### PR TITLE
Task to bump tracked `faabric` version

### DIFF
--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -14,7 +14,7 @@ VERSIONED_FILES = {
     "faabric": [
         ".env",
         ".github/workflows/tests.yml",
-        "deploy/k8s-common/planner.yml",
+        "./deploy/k8s-common/planner.yml",
     ],
     "cpp": [".env", ".github/workflows/tests.yml"],
     "python": [".env", ".github/workflows/tests.yml"],
@@ -162,7 +162,7 @@ def bump(ctx, ver=None, python=False, cpp=False, faabric=False):
                 r"{}\/planner:".format(ACR_NAME),
                 "FAABRIC_VERSION=",
             ]
-            for f in VERSIONED_FILES["python"]:
+            for f in VERSIONED_FILES["faabric"]:
                 for string in strings_to_check:
                     sed_cmd = "sed -i 's/{}{}/{}{}/g' {}".format(
                         string, old_ver, string, new_ver, f

--- a/faasmcli/faasmcli/tasks/git.py
+++ b/faasmcli/faasmcli/tasks/git.py
@@ -11,6 +11,11 @@ REPO_NAME = "faasm/faasm"
 
 VERSIONED_FILES = {
     "faasm": [".env", "VERSION"],
+    "faabric": [
+        ".env",
+        ".github/workflows/tests.yml",
+        "deploy/k8s-common/planner.yml",
+    ],
     "cpp": [".env", ".github/workflows/tests.yml"],
     "python": [".env", ".github/workflows/tests.yml"],
 }
@@ -88,11 +93,11 @@ def _create_tag(tag_name, force=False):
 
 
 @task
-def bump(ctx, ver=None, python=False, cpp=False):
+def bump(ctx, ver=None, python=False, cpp=False, faabric=False):
     """
     Increase the version (defaults to bumping a single minor version)
     """
-    bump_faasm_ver = (not python) and (not cpp)
+    bump_faasm_ver = (not python) and (not cpp) and (not faabric)
     if bump_faasm_ver:
         old_ver = get_version()
         if ver:
@@ -143,6 +148,19 @@ def bump(ctx, ver=None, python=False, cpp=False):
             strings_to_check = [
                 r"{}\/cpp-sysroot:".format(ACR_NAME),
                 "CPP_VERSION=",
+            ]
+            for f in VERSIONED_FILES["python"]:
+                for string in strings_to_check:
+                    sed_cmd = "sed -i 's/{}{}/{}{}/g' {}".format(
+                        string, old_ver, string, new_ver, f
+                    )
+                    print(sed_cmd)
+                    run(sed_cmd, shell=True, check=True)
+        if faabric:
+            old_ver, new_ver = get_version("faabric")
+            strings_to_check = [
+                r"{}\/planner:".format(ACR_NAME),
+                "FAABRIC_VERSION=",
             ]
             for f in VERSIONED_FILES["python"]:
                 for string in strings_to_check:

--- a/faasmcli/faasmcli/util/version.py
+++ b/faasmcli/faasmcli/util/version.py
@@ -34,5 +34,11 @@ def get_version(project="faasm"):
         new_ver = read_version_from_file(new_ver_file)
         return old_ver, new_ver
 
+    if project == "faabric":
+        old_ver = read_version_from_env_file(env_file, "FAABRIC_VERSION")
+        new_ver_file = join(PROJ_ROOT, "faabric", "VERSION")
+        new_ver = read_version_from_file(new_ver_file)
+        return old_ver, new_ver
+
     print("Unrecognised project name to get version from: {}".format(project))
     raise RuntimeError("Unrecognised project name")


### PR DESCRIPTION
Akin to #721, but there we also bumped the versions for `cpp` and `python`. This was because, at that point, we did not need to track the faabric version for any docker images. Now, with the planner we do, as the planner is tagged with faabric's version.