### PR TITLE
Remove obsolete `callFunction` signature

### DIFF
--- a/src/faaslet/Faaslet.cpp
+++ b/src/faaslet/Faaslet.cpp
@@ -42,15 +42,15 @@ void preloadPythonRuntime()
 
     SPDLOG_INFO("Preparing python runtime");
 
-    faabric::Message msg =
-      faabric::util::messageFactory(PYTHON_USER, PYTHON_FUNC);
+    auto req = faabric::util::batchExecFactory(PYTHON_USER, PYTHON_FUNC, 1);
+    auto& msg = *req->mutable_messages(0);
     msg.set_ispython(true);
     msg.set_pythonuser("python");
     msg.set_pythonfunction("noop");
-    faabric::util::setMessageId(msg);
+    msg.set_topologyhint("FORCE_LOCAL");
 
     faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.callFunction(msg, true);
+    sch.callFunctions(req);
 }
 
 Faaslet::Faaslet(faabric::Message& msg)

--- a/src/wamr/faasm.cpp
+++ b/src/wamr/faasm.cpp
@@ -177,6 +177,7 @@ static void __faasm_write_output_wrapper(wasm_exec_env_t exec_env,
 
     faabric::Message& call = ExecutorContext::get()->getMsg();
     call.set_outputdata(outBuff, outLen);
+    SPDLOG_WARN("Written output: {}", call.outputdata());
 }
 
 static NativeSymbol ns[] = {

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -104,42 +104,6 @@ int makeChainedCall(const std::string& functionName,
     return msg.id();
 }
 
-// TODO: is this used?
-int spawnChainedThread(const std::string& snapshotKey,
-                       size_t snapshotSize,
-                       int funcPtr,
-                       int argsPtr)
-{
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-
-    faabric::Message& originalMsg =
-      faabric::scheduler::ExecutorContext::get()->getMsg();
-    faabric::Message call =
-      faabric::util::messageFactory(originalMsg.user(), originalMsg.function());
-    call.set_isasync(true);
-
-    // Propagate app ID
-    call.set_appid(originalMsg.appid());
-
-    // Snapshot details
-    call.set_snapshotkey(snapshotKey);
-
-    // Function pointer and args
-    // NOTE - with a pthread interface we only ever pass the function a single
-    // pointer argument, hence we use the input data here to hold this argument
-    // as a string
-    call.set_funcptr(funcPtr);
-    call.set_inputdata(std::to_string(argsPtr));
-
-    const std::string origStr = faabric::util::funcToString(originalMsg, false);
-    const std::string chainedStr = faabric::util::funcToString(call, false);
-
-    // Schedule the call
-    sch.callFunction(call);
-
-    return call.id();
-}
-
 int awaitChainedCallOutput(unsigned int messageId, char* buffer, int bufferLen)
 {
     int callTimeoutMs = conf::getFaasmConfig().chainedCallTimeout;

--- a/tests/test/enclave/test_enclave.cpp
+++ b/tests/test/enclave/test_enclave.cpp
@@ -14,9 +14,9 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[sgx]")
 {
     auto req = setUpContext("demo", "hello");
-    faabric::Message& msg = req->mutable_messages()->at(0);
+    conf.wasmVm = "sgx";
 
-    execSgxFunction(msg);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -24,8 +24,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[sgx]")
 {
     auto req = setUpContext("demo", "hello");
-    faabric::Message& msg = req->mutable_messages()->at(0);
+    conf.wasmVm = "sgx";
 
-    execFuncWithSgxPool(msg, 10000);
+    executeWithPool(req, 10000);
 }
 }

--- a/tests/test/faaslet/test_chaining.cpp
+++ b/tests/test/faaslet/test_chaining.cpp
@@ -5,32 +5,28 @@
 
 #include <faabric/util/environment.h>
 
-using namespace faaslet;
-
 namespace tests {
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test function chaining",
+                 "Test function chaining by pointer",
                  "[faaslet]")
 {
     SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
     SECTION("WAMR") { conf.wasmVm = "wamr"; }
 
-    faabric::Message call = faabric::util::messageFactory("demo", "chain");
-    execFuncWithPool(call, true, 5000);
+    auto req = faabric::util::batchExecFactory("demo", "chain", 1);
+    executeWithPool(req, 5000);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test named function chaining",
+                 "Test function chaining by name",
                  "[faaslet]")
 {
     SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
     SECTION("WAMR") { conf.wasmVm = "wamr"; }
 
-    faabric::Message call =
-      faabric::util::messageFactory("demo", "chain_named_a");
-    execFuncWithPool(call, true, 5000);
+    auto req = faabric::util::batchExecFactory("demo", "chain_named_a", 1);
+    executeWithPool(req, 5000);
 }
-
 }

--- a/tests/test/faaslet/test_dynamic_linking.cpp
+++ b/tests/test/faaslet/test_dynamic_linking.cpp
@@ -17,10 +17,9 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
     REQUIRE(boost::filesystem::exists(filePath));
 
     auto req = setUpContext("demo", "dynlink");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("Single execution") { execFunction(msg); }
+    SECTION("Single execution") { executeWithPool(req); }
 
-    SECTION("Multiple execution") { checkMultipleExecutions(msg, 3); }
+    SECTION("Multiple execution") { executeWithPoolMultipleTimes(req, 3); }
 }
 }

--- a/tests/test/faaslet/test_env.cpp
+++ b/tests/test/faaslet/test_env.cpp
@@ -12,11 +12,12 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet][wamr]")
 {
     auto req = setUpContext("demo", "getenv");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -24,20 +25,20 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "conf_flags");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
-TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test exit",
-                 "[faaslet][wamr]")
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test exit", "[faaslet]")
 {
     auto req = setUpContext("demo", "exit");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
     // 21/02/2023 - See bytecodealliance/wasm-micro-runtime#1979
     // SECTION("WAMR") { execWamrFunction(msg); }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -45,7 +46,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "optarg");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -53,13 +55,15 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "sysconf");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test uname", "[faaslet]")
 {
     auto req = setUpContext("demo", "uname");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -67,7 +71,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "getpwuid");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -75,7 +80,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "getcwd");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -86,15 +92,17 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
     faabric::Message& msg = req->mutable_messages()->at(0);
     msg.set_cmdline("alpha B_eta G$mma d3-lt4");
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
 
     /* 04/03/2023 - This test is failing in hardware mode
     #ifndef FAASM_SGX_DISABLED_MODE
         SECTION("SGX") { execSgxFunction(msg); }
     #endif
     */
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
@@ -102,6 +110,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "waitpid");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 }

--- a/tests/test/faaslet/test_exec_graph.cpp
+++ b/tests/test/faaslet/test_exec_graph.cpp
@@ -11,8 +11,8 @@ TEST_CASE_METHOD(
   "Test function chaining can be recorded in the execution graph",
   "[exec-graph][chaining]")
 {
-    faabric::Message call =
-      faabric::util::messageFactory("demo", "chain_named_a");
+    auto req = faabric::util::batchExecFactory("demo", "chain_named_a", 1);
+    auto& call = *req->mutable_messages(0);
     int expectedNumNodes;
 
     SECTION("Turn recording on")
@@ -23,7 +23,7 @@ TEST_CASE_METHOD(
 
     SECTION("Recording off (default)") { expectedNumNodes = 1; }
 
-    sch.callFunction(call);
+    sch.callFunctions(req);
     faabric::Message result = sch.getFunctionResult(call, 5000);
     REQUIRE(result.returnvalue() == 0);
 
@@ -37,7 +37,8 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
                  "Test MPI executions can be recorded in the execution graph",
                  "[exec-graph][mpi]")
 {
-    faabric::Message call = faabric::util::messageFactory("mpi", "mpi_bcast");
+    auto req = faabric::util::batchExecFactory("mpi", "mpi_bcast", 1);
+    auto& call = *req->mutable_messages(0);
     call.set_mpiworldsize(5);
     int expectedNumNodes;
 
@@ -49,7 +50,7 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
 
     SECTION("Recording off (default)") { expectedNumNodes = 1; }
 
-    sch.callFunction(call);
+    sch.callFunctions(req);
     faabric::Message result = sch.getFunctionResult(call, 5000);
     REQUIRE(result.returnvalue() == 0);
 

--- a/tests/test/faaslet/test_filesystem.cpp
+++ b/tests/test/faaslet/test_filesystem.cpp
@@ -36,9 +36,8 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                                           "hosts", "passwd", "resolv.conf" };
 
     auto req = setUpContext("demo", "getdents");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    const std::string result = execFunctionWithStringResult(msg);
+    const std::string result = executeWithPool(req).at(0).outputdata();
     std::vector<std::string> actual = splitString(result, ",");
 
     // Check we have a sensible number
@@ -59,64 +58,66 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "listdir");
-    execFunction(req);
+
+    executeWithPool(req);
 }
 
-TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test fcntl",
-                 "[faaslet][wamr]")
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test fcntl", "[faaslet]")
 {
     auto req = setUpContext("demo", "fcntl");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test fread", "[faaslet]")
 {
     auto req = setUpContext("demo", "fread");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
-TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test fstat",
-                 "[faaslet][wamr]")
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test fstat", "[faaslet]")
 {
     auto req = setUpContext("demo", "fstat");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test file operations",
-                 "[faaslet][wamr]")
+                 "[faaslet]")
 {
     auto req = setUpContext("demo", "file");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test file descriptors",
-                 "[faaslet][wamr]")
+                 "[faaslet]")
 {
     auto req = setUpContext("demo", "filedescriptor");
-    faabric::Message& msg = req->mutable_messages()->at(0);
 
-    SECTION("WAVM") { execFunction(msg); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(msg); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 }

--- a/tests/test/faaslet/test_lang.cpp
+++ b/tests/test/faaslet/test_lang.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "ptr_ptr");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture,
@@ -19,30 +19,30 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "long_double");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test sizes", "[faaslet]")
 {
     auto req = setUpContext("demo", "sizes");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test stack/ heap", "[faaslet]")
 {
     auto req = setUpContext("demo", "stackheap");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test backtrace", "[faaslet]")
 {
     auto req = setUpContext("demo", "backtrace");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test varargs", "[faaslet]")
 {
     auto req = setUpContext("demo", "va_arg");
-    execFunction(req);
+    executeWithPool(req);
 }
 }

--- a/tests/test/faaslet/test_memory.cpp
+++ b/tests/test/faaslet/test_memory.cpp
@@ -9,18 +9,18 @@ namespace tests {
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test memcpy", "[faaslet]")
 {
     auto req = setUpContext("demo", "memcpy");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test memmove", "[faaslet]")
 {
     auto req = setUpContext("demo", "memmove");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test calloc", "[faaslet]")
 {
     auto req = setUpContext("demo", "calloc");
-    execFunction(req);
+    executeWithPool(req);
 }
 }

--- a/tests/test/faaslet/test_mpi.cpp
+++ b/tests/test/faaslet/test_mpi.cpp
@@ -30,7 +30,8 @@ class MPIFuncTestFixture
         // Note: we don't `set_mpiworldsize` here, so all tests run with the
         // default MPI world size (5). Some tests will fail if we change this.
         faabric::Message msg = faabric::util::messageFactory("mpi", funcName);
-        faabric::Message result = execFuncWithPool(msg, true, 10000);
+        auto req = faabric::util::batchExecFactory("mpi", funcName, 1);
+        faabric::Message result = executeWithPool(req, 10000).at(0);
 
         // Check all other functions were successful
         auto& sch = faabric::scheduler::getScheduler();

--- a/tests/test/faaslet/test_shared_files.cpp
+++ b/tests/test/faaslet/test_shared_files.cpp
@@ -4,16 +4,14 @@
 #include "fixtures.h"
 #include "utils.h"
 
-#include <storage/FileLoader.h>
-
 #include <faabric/util/bytes.h>
 #include <faabric/util/config.h>
 #include <faabric/util/files.h>
 #include <faabric/util/func.h>
+#include <storage/FileLoader.h>
+#include <wamr/WAMRWasmModule.h>
 
 #include <boost/filesystem.hpp>
-
-#include <wamr/WAMRWasmModule.h>
 
 namespace tests {
 
@@ -45,9 +43,11 @@ TEST_CASE_METHOD(SharedFilesExecTestFixture,
 
     // Execute the function
     auto req = setUpContext("demo", "shared_file");
-    SECTION("WAVM") { execFunction(req); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(req->mutable_messages()->at(0)); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 
     // Check file has been synced locally
     REQUIRE(boost::filesystem::exists(fullPath));

--- a/tests/test/faaslet/test_threads.cpp
+++ b/tests/test/faaslet/test_threads.cpp
@@ -9,7 +9,6 @@
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
 #include <faabric/util/testing.h>
-
 #include <wavm/WAVMWasmModule.h>
 
 namespace tests {
@@ -28,7 +27,7 @@ class PthreadTestFixture
         std::shared_ptr<faabric::BatchExecuteRequest> req =
           faabric::util::batchExecFactory("demo", function, 1);
 
-        execBatchWithPool(req, nThreads);
+        executeWithPool(req);
     }
 
   protected:

--- a/tests/test/faaslet/test_time.cpp
+++ b/tests/test/faaslet/test_time.cpp
@@ -8,6 +8,6 @@ namespace tests {
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test time progresses", "[faaslet]")
 {
     auto req = setUpContext("demo", "gettime");
-    execFunction(req->mutable_messages()->at(0));
+    executeWithPool(req);
 }
 }

--- a/tests/test/faaslet/test_zygote.cpp
+++ b/tests/test/faaslet/test_zygote.cpp
@@ -11,7 +11,7 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "zygote_check");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture,
@@ -19,6 +19,6 @@ TEST_CASE_METHOD(FunctionExecTestFixture,
                  "[faaslet]")
 {
     auto req = setUpContext("demo", "zygote_check");
-    checkMultipleExecutions(req->mutable_messages()->at(0), 4);
+    executeWithPoolMultipleTimes(req, 4);
 }
 }

--- a/tests/test/main.cpp
+++ b/tests/test/main.cpp
@@ -3,14 +3,14 @@
 // Disable catch signal catching to avoid interfering with dirty tracking
 #define CATCH_CONFIG_NO_POSIX_SIGNALS 1
 
+#include <catch2/catch.hpp>
+
 #include "faabric_utils.h"
 #include "utils.h"
 
-#include <catch2/catch.hpp>
-
 #include <faabric/util/crash.h>
 #include <faabric/util/logging.h>
-
+#include <faaslet/Faaslet.h>
 #include <storage/S3Wrapper.h>
 #include <storage/SharedFiles.h>
 

--- a/tests/test/wamr/test_wamr.cpp
+++ b/tests/test/wamr/test_wamr.cpp
@@ -3,10 +3,10 @@
 #include "faasm_fixtures.h"
 #include "utils.h"
 
+#include <conf/FaasmConfig.h>
 #include <faabric/util/config.h>
 #include <faabric/util/func.h>
-
-#include <conf/FaasmConfig.h>
+#include <faaslet/Faaslet.h>
 #include <wamr/WAMRWasmModule.h>
 
 using namespace wasm;

--- a/tests/test/wasm/test_io.cpp
+++ b/tests/test/wasm/test_io.cpp
@@ -12,12 +12,12 @@ namespace tests {
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test printf", "[wasm]")
 {
     auto req = setUpContext("demo", "print");
-    execFunction(req);
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture, "Test emscripten I/O", "[wasm]")
 {
     auto req = setUpContext("demo", "emscripten_check");
-    execFunction(req);
+    executeWithPool(req);
 }
 }

--- a/tests/test/wasm/test_memory.cpp
+++ b/tests/test/wasm/test_memory.cpp
@@ -153,24 +153,26 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
 
 TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
                  "Test mmap/munmap",
-                 "[faaslet]")
+                 "[wasm]")
 {
+    auto req = setUpContext("demo", "mmap");
+
     SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
     SECTION("WAMR") { conf.wasmVm = "wamr"; }
 
-    checkCallingFunctionGivesBoolOutput("demo", "mmap", true);
+    REQUIRE(executeWithPoolGetBooleanResult(req));
 }
 
-TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
-                 "Test big mmap",
-                 "[faaslet]")
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture, "Test big mmap", "[wasm]")
 {
     auto req = setUpContext("demo", "mmap_big");
 
-    SECTION("WAVM") { execFunction(req); }
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
 
-    SECTION("WAMR") { execWamrFunction(req->mutable_messages()->at(0)); }
+    SECTION("WAMR") { conf.wasmVm = "wamr"; }
+
+    executeWithPool(req);
 }
 
 TEST_CASE_METHOD(FunctionExecTestFixture,

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -205,7 +205,7 @@ TEST_CASE_METHOD(OpenMPTestFixture,
 
     auto req = faabric::util::batchExecFactory("omp", "nested_parallel", 1);
     auto& msg = *req->mutable_messages(0);
-    faabric::Message result = executeWithPool(req).at(0);
+    faabric::Message result = executeWithPool(req, 1000, false).at(0);
 
     // Get result
     REQUIRE(result.returnvalue() > 0);

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -31,8 +31,9 @@ class OpenMPTestFixture
     std::string doOmpTestLocal(const std::string& function)
     {
         faabric::Message msg = faabric::util::messageFactory("omp", function);
+        auto req = faabric::util::batchExecFactory("omp", function, 1);
         faabric::Message result =
-          execFuncWithPool(msg, false, OMP_TEST_TIMEOUT_MS);
+          executeWithPool(req, OMP_TEST_TIMEOUT_MS).at(0);
 
         return result.outputdata();
     }
@@ -184,9 +185,10 @@ TEST_CASE_METHOD(OpenMPTestFixture,
 
     // Overload the number of cores
     faabric::Message msg = faabric::util::messageFactory("omp", "mem_stress");
+    auto req = faabric::util::batchExecFactory("omp", "mem_stress", 1);
     msg.set_cmdline(std::to_string(nOmpThreads));
 
-    execFuncWithPool(msg, false, OMP_TEST_TIMEOUT_MS);
+    executeWithPool(req, OMP_TEST_TIMEOUT_MS);
 }
 
 TEST_CASE_METHOD(OpenMPTestFixture,
@@ -201,9 +203,9 @@ TEST_CASE_METHOD(OpenMPTestFixture,
     res.set_slots(nSlots);
     sch.setThisHostResources(res);
 
-    faabric::Message msg =
-      faabric::util::messageFactory("omp", "nested_parallel");
-    faabric::Message result = execErrorFunction(msg);
+    auto req = faabric::util::batchExecFactory("omp", "nested_parallel", 1);
+    auto& msg = *req->mutable_messages(0);
+    faabric::Message result = executeWithPool(req).at(0);
 
     // Get result
     REQUIRE(result.returnvalue() > 0);

--- a/tests/test/wavm/test_module_cache.cpp
+++ b/tests/test/wavm/test_module_cache.cpp
@@ -6,7 +6,7 @@
 #include <faabric/proto/faabric.pb.h>
 #include <faabric/util/func.h>
 #include <faabric/util/macros.h>
-
+#include <faaslet/Faaslet.h>
 #include <wavm/WAVMWasmModule.h>
 
 namespace tests {

--- a/tests/utils/utils.h
+++ b/tests/utils/utils.h
@@ -2,41 +2,27 @@
 
 #include <faabric/util/func.h>
 
-#include <faaslet/Faaslet.h>
+#define EXECUTE_POOL_TIMEOUT_MS 1000
 
 namespace tests {
-void execFunction(std::shared_ptr<faabric::BatchExecuteRequest> req,
-                  const std::string& expectedOutput = "");
+// ------
+// Base functions to execute a batch in a runner pool
+// ------
 
-void execFunction(faabric::Message& msg,
-                  const std::string& expectedOutput = "");
+std::vector<faabric::Message> waitForBatchResults(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int timeoutMs,
+  bool requireSuccess);
 
-void execWamrFunction(faabric::Message& msg,
-                      const std::string& expectedOutput = "");
+std::vector<faabric::Message> executeWithPool(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int timeoutMs = EXECUTE_POOL_TIMEOUT_MS,
+  bool requireSuccess = true);
 
-std::string execFunctionWithStringResult(faabric::Message& msg);
+void executeWithPoolMultipleTimes(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int numRepeats);
 
-void execBatchWithPool(std::shared_ptr<faabric::BatchExecuteRequest> req,
-                       int nThreads);
-
-faabric::Message execFuncWithPool(faabric::Message& call,
-                                  bool clean = true,
-                                  int timeout = 1000);
-
-faabric::Message execErrorFunction(faabric::Message& call);
-
-void executeWithWamrPool(const std::string& user,
-                         const std::string& func,
-                         int timeout = 1000);
-
-void execSgxFunction(faabric::Message& call,
-                     const std::string& expectedOutput = "");
-
-void execFuncWithSgxPool(faabric::Message& call, int timeout = 1000);
-
-void checkMultipleExecutions(faabric::Message& msg, int nExecs);
-
-void checkCallingFunctionGivesBoolOutput(const std::string& user,
-                                         const std::string& funcName,
-                                         bool expected);
+bool executeWithPoolGetBooleanResult(
+  std::shared_ptr<faabric::BatchExecuteRequest> req);
 }

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -1,127 +1,51 @@
-#include "utils.h"
 #include <catch2/catch.hpp>
 
-#include <faabric/proto/faabric.pb.h>
-#include <faabric/runner/FaabricMain.h>
-#include <faabric/scheduler/FunctionCallClient.h>
-#include <faabric/snapshot/SnapshotClient.h>
-#include <faabric/snapshot/SnapshotRegistry.h>
-#include <faabric/util/bytes.h>
-#include <faabric/util/config.h>
-#include <faabric/util/environment.h>
-#include <faabric/util/logging.h>
-#include <faabric/util/testing.h>
-#include <faaslet/Faaslet.h>
+#include "utils.h"
 
 #include <conf/FaasmConfig.h>
-#ifndef FAASM_SGX_DISABLED_MODE
-#include <enclave/outside/EnclaveInterface.h>
-#endif
-#include <wamr/WAMRWasmModule.h>
-#include <wavm/WAVMWasmModule.h>
+#include <faabric/proto/faabric.pb.h>
+#include <faabric/runner/FaabricMain.h>
+#include <faaslet/Faaslet.h>
 
 using namespace faaslet;
 
 namespace tests {
 
-void execFunction(std::shared_ptr<faabric::BatchExecuteRequest> req,
-                  const std::string& expectedOutput)
+std::vector<faabric::Message> waitForBatchResults(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int timeoutMs,
+  bool requireSuccess)
 {
-    return execFunction(req->mutable_messages()->at(0), expectedOutput);
-}
+    auto& sch = faabric::scheduler::getScheduler();
 
-void execFunction(faabric::Message& call, const std::string& expectedOutput)
-{
-    // Turn off python preloading
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    std::string originalPreload = conf.pythonPreload;
-    conf.pythonPreload = "off";
+    std::vector<faabric::Message> resultMsgs;
 
-    wasm::WAVMWasmModule module;
-    module.bindToFunction(call);
-    int returnValue = module.executeFunction(call);
-
-    if (!expectedOutput.empty()) {
-        std::string actualOutput = call.outputdata();
-        REQUIRE(actualOutput == expectedOutput);
+    for (const auto& m : req->messages()) {
+        if (req->type() == faabric::BatchExecuteRequest::THREADS) {
+            int returnValue = sch.awaitThreadResult(m.id());
+            if (requireSuccess) {
+                REQUIRE(returnValue == 0);
+            }
+            faabric::Message result;
+            result.set_id(m.id());
+            result.set_returnvalue(returnValue);
+            resultMsgs.push_back(result);
+        } else {
+            faabric::Message result = sch.getFunctionResult(m, 20000);
+            if (requireSuccess) {
+                REQUIRE(result.returnvalue() == 0);
+            }
+            resultMsgs.push_back(result);
+        }
     }
 
-    REQUIRE(returnValue == 0);
-    REQUIRE(call.returnvalue() == 0);
-
-    conf.pythonPreload = originalPreload;
+    return resultMsgs;
 }
 
-void execWamrFunction(faabric::Message& call, const std::string& expectedOutput)
-{
-    // Turn off python preloading
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    std::string originalPreload = conf.pythonPreload;
-    conf.pythonPreload = "off";
-    conf.wasmVm = "wamr";
-
-    wasm::WAMRWasmModule module;
-    module.bindToFunction(call);
-    int returnValue = module.executeFunction(call);
-
-    if (!expectedOutput.empty()) {
-        std::string actualOutput = call.outputdata();
-        REQUIRE(actualOutput == expectedOutput);
-    }
-    module.reset(call, "");
-
-    REQUIRE(returnValue == 0);
-    REQUIRE(call.returnvalue() == 0);
-
-    conf.pythonPreload = originalPreload;
-}
-
-std::string execFunctionWithStringResult(faabric::Message& call)
-{
-    // Turn off python preloading
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    std::string originalPreload = conf.pythonPreload;
-    conf.pythonPreload = "off";
-
-    auto fac = std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startRunner();
-
-    // Call the function
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.callFunction(call);
-
-    // This timeout needs to be long enough for slow functions to execute
-    const faabric::Message result = sch.getFunctionResult(call, 20000);
-    if (result.returnvalue() != 0) {
-        SPDLOG_ERROR("Function failed: {}", result.outputdata());
-        FAIL();
-    }
-    REQUIRE(result.returnvalue() == 0);
-
-    conf.pythonPreload = originalPreload;
-
-    m.shutdown();
-
-    return result.outputdata();
-}
-
-void checkMultipleExecutions(faabric::Message& msg, int nExecs)
-{
-    wasm::WAVMWasmModule module;
-    module.bindToFunction(msg);
-
-    for (int i = 0; i < nExecs; i++) {
-        int returnValue = module.executeFunction(msg);
-        REQUIRE(returnValue == 0);
-
-        // Reset
-        module.reset(msg, "");
-    }
-}
-
-void execBatchWithPool(std::shared_ptr<faabric::BatchExecuteRequest> req,
-                       int nSlots)
+std::vector<faabric::Message> executeWithPool(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int timeoutMs,
+  bool requireSuccess)
 {
     faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
     conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
@@ -142,158 +66,29 @@ void execBatchWithPool(std::shared_ptr<faabric::BatchExecuteRequest> req,
     usleep(1000 * 500);
 
     // Wait for all functions to complete
-    for (auto& m : req->messages()) {
-        if (req->type() == faabric::BatchExecuteRequest::THREADS) {
-            int returnValue = sch.awaitThreadResult(m.id());
-            REQUIRE(returnValue == 0);
-        } else {
-            faabric::Message result = sch.getFunctionResult(m, 20000);
-            REQUIRE(result.returnvalue() == 0);
-        }
+    auto resultMsgs = waitForBatchResults(req, timeoutMs, requireSuccess);
+
+    m.shutdown();
+
+    return resultMsgs;
+}
+
+void executeWithPoolMultipleTimes(
+  std::shared_ptr<faabric::BatchExecuteRequest> req,
+  int numRepeats)
+{
+    for (int i = 0; i < numRepeats; i++) {
+        executeWithPool(req);
     }
-
-    m.shutdown();
 }
 
-faabric::Message execFuncWithPool(faabric::Message& call,
-                                  bool clean,
-                                  int timeout)
+bool executeWithPoolGetBooleanResult(
+  std::shared_ptr<faabric::BatchExecuteRequest> req)
 {
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.shutdown();
-    sch.addHostToGlobalSet();
+    auto resultMsg = executeWithPool(req).at(0);
 
-    // Modify system config (network ns requires root)
-    faabric::util::SystemConfig& conf = faabric::util::getSystemConfig();
-    conf::FaasmConfig& faasmConf = conf::getFaasmConfig();
-    std::string originalNsMode = faasmConf.netNsMode;
-    conf.boundTimeout = timeout;
-    faasmConf.netNsMode = "off";
+    SPDLOG_WARN("Result: {}", resultMsg.outputdata());
 
-    // Set up the system
-    auto fac = std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startRunner();
-
-    // Make the call
-    sch.callFunction(call);
-
-    // Await the result of the main function
-    // NOTE - this timeout will only get hit when things have failed.
-    // It also needs to be long enough to let longer tests complete
-    faabric::Message result = sch.getFunctionResult(call, timeout);
-    REQUIRE(result.returnvalue() == 0);
-
-    faasmConf.netNsMode = originalNsMode;
-
-    m.shutdown();
-
-    return result;
-}
-
-void doWamrPoolExecution(faabric::Message& msg, int timeout = 1000)
-{
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    const std::string originalVm = conf.wasmVm;
-    conf.wasmVm = "wamr";
-
-    // Don't clean so that the WAMR configuration persists
-    execFuncWithPool(msg, false, timeout);
-
-    conf.wasmVm = originalVm;
-}
-
-faabric::Message execErrorFunction(faabric::Message& call)
-{
-    auto fac = std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startRunner();
-
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.callFunction(call);
-
-    faabric::Message result = sch.getFunctionResult(call, 1);
-
-    m.shutdown();
-
-    return result;
-}
-
-void executeWithWamrPool(const std::string& user,
-                         const std::string& func,
-                         int timeout)
-{
-    faabric::Message call = faabric::util::messageFactory(user, func);
-    doWamrPoolExecution(call, timeout);
-}
-
-void execSgxFunction(faabric::Message& call, const std::string& expectedOutput)
-{
-#ifndef FAASM_SGX_DISABLED_MODE
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    const std::string originalVm = conf.wasmVm;
-    conf.wasmVm = "sgx";
-
-    wasm::EnclaveInterface enclaveInterface;
-    enclaveInterface.bindToFunction(call);
-    int returnValue = enclaveInterface.executeFunction(call);
-
-    if (!expectedOutput.empty()) {
-        std::string actualOutput = call.outputdata();
-        REQUIRE(actualOutput == expectedOutput);
-    }
-
-    REQUIRE(returnValue == 0);
-    REQUIRE(call.returnvalue() == 0);
-
-    conf.wasmVm = originalVm;
-#else
-    SPDLOG_ERROR("Running SGX test but SGX is disabled");
-#endif
-}
-
-void execFuncWithSgxPool(faabric::Message& call, int timeout)
-{
-#ifndef FAASM_SGX_DISABLED_MODE
-    conf::FaasmConfig& conf = conf::getFaasmConfig();
-    const std::string originalVm = conf.wasmVm;
-    conf.wasmVm = "sgx";
-
-    // Don't clean so that the SGX configuration persists
-    execFuncWithPool(call, false, timeout);
-
-    conf.wasmVm = originalVm;
-#else
-    SPDLOG_ERROR("Running SGX test but SGX is disabled");
-#endif
-}
-
-void checkCallingFunctionGivesBoolOutput(const std::string& user,
-                                         const std::string& funcName,
-                                         bool expected)
-{
-    faabric::Message call = faabric::util::messageFactory("demo", funcName);
-
-    faabric::scheduler::Scheduler& sch = faabric::scheduler::getScheduler();
-    sch.callFunction(call);
-
-    auto fac = std::make_shared<faaslet::FaasletFactory>();
-    faabric::runner::FaabricMain m(fac);
-    m.startRunner();
-
-    // Check output is true
-    faabric::Message result = sch.getFunctionResult(call, 1);
-    REQUIRE(result.returnvalue() == 0);
-
-    std::string expectedOutput;
-    if (expected) {
-        expectedOutput = "success";
-    } else {
-        expectedOutput = "failure";
-    }
-
-    REQUIRE(result.outputdata() == expectedOutput);
-
-    m.shutdown();
+    return resultMsg.outputdata() == "1";
 }
 }

--- a/tests/utils/worker_utils.cpp
+++ b/tests/utils/worker_utils.cpp
@@ -89,6 +89,6 @@ bool executeWithPoolGetBooleanResult(
 
     SPDLOG_WARN("Result: {}", resultMsg.outputdata());
 
-    return resultMsg.outputdata() == "1";
+    return resultMsg.outputdata() == "success";
 }
 }


### PR DESCRIPTION
Originally, we used `callFunction(faabric::Message)` to invoke function execution. At some point we moved to `callFunctions(faabric::BatchExecuteRequest)`, and we kept the former for backwards-compatibility.

In this PR, I remove the usage of `callFunction` altogether, simplifying the code-base. In the process, I also simplify the variety of `exec*` functions we had for the tests, making all of them boil down to the same baseline code.