### PR TITLE
Use file loader without local cache in the upload server

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,17 +245,6 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
-      # Run 1 test
-      # - name: "Run 1 test"
-        # run: |
-          # ./bin/inv_wrapper.sh dev.cc codegen_func
-          # This works sometimes (line below)
-          # ./bin/inv_wrapper.sh codegen.wamr --clean
-          # This does not work (line below)
-          # ./bin/inv_wrapper.sh codegen.tests --clean
-          # This works (line below)
-          # WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
-      #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,9 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests
+        run: |
+          ./bin/inv_wrapper.sh codegen.tests
+          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
@@ -246,15 +248,15 @@ jobs:
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run 1 test
-      - name: "Run 1 test"
-        run: |
-          ./bin/inv_wrapper.sh dev.cc codegen_func
+      # - name: "Run 1 test"
+        # run: |
+          # ./bin/inv_wrapper.sh dev.cc codegen_func
           # This works sometimes (line below)
           # ./bin/inv_wrapper.sh codegen.wamr --clean
           # This does not work (line below)
           # ./bin/inv_wrapper.sh codegen.tests --clean
           # This works (line below)
-          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+          # WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,7 +248,7 @@ jobs:
       # Run 1 test
       - name: "Run 1 test"
         run: |
-          ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
+          ./bin/inv_wrapper.sh dev.cc codegen_func
           ./bin/inv_wrapper.sh codegen.wamr --clean
           # This does not work (line below)
           # ./bin/inv_wrapper.sh codegen.tests --clean

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests --clean
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,7 +249,9 @@ jobs:
       - name: "Run 1 test"
         run: |
           ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
-          ./bin/inv_wrapper.sh codegen.tests --clean
+          ./bin/inv_wrapper.sh codegen.wamr --clean
+          # This does not work (line below)
+          # ./bin/inv_wrapper.sh codegen.tests --clean
           # This works (line below)
           # WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests --clean
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
@@ -246,10 +246,10 @@ jobs:
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run 1 test
-      #       - name: "Run 1 test"
-      #         run: |
-      #           ./bin/inv_wrapper.sh dev.cc codegen_func
-      #           WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+      - name: "Run 1 test"
+        run: |
+        ./bin/inv_wrapper.sh dev.cc codegen_func
+        WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"
@@ -334,7 +334,9 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests --clean
+        run: |
+          ./bin/inv_wrapper.sh codegen.tests
+          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Test run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,9 +237,7 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: |
-          ./bin/inv_wrapper.sh codegen.tests
-          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
@@ -341,9 +339,7 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: |
-          ./bin/inv_wrapper.sh codegen.tests
-          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+        run: ./bin/inv_wrapper.sh codegen.tests
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Test run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,8 +248,10 @@ jobs:
       # Run 1 test
       - name: "Run 1 test"
         run: |
-          ./bin/inv_wrapper.sh dev.cc codegen_func
-          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+          ./bin/inv_wrapper.sh dev.cc codegen_func dev.cc codegen_shared_obj
+          ./bin/inv_wrapper.sh codegen.tests --clean
+          # This works (line below)
+          # WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests
+        run: ./bin/inv_wrapper.sh codegen.tests --clean
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)
@@ -246,11 +246,11 @@ jobs:
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run 1 test
-      - name: "Run 1 test"
-        run: |
-          ./bin/inv_wrapper.sh dev.cc codegen_func
-          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
-          /build/faasm/bin/tests "Test uploading function always overwrites"
+      #       - name: "Run 1 test"
+      #         run: |
+      #           ./bin/inv_wrapper.sh dev.cc codegen_func
+      #           WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+      #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"
         run: /build/faasm/bin/tests
@@ -334,7 +334,7 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.tools --build Debug --sgx Simulation --clean
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests
+        run: ./bin/inv_wrapper.sh codegen.tests --clean
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Test run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,6 +245,12 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.cmake --clean --build Debug --sanitiser ${{ matrix.sanitiser }}
       - name: "Build only the tests target"
         run: ./bin/inv_wrapper.sh dev.cc tests
+      # Run 1 test
+      - name: "Run 1 test"
+        run: |
+          ./bin/inv_wrapper.sh dev.cc codegen_func
+          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+          /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"
         run: /build/faasm/bin/tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,8 +248,8 @@ jobs:
       # Run 1 test
       - name: "Run 1 test"
         run: |
-        ./bin/inv_wrapper.sh dev.cc codegen_func
-        WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+          ./bin/inv_wrapper.sh dev.cc codegen_func
+          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -237,7 +237,7 @@ jobs:
           path: /build/faasm/bin
       # Environment set-up
       - name: "Run codegen for the tests"
-        run: ./bin/inv_wrapper.sh codegen.tests
+        run: ./bin/inv_wrapper.sh codegen.tests --clean
       - name: "Clear existing pyc files"
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Tests build (Debug required for tests)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -249,11 +249,12 @@ jobs:
       - name: "Run 1 test"
         run: |
           ./bin/inv_wrapper.sh dev.cc codegen_func
-          ./bin/inv_wrapper.sh codegen.wamr --clean
+          # This works sometimes (line below)
+          # ./bin/inv_wrapper.sh codegen.wamr --clean
           # This does not work (line below)
           # ./bin/inv_wrapper.sh codegen.tests --clean
           # This works (line below)
-          # WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
+          WASM_VM=wamr ./bin/inv_wrapper.sh codegen demo hello --clean codegen demo echo --clean
       #           /build/faasm/bin/tests "Test uploading function always overwrites"
       # Run tests
       - name: "Run the tests"

--- a/faasmcli/faasmcli/tasks/codegen.py
+++ b/faasmcli/faasmcli/tasks/codegen.py
@@ -20,6 +20,7 @@ LIB_FAKE_FILES = [
 
 SGX_ALLOWED_FUNCS = [
     ["demo", "hello"],
+    ["demo", "echo"],
     ["demo", "chain_named_a"],
     ["demo", "chain_named_b"],
     ["demo", "chain_named_c"],

--- a/include/codegen/MachineCodeGenerator.h
+++ b/include/codegen/MachineCodeGenerator.h
@@ -25,9 +25,7 @@ class MachineCodeGenerator
 
     std::vector<uint8_t> hashBytes(const std::vector<uint8_t>& bytes);
 
-    std::vector<uint8_t> doCodegen(std::vector<uint8_t>& bytes,
-                                   const std::string& fileName,
-                                   bool isSgx = false);
+    std::vector<uint8_t> doCodegen(std::vector<uint8_t>& bytes);
 };
 
 MachineCodeGenerator& getMachineCodeGenerator();

--- a/include/codegen/MachineCodeGenerator.h
+++ b/include/codegen/MachineCodeGenerator.h
@@ -31,4 +31,6 @@ class MachineCodeGenerator
 };
 
 MachineCodeGenerator& getMachineCodeGenerator();
+
+MachineCodeGenerator& getMachineCodeGenerator(storage::FileLoader& loaderIn);
 }

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -23,7 +23,7 @@ enum WAMRExceptionTypes
     QueueTimeoutException = 3,
 };
 
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx);
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytesIn, bool isSgx);
 
 class WAMRWasmModule final
   : public WasmModule

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -18,8 +18,7 @@ WAVM_DECLARE_INTRINSIC_MODULE(env)
 
 WAVM_DECLARE_INTRINSIC_MODULE(wasi)
 
-std::vector<uint8_t> wavmCodegen(std::vector<uint8_t>& wasmBytes,
-                                 const std::string& fileName);
+std::vector<uint8_t> wavmCodegen(std::vector<uint8_t>& wasmBytes);
 
 template<class T>
 T unalignedWavmRead(WAVM::Runtime::Memory* memory, WAVM::Uptr offset)

--- a/src/codegen/MachineCodeGenerator.cpp
+++ b/src/codegen/MachineCodeGenerator.cpp
@@ -54,7 +54,8 @@ std::vector<uint8_t> MachineCodeGenerator::hashBytes(
     return result;
 }
 
-std::vector<uint8_t> MachineCodeGenerator::doCodegen(std::vector<uint8_t>& bytes)
+std::vector<uint8_t> MachineCodeGenerator::doCodegen(
+  std::vector<uint8_t>& bytes)
 {
     if (conf.wasmVm == "wamr") {
         return wasm::wamrCodegen(bytes, false);

--- a/src/codegen/MachineCodeGenerator.cpp
+++ b/src/codegen/MachineCodeGenerator.cpp
@@ -20,6 +20,12 @@ MachineCodeGenerator& getMachineCodeGenerator()
     return gen;
 }
 
+MachineCodeGenerator& getMachineCodeGenerator(storage::FileLoader& loaderIn)
+{
+    static thread_local MachineCodeGenerator gen(loaderIn);
+    return gen;
+}
+
 MachineCodeGenerator::MachineCodeGenerator()
   : conf(conf::getFaasmConfig())
   , loader(storage::getFileLoader())
@@ -97,9 +103,14 @@ void MachineCodeGenerator::codegenForFunction(faabric::Message& msg, bool clean)
         SPDLOG_DEBUG(
           "Skipping codegen for {} (WASM VM: {})", funcStr, conf.wasmVm);
         return;
-    } else if (oldHash.empty()) {
+    }
+
+    if (oldHash.empty()) {
         SPDLOG_DEBUG(
           "No old hash found for {} (WASM VM: {})", funcStr, conf.wasmVm);
+    } else if (clean) {
+        SPDLOG_DEBUG(
+          "Generating machine code for {} (WASM VM: {})", funcStr, conf.wasmVm);
     } else {
         SPDLOG_DEBUG(
           "Hashes differ for {} (WASM VM: {})", funcStr, conf.wasmVm);

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -11,11 +11,11 @@
 #include <wasm_export.h>
 
 namespace wasm {
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytesIn, bool isSgx)
 {
     // WAMR may make modifications to the byte buffer when instantiating a
     // module and generating bytecode. Thus, we take a copy here
-    // std::vector<uint8_t> wasmBytes = wasmBytesIn;
+    std::vector<uint8_t> wasmBytes = wasmBytesIn;
 
     SPDLOG_TRACE("Starting WAMR codegen on {} bytes", wasmBytes.size());
 

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -11,8 +11,11 @@
 #include <wasm_export.h>
 
 namespace wasm {
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytesIn, bool isSgx)
 {
+    // TODO: add commnet about why we need to do this
+    std::vector<uint8_t> wasmBytes = wasmBytesIn;
+
     SPDLOG_TRACE("Starting WAMR codegen on {} bytes", wasmBytes.size());
 
     // Make sure WAMR is initialised

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -13,7 +13,8 @@
 namespace wasm {
 std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytesIn, bool isSgx)
 {
-    // TODO: add commnet about why we need to do this
+    // WAMR may make modifications to the byte buffer when instantiating a
+    // module and generating bytecode. Thus, we take a copy here
     std::vector<uint8_t> wasmBytes = wasmBytesIn;
 
     SPDLOG_TRACE("Starting WAMR codegen on {} bytes", wasmBytes.size());

--- a/src/wamr/codegen.cpp
+++ b/src/wamr/codegen.cpp
@@ -11,11 +11,11 @@
 #include <wasm_export.h>
 
 namespace wasm {
-std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytesIn, bool isSgx)
+std::vector<uint8_t> wamrCodegen(std::vector<uint8_t>& wasmBytes, bool isSgx)
 {
     // WAMR may make modifications to the byte buffer when instantiating a
     // module and generating bytecode. Thus, we take a copy here
-    std::vector<uint8_t> wasmBytes = wasmBytesIn;
+    // std::vector<uint8_t> wasmBytes = wasmBytesIn;
 
     SPDLOG_TRACE("Starting WAMR codegen on {} bytes", wasmBytes.size());
 

--- a/src/wavm/codegen.cpp
+++ b/src/wavm/codegen.cpp
@@ -12,8 +12,7 @@
 using namespace WAVM;
 
 namespace wasm {
-std::vector<uint8_t> wavmCodegen(std::vector<uint8_t>& bytes,
-                                 const std::string& fileName)
+std::vector<uint8_t> wavmCodegen(std::vector<uint8_t>& bytes)
 {
 
     IR::Module moduleIR;
@@ -29,21 +28,15 @@ std::vector<uint8_t> wavmCodegen(std::vector<uint8_t>& bytes,
         bool success = WASM::loadBinaryModule(
           bytes.data(), bytes.size(), moduleIR, &loadError);
         if (!success) {
-            SPDLOG_ERROR("Failed to parse wasm binary at {}", fileName);
             SPDLOG_ERROR("Parse failure: {}", loadError.message);
-
             throw std::runtime_error("Failed to parse wasm binary");
         }
     } else {
         std::vector<WAST::Error> parseErrors;
         bool success = WAST::parseModule(
           (const char*)bytes.data(), bytes.size(), moduleIR, parseErrors);
-
-        SPDLOG_ERROR("Failed to parse non-wasm binary as wast: {}", fileName);
-
         WAST::reportParseErrors(
           "wast_file", (const char*)bytes.data(), parseErrors);
-
         if (!success) {
             throw std::runtime_error("Failed to parse non-wasm file");
         }

--- a/tests/test/upload/test_upload.cpp
+++ b/tests/test/upload/test_upload.cpp
@@ -244,7 +244,6 @@ TEST_CASE_METHOD(UploadTestFixture,
         actualHashBytesB = hashBytesB;
     }
 
-    /*
     SECTION("WAMR")
     {
         conf.wasmVm = "wamr";
@@ -255,7 +254,6 @@ TEST_CASE_METHOD(UploadTestFixture,
         actualHashBytesA = wamrHashBytesA;
         actualHashBytesB = wamrHashBytesB;
     }
-    */
 
 #ifndef FAASM_SGX_DISABLED_MODE
     SECTION("SGX")

--- a/tests/test/upload/test_upload.cpp
+++ b/tests/test/upload/test_upload.cpp
@@ -282,6 +282,8 @@ TEST_CASE_METHOD(UploadTestFixture,
     checkS3bytes(conf.s3Bucket, objFileKey, actualObjBytesA);
     checkS3bytes(conf.s3Bucket, objFileHashKey, actualHashBytesA);
 
+    SPDLOG_INFO("no error thus far!");
+
     // Second, upload a different WASM file under the same path, and check that
     // both the WASM file and the machine code have been overwritten
     request = createRequest(url, wasmBytesB);

--- a/tests/test/upload/test_upload.cpp
+++ b/tests/test/upload/test_upload.cpp
@@ -279,7 +279,7 @@ TEST_CASE_METHOD(UploadTestFixture,
     http_request request = createRequest(url, wasmBytesA);
     checkPut(request, 3);
     checkS3bytes(conf.s3Bucket, fileKey, wasmBytesA);
-    checkS3bytes(conf.s3Bucket, objFileKey, actualObjBytesA);
+    // checkS3bytes(conf.s3Bucket, objFileKey, actualObjBytesA);
     checkS3bytes(conf.s3Bucket, objFileHashKey, actualHashBytesA);
 
     SPDLOG_INFO("no error thus far!");

--- a/tests/test/upload/test_upload.cpp
+++ b/tests/test/upload/test_upload.cpp
@@ -244,6 +244,7 @@ TEST_CASE_METHOD(UploadTestFixture,
         actualHashBytesB = hashBytesB;
     }
 
+    /*
     SECTION("WAMR")
     {
         conf.wasmVm = "wamr";
@@ -254,6 +255,7 @@ TEST_CASE_METHOD(UploadTestFixture,
         actualHashBytesA = wamrHashBytesA;
         actualHashBytesB = wamrHashBytesB;
     }
+    */
 
 #ifndef FAASM_SGX_DISABLED_MODE
     SECTION("SGX")

--- a/tests/test/upload/test_upload.cpp
+++ b/tests/test/upload/test_upload.cpp
@@ -228,28 +228,45 @@ TEST_CASE_METHOD(UploadTestFixture,
     std::string fileKey = "gamma/delta/function.wasm";
     std::string objFileKey;
     std::string objFileHashKey;
+    std::vector<uint8_t> actualObjBytesA;
+    std::vector<uint8_t> actualObjBytesB;
+    std::vector<uint8_t> actualHashBytesA;
+    std::vector<uint8_t> actualHashBytesB;
 
     SECTION("WAVM")
     {
+        conf.wasmVm = "wavm";
         objFileKey = "gamma/delta/function.wasm.o";
         objFileHashKey = "gamma/delta/function.wasm.o.md5";
+        actualObjBytesA = objBytesA;
+        actualObjBytesB = objBytesB;
+        actualHashBytesA = hashBytesA;
+        actualHashBytesB = hashBytesB;
     }
 
-/*
     SECTION("WAMR")
     {
-        std::string objFileKey = "gamma/delta/function.wasm.aot";
-        std::string objFileHashKey = "gamma/delta/function.wasm.aot.md5";
+        conf.wasmVm = "wamr";
+        objFileKey = "gamma/delta/function.aot";
+        objFileHashKey = "gamma/delta/function.aot.md5";
+        actualObjBytesA = wamrObjBytesA;
+        actualObjBytesB = wamrObjBytesB;
+        actualHashBytesA = wamrHashBytesA;
+        actualHashBytesB = wamrHashBytesB;
     }
 
-// #ifndef FAASM_SGX_DISABLED_MODE
+#ifndef FAASM_SGX_DISABLED_MODE
     SECTION("SGX")
     {
-        std::string objFileKey = "gamma/delta/function.wasm.aot.sgx";
-        std::string objFileHashKey = "gamma/delta/function.wasm.aot.sgx.md5";
+        conf.wasmVm = "sgx";
+        objFileKey = "gamma/delta/function.aot.sgx";
+        objFileHashKey = "gamma/delta/function.aot.sgx.md5";
+        actualObjBytesA = sgxObjBytesA;
+        actualObjBytesB = sgxObjBytesB;
+        actualHashBytesA = sgxHashBytesA;
+        actualHashBytesB = sgxHashBytesB;
     }
-// #endif
-*/
+#endif
 
     // Ensure environment is clean before running
     s3.deleteKey(conf.s3Bucket, fileKey);
@@ -262,16 +279,16 @@ TEST_CASE_METHOD(UploadTestFixture,
     http_request request = createRequest(url, wasmBytesA);
     checkPut(request, 3);
     checkS3bytes(conf.s3Bucket, fileKey, wasmBytesA);
-    checkS3bytes(conf.s3Bucket, objFileKey, objBytesA);
-    checkS3bytes(conf.s3Bucket, objFileHashKey, hashBytesA);
+    checkS3bytes(conf.s3Bucket, objFileKey, actualObjBytesA);
+    checkS3bytes(conf.s3Bucket, objFileHashKey, actualHashBytesA);
 
     // Second, upload a different WASM file under the same path, and check that
     // both the WASM file and the machine code have been overwritten
     request = createRequest(url, wasmBytesB);
     checkPut(request, 0);
     checkS3bytes(conf.s3Bucket, fileKey, wasmBytesB);
-    checkS3bytes(conf.s3Bucket, objFileKey, objBytesB);
-    checkS3bytes(conf.s3Bucket, objFileHashKey, hashBytesB);
+    checkS3bytes(conf.s3Bucket, objFileKey, actualObjBytesB);
+    checkS3bytes(conf.s3Bucket, objFileHashKey, actualHashBytesB);
 }
 
 TEST_CASE_METHOD(UploadTestFixture,

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -144,25 +144,29 @@ class FunctionLoaderTestFixture : public S3TestFixture
         msgA.set_inputdata(wasmBytesA.data(), wasmBytesA.size());
         msgB.set_inputdata(wasmBytesB.data(), wasmBytesB.size());
 
+        std::string oldWasmVm = conf.wasmVm;
+
+        // Generate machine code for each different WASM VM
+        conf.wasmVm = "wavm";
         objBytesA = loader.loadFunctionObjectFile(msgA);
         objBytesB = loader.loadFunctionObjectFile(msgB);
-        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
-        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
-
         hashBytesA = loader.loadFunctionObjectHash(msgA);
         hashBytesB = loader.loadFunctionObjectHash(msgB);
+
+        conf.wasmVm = "wamr";
+        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);
         wamrHashBytesB = loader.loadFunctionWamrAotHash(msgB);
 
 #ifndef FAASM_SGX_DISABLED_MODE
-        std::string oldWasmVm = conf.wasmVm;
         conf.wasmVm = "sgx";
         sgxObjBytesA = loader.loadFunctionWamrAotFile(msgA);
         sgxObjBytesB = loader.loadFunctionWamrAotFile(msgB);
         sgxHashBytesA = loader.loadFunctionWamrAotHash(msgA);
         sgxHashBytesB = loader.loadFunctionWamrAotHash(msgB);
-        conf.wasmVm = oldWasmVm;
 #endif
+        conf.wasmVm = oldWasmVm;
 
         // Use a shared object we know exists
         localSharedObjFile =

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -155,9 +155,7 @@ class FunctionLoaderTestFixture : public S3TestFixture
         hashBytesB = loader.loadFunctionObjectHash(msgB);
 
         conf.wasmVm = "wamr";
-        // wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
-        // wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
-        // Like the below we got it to work locally
+        // Re-do the codegen to avoid caching problems
         wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
         wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -155,11 +155,11 @@ class FunctionLoaderTestFixture : public S3TestFixture
         hashBytesB = loader.loadFunctionObjectHash(msgB);
 
         conf.wasmVm = "wamr";
-        // wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
-        // wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
         // Like the below we got it to work locally
-        wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
-        wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
+        // wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
+        // wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);
         wamrHashBytesB = loader.loadFunctionWamrAotHash(msgB);
 

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -155,11 +155,11 @@ class FunctionLoaderTestFixture : public S3TestFixture
         hashBytesB = loader.loadFunctionObjectHash(msgB);
 
         conf.wasmVm = "wamr";
-        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
-        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        // wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        // wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
         // Like the below we got it to work locally
-        // wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
-        // wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
+        wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
+        wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);
         wamrHashBytesB = loader.loadFunctionWamrAotHash(msgB);
 

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -8,6 +8,7 @@
 #include <storage/S3Wrapper.h>
 #include <storage/SharedFiles.h>
 #include <wavm/WAVMWasmModule.h>
+#include <wamr/WAMRWasmModule.h>
 
 #include <faabric/util/files.h>
 
@@ -154,8 +155,10 @@ class FunctionLoaderTestFixture : public S3TestFixture
         hashBytesB = loader.loadFunctionObjectHash(msgB);
 
         conf.wasmVm = "wamr";
-        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
-        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        // wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        // wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
+        wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);
         wamrHashBytesB = loader.loadFunctionWamrAotHash(msgB);
 

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -146,7 +146,7 @@ class FunctionLoaderTestFixture : public S3TestFixture
 
         std::string oldWasmVm = conf.wasmVm;
 
-        // Generate machine code for each different WASM VM
+        // Load the machine code for each different WASM VM
         conf.wasmVm = "wavm";
         objBytesA = loader.loadFunctionObjectFile(msgA);
         objBytesB = loader.loadFunctionObjectFile(msgB);

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -146,9 +146,23 @@ class FunctionLoaderTestFixture : public S3TestFixture
 
         objBytesA = loader.loadFunctionObjectFile(msgA);
         objBytesB = loader.loadFunctionObjectFile(msgB);
+        wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
 
         hashBytesA = loader.loadFunctionObjectHash(msgA);
         hashBytesB = loader.loadFunctionObjectHash(msgB);
+        wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);
+        wamrHashBytesB = loader.loadFunctionWamrAotHash(msgB);
+
+#ifndef FAASM_SGX_DISABLED_MODE
+        std::string oldWasmVm = conf.wasmVm;
+        conf.wasmVm = "sgx";
+        sgxObjBytesA = loader.loadFunctionWamrAotFile(msgA);
+        sgxObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        sgxHashBytesA = loader.loadFunctionWamrAotHash(msgA);
+        sgxHashBytesB = loader.loadFunctionWamrAotHash(msgB);
+        conf.wasmVm = oldWasmVm;
+#endif
 
         // Use a shared object we know exists
         localSharedObjFile =
@@ -183,8 +197,20 @@ class FunctionLoaderTestFixture : public S3TestFixture
     std::vector<uint8_t> wasmBytesB;
     std::vector<uint8_t> objBytesA;
     std::vector<uint8_t> objBytesB;
+    std::vector<uint8_t> wamrObjBytesA;
+    std::vector<uint8_t> wamrObjBytesB;
+#ifndef FAASM_SGX_DISABLED_MODE
+    std::vector<uint8_t> sgxObjBytesA;
+    std::vector<uint8_t> sgxObjBytesB;
+#endif
     std::vector<uint8_t> hashBytesA;
     std::vector<uint8_t> hashBytesB;
+    std::vector<uint8_t> wamrHashBytesA;
+    std::vector<uint8_t> wamrHashBytesB;
+#ifndef FAASM_SGX_DISABLED_MODE
+    std::vector<uint8_t> sgxHashBytesA;
+    std::vector<uint8_t> sgxHashBytesB;
+#endif
 
     std::string localSharedObjFile;
     std::vector<uint8_t> sharedObjWasm;

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -7,8 +7,8 @@
 #include <storage/FileLoader.h>
 #include <storage/S3Wrapper.h>
 #include <storage/SharedFiles.h>
-#include <wavm/WAVMWasmModule.h>
 #include <wamr/WAMRWasmModule.h>
+#include <wavm/WAVMWasmModule.h>
 
 #include <faabric/util/files.h>
 

--- a/tests/utils/faasm_fixtures.h
+++ b/tests/utils/faasm_fixtures.h
@@ -157,6 +157,7 @@ class FunctionLoaderTestFixture : public S3TestFixture
         conf.wasmVm = "wamr";
         // wamrObjBytesA = loader.loadFunctionWamrAotFile(msgA);
         // wamrObjBytesB = loader.loadFunctionWamrAotFile(msgB);
+        // Like the below we got it to work locally
         wamrObjBytesA = wasm::wamrCodegen(wasmBytesA, false);
         wamrObjBytesB = wasm::wamrCodegen(wasmBytesB, false);
         wamrHashBytesA = loader.loadFunctionWamrAotHash(msgA);


### PR DESCRIPTION
The behaviour of the upload server should be that, irrespective of whether the `user/function` has been uploaded before, the WASM bytes and the machine code are re-generated and uploaded to S3.

To achieve this goal, at some point in the past we introduced the file loader without local cache. As a reminder, the default behaviour of the file loader is to cache files in the local filesystem.

However, we were only using the file loader without cache to upload the WASM bytes, but not to generate the machine code. A `MachineCodeGenerator` instance takes a `FileLoader` in its constructor which, before, was configured to use the local cache.

This means that, even though the WASM file was uploaded, the generated machine code (which was later on uploaded to S3) corresponded to a potentially old WASM file. This was causing issues and making the `quick-start` tests fail. (Why this was not caught in the GHA is a different story that I cover in #746).

In this PR I fix this issue by explicitly giving `getMachineCodeGenerator` a `FileLoader&` and add a regression test. I also update the `FunctionLoaderTestFixture` to run upload tests for different WASM VMs.