### PR TITLE
WAMR Exception Handling

### DIFF
--- a/.env
+++ b/.env
@@ -5,8 +5,8 @@ FAASM_WORKER_IMAGE=faasm.azurecr.io/worker:0.9.8
 FAABRIC_VERSION=0.4.4
 FAABRIC_PLANNER_IMAGE=faasm.azurecr.io/planner:0.4.4
 
-CPP_VERSION=0.2.5
-CPP_CLI_IMAGE=faasm.azurecr.io/cpp-sysroot:0.2.5
+CPP_VERSION=0.2.6
+CPP_CLI_IMAGE=faasm.azurecr.io/cpp-sysroot:0.2.6
 
 PYTHON_VERSION=0.2.5
 PYTHON_CLI_IMAGE=faasm.azurecr.io/cpython:0.2.5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     container:
-      image: faasm.azurecr.io/cpp-sysroot:0.2.5
+      image: faasm.azurecr.io/cpp-sysroot:0.2.6
       credentials:
         username: ${{ secrets.ACR_SERVICE_PRINCIPAL_ID }}
         password: ${{ secrets.ACR_SERVICE_PRINCIPAL_PASSWORD }}

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -87,7 +87,8 @@ class WAMRWasmModule final
 
     int executeWasmFunctionFromPointer(faabric::Message& msg);
 
-    bool executeCatchException(WASMFunctionInstanceCommon* func,
+    bool executeCatchException(WASMExecEnv* execEnv,
+                               WASMFunctionInstanceCommon* func,
                                int wasmFuncPtr,
                                int argc,
                                std::vector<uint32_t>& argv);

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -87,8 +87,7 @@ class WAMRWasmModule final
 
     int executeWasmFunctionFromPointer(faabric::Message& msg);
 
-    bool executeCatchException(wasm_exec_env_t execEnv,
-                               WASMFunctionInstanceCommon* func,
+    bool executeCatchException(WASMFunctionInstanceCommon* func,
                                int wasmFuncPtr,
                                int argc,
                                std::vector<uint32_t>& argv);

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -87,6 +87,12 @@ class WAMRWasmModule final
 
     int executeWasmFunctionFromPointer(faabric::Message& msg);
 
+    bool executeCatchException(wasm_exec_env_t execEnv,
+                               WASMFunctionInstanceCommon* func,
+                               int wasmFuncPtr,
+                               int argc,
+                               std::vector<uint32_t>& argv);
+
     void bindInternal(faabric::Message& msg);
 
     bool doGrowMemory(uint32_t pageChange) override;

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -87,8 +87,7 @@ class WAMRWasmModule final
 
     int executeWasmFunctionFromPointer(faabric::Message& msg);
 
-    bool executeCatchException(WASMExecEnv* execEnv,
-                               WASMFunctionInstanceCommon* func,
+    bool executeCatchException(WASMFunctionInstanceCommon* func,
                                int wasmFuncPtr,
                                int argc,
                                std::vector<uint32_t>& argv);

--- a/include/wasm/WasmModule.h
+++ b/include/wasm/WasmModule.h
@@ -76,6 +76,13 @@ class WasmModule
     // ----- Filesystem -----
     storage::FileSystem& getFileSystem();
 
+    // ----- Exception handling -----
+    // Faasm supports three different WASM runtimes, WAVM, WAMR, and WAMR
+    // inside SGX. Unfortunately, only WAVM is written in C++ and correctly
+    // propagates exceptions thrown by Faasm's C++ handlers. For WAMR-based
+    // code we work around the lack of exceptions with setjmp/longjmp
+    virtual void doThrowException(std::exception& e);
+
     // ----- Stdout capture -----
     ssize_t captureStdout(const struct ::iovec* iovecs, int iovecCount);
 

--- a/include/wasm/host_interface_test.h
+++ b/include/wasm/host_interface_test.h
@@ -7,7 +7,8 @@ namespace wasm {
  * runtime all the way to Faasm. With this enum we indicate the test number.
  * Note that, most likely, this header file needs to be duplicated in Faasm (?)
  */
-enum HostInterfaceTest {
+enum HostInterfaceTest
+{
     NoTest = 0,
     ExceptionPropagationTest = 1,
 };

--- a/include/wasm/host_interface_test.h
+++ b/include/wasm/host_interface_test.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace wasm {
+/* We use one host interface call, `__faasm_host_interface_test` to test
+ * different behaviours of host interface calls like, for example, throwing
+ * an exception and testing that it propagates correctly through the WASM
+ * runtime all the way to Faasm. With this enum we indicate the test number.
+ * Note that, most likely, this header file needs to be duplicated in Faasm (?)
+ */
+enum HostInterfaceTest {
+    NoTest = 0,
+    ExceptionPropagationTest = 1,
+};
+
+void doHostInterfaceTest(int testNum);
+}

--- a/include/wavm/WAVMWasmModule.h
+++ b/include/wavm/WAVMWasmModule.h
@@ -63,6 +63,9 @@ class WAVMWasmModule final
 
     void reset(faabric::Message& msg, const std::string& snapshotKey) override;
 
+    // ----- Exception handling -----
+    void doThrowException(std::exception& e) override;
+
     // ----- Memory management -----
     uint32_t mmapFile(uint32_t fd, size_t length) override;
 

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -396,12 +396,17 @@ void WAMRWasmModule::doThrowException(std::exception& e)
     // associated to the exception
     if (dynamic_cast<faabric::util::FunctionMigratedException*>(&e) !=
         nullptr) {
+        // Make sure to explicitly call the exceptions destructor explicitly
+        // to avoid memory leaks when longjmp-ing
+        e.~exception();
         longjmp(wamrExceptionJmpBuf,
                 WAMRExceptionTypes::FunctionMigratedException);
     } else if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) !=
                nullptr) {
+        e.~exception();
         longjmp(wamrExceptionJmpBuf, WAMRExceptionTypes::QueueTimeoutException);
     } else {
+        e.~exception();
         longjmp(wamrExceptionJmpBuf, WAMRExceptionTypes::DefaultException);
     }
 }

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -9,6 +9,7 @@
 #include <wasm/WasmModule.h>
 
 #include <cstdint>
+#include <setjmp.h>
 #include <stdexcept>
 #include <stdio.h>
 #include <stdlib.h>
@@ -179,7 +180,7 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
 
     if (msg.funcptr() > 0) {
         // Run the function from the pointer
-        returnValue = executeWasmFunctionFromPointer(msg.funcptr());
+        returnValue = executeWasmFunctionFromPointer(msg);
     } else {
         prepareArgcArgv(msg);
 
@@ -193,8 +194,38 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
     return returnValue;
 }
 
-int WAMRWasmModule::executeWasmFunctionFromPointer(int wasmFuncPtr)
+int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
 {
+     // WASM function pointers are indices into the module's function table
+    int wasmFuncPtr = msg.funcptr();
+    std::string inputData = msg.inputdata();
+
+    SPDLOG_DEBUG("WAMR executing function from pointer {} (args: {})",
+                 wasmFuncPtr,
+                 inputData);
+
+    // Work out the function signature from the function pointer
+    // TODO: maybe move to a different function
+    AOTModuleInstance* aotModuleInstance =
+      reinterpret_cast<AOTModuleInstance*>(moduleInstance);
+    AOTTableInstance* tableInstance = aotModuleInstance->tables[0];
+    if (tableInstance == nullptr || wasmFuncPtr >= tableInstance->cur_size) {
+        SPDLOG_ERROR("Error getting WAMR function signature from ptr: {}",
+                     wasmFuncPtr);
+        throw std::runtime_error("Error getting WAMR function signature");
+    }
+    uint32_t funcIdx = tableInstance->elems[wasmFuncPtr];
+    uint32_t funcTypeIdx = aotModuleInstance->func_type_indexes[funcIdx];
+
+    AOTModule* aotModule = reinterpret_cast<AOTModule*>(wasmModule);
+    AOTFuncType* funcType = aotModule->func_types[funcTypeIdx];
+    int argCount = funcType->param_count;
+    int resultCount = funcType->result_count;
+    SPDLOG_DEBUG("WAMR Function pointer has {} arguments and returns {} value",
+                 argCount,
+                 resultCount);
+    bool returnsVoid = resultCount == 0;
+
     // NOTE: WAMR doesn't provide a nice interface for calling functions using
     // function pointers, so we have to call a few more low-level functions to
     // get it to work.
@@ -210,25 +241,47 @@ int WAMRWasmModule::executeWasmFunctionFromPointer(int wasmFuncPtr)
     // Set thread handle and stack boundary (required by WAMR)
     wasm_exec_env_set_thread_info(execEnv.get());
 
-    // Call the function pointer
-    // NOTE: for some reason WAMR uses the argv array to pass the function
-    // return value, so we have to provide something big enough
-    std::vector<uint32_t> argv = { 0 };
-    bool success =
-      wasm_runtime_call_indirect(execEnv.get(), wasmFuncPtr, 0, argv.data());
+    std::vector<uint32_t> argv;
+    switch (argCount) {
+        // Even if the function takes no arguments, we need to pass an argv
+        // with at least one element, as WAMR will set the return value in
+        // argv[0]
+        case 0:
+            argv = { 0 };
+            break;
+        // If we are calling with just one argument, we assume its an integer
+        // value. We could switch on the data type of the AOTType*, but we
+        // don't do it just yet
+        case 1:
+            argv = { (uint32_t)std::stoi(inputData) };
+            break;
+        default: {
+            SPDLOG_ERROR("Unrecognised WAMR function pointer signature (args: "
+                         "{}, return: {})",
+                         argCount,
+                         resultCount);
+            throw std::runtime_error(
+              "Unrecognised WAMR function pointer signature");
+        }
+    }
+    std::vector<uint32_t> originalArgv = argv;
+    bool success = wasm_runtime_call_indirect(
+      execEnv.get(), wasmFuncPtr, argCount, argv.data());
 
-    uint32_t returnValue = argv[0];
-
-    // Handle errors
-    if (!success || returnValue != 0) {
-        std::string errorMessage(
-          ((AOTModuleInstance*)moduleInstance)->cur_exception);
-
-        SPDLOG_ERROR("Failed to execute from function pointer {}: {}",
+    if (!success) {
+        SPDLOG_ERROR("Error executing {}: {}",
                      wasmFuncPtr,
-                     returnValue);
+                     wasm_runtime_get_exception(moduleInstance));
+        throw std::runtime_error("Error executing WASM func ptr with WAMR");
+    }
 
-        return returnValue;
+    // If we are calling a void function by pointer with some arguments, the
+    // return value will be, precisely, the input arguments (and not 0)
+    uint32_t returnValue;
+    if (returnsVoid) {
+        returnValue = !(argv[0] == originalArgv[0]);
+    } else {
+        returnValue = 0;
     }
 
     return returnValue;
@@ -257,7 +310,36 @@ int WAMRWasmModule::executeWasmFunction(const std::string& funcName)
     // pass it, therefore we should provide a single integer argv even though
     // it's not actually used
     std::vector<uint32_t> argv = { 0 };
-    bool success = wasm_runtime_call_wasm(execEnv, func, 0, argv.data());
+    bool success;
+    {
+        // This switch statement is used to catch exceptions thrown by native
+        // functions (written in C++) called from WASM code executed in WAMR.
+        // Given that WAMR is written in C, exceptions are not propagated, and
+        // thus we implement our custom handler
+        switch (setjmp(wamrExceptionJmpBuf)) {
+            case 0: {
+                success = wasm_runtime_call_wasm(execEnv, func, 0, argv.data());
+                break;
+            }
+            // Make sure that we throw an exception if setjmp is called from
+            // a longjmp (and returns a value different than 0) as local
+            // variables in the stack could be corrupted
+            case WAMRExceptionTypes::FunctionMigratedException: {
+                throw faabric::util::FunctionMigratedException(
+                  "Migrating MPI rank");
+            }
+            case WAMRExceptionTypes::QueueTimeoutException: {
+                throw std::runtime_error("Timed-out dequeueing!");
+            }
+            case WAMRExceptionTypes::DefaultException: {
+                throw std::runtime_error("Default WAMR exception");
+            }
+            default: {
+                SPDLOG_ERROR("WAMR exception handler reached unreachable case");
+                throw std::runtime_error("Unreachable WAMR exception handler");
+            }
+        }
+    }
     uint32_t returnValue = argv[0];
 
     if (!success) {

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -198,7 +198,7 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
 
 int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
 {
-     // WASM function pointers are indices into the module's function table
+    // WASM function pointers are indices into the module's function table
     int wasmFuncPtr = msg.funcptr();
     std::string inputData = msg.inputdata();
 
@@ -317,12 +317,13 @@ bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
                                            std::vector<uint32_t>& argv)
 {
     bool isIndirect;
-    if (wasmFuncPtr == NO_WASM_FUNC_PTR && func != nullptr)  {
+    if (wasmFuncPtr == NO_WASM_FUNC_PTR && func != nullptr) {
         isIndirect = false;
     } else if (wasmFuncPtr != NO_WASM_FUNC_PTR && func == nullptr) {
         isIndirect = true;
     } else {
-        throw std::runtime_error("Incorrect combination of arguments to execute WAMR function");
+        throw std::runtime_error(
+          "Incorrect combination of arguments to execute WAMR function");
     }
 
     // Get singleton execution environment
@@ -340,9 +341,11 @@ bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
         switch (setjmp(wamrExceptionJmpBuf)) {
             case 0: {
                 if (isIndirect) {
-                    success = wasm_runtime_call_indirect(execEnv, wasmFuncPtr, argc, argv.data());
+                    success = wasm_runtime_call_indirect(
+                      execEnv, wasmFuncPtr, argc, argv.data());
                 } else {
-                    success = wasm_runtime_call_wasm(execEnv, func, argc, argv.data());
+                    success =
+                      wasm_runtime_call_wasm(execEnv, func, argc, argv.data());
                 }
                 break;
             }
@@ -384,9 +387,8 @@ void WAMRWasmModule::doThrowException(std::exception& e)
         longjmp(wamrExceptionJmpBuf,
                 WAMRExceptionTypes::FunctionMigratedException);
     } else if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) !=
-        nullptr) {
-        longjmp(wamrExceptionJmpBuf,
-                WAMRExceptionTypes::QueueTimeoutException);
+               nullptr) {
+        longjmp(wamrExceptionJmpBuf, WAMRExceptionTypes::QueueTimeoutException);
     } else {
         longjmp(wamrExceptionJmpBuf, WAMRExceptionTypes::DefaultException);
     }

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -177,9 +177,6 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
     WasmExecutionContext ctx(this);
     int returnValue = 0;
 
-    // Run wasm initialisers
-    // executeWasmFunction(WASM_CTORS_FUNC_NAME);
-
     if (msg.funcptr() > 0) {
         // Run the function from the pointer
         returnValue = executeWasmFunctionFromPointer(msg);

--- a/src/wamr/faasm.cpp
+++ b/src/wamr/faasm.cpp
@@ -76,7 +76,8 @@ static int32_t __faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
 /*
  * Single entry-point for testing the host interface behaviour
  */
-static void __faasm_host_interface_test_wrapper(wasm_exec_env_t execEnv, int32_t testNum)
+static void __faasm_host_interface_test_wrapper(wasm_exec_env_t execEnv,
+                                                int32_t testNum)
 {
     wasm::doHostInterfaceTest(testNum);
 }

--- a/src/wamr/faasm.cpp
+++ b/src/wamr/faasm.cpp
@@ -8,6 +8,7 @@
 #include <wasm/WasmExecutionContext.h>
 #include <wasm/WasmModule.h>
 #include <wasm/chaining.h>
+#include <wasm/host_interface_test.h>
 #include <wasm/migration.h>
 
 #include <wasm_export.h>
@@ -70,6 +71,14 @@ static int32_t __faasm_chain_ptr_wrapper(wasm_exec_env_t exec_env,
     faabric::Message& call = ExecutorContext::get()->getMsg();
     std::vector<uint8_t> inputData(BYTES(inBuff), BYTES(inBuff) + inLen);
     return makeChainedCall(call.function(), wasmFuncPtr, nullptr, inputData);
+}
+
+/*
+ * Single entry-point for testing the host interface behaviour
+ */
+static void __faasm_host_interface_test_wrapper(wasm_exec_env_t execEnv, int32_t testNum)
+{
+    wasm::doHostInterfaceTest(testNum);
 }
 
 static void __faasm_migrate_point_wrapper(wasm_exec_env_t execEnv,
@@ -139,6 +148,7 @@ static NativeSymbol ns[] = {
     REG_NATIVE_FUNC(__faasm_await_call, "(i)i"),
     REG_NATIVE_FUNC(__faasm_chain_name, "($$i)i"),
     REG_NATIVE_FUNC(__faasm_chain_ptr, "(i$i)i"),
+    REG_NATIVE_FUNC(__faasm_host_interface_test, "(i)"),
     REG_NATIVE_FUNC(__faasm_migrate_point, "(i$)"),
     REG_NATIVE_FUNC(__faasm_pull_state, "(*i)"),
     REG_NATIVE_FUNC(__faasm_push_state, "(*)"),

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -3,6 +3,7 @@ faasm_private_lib(wasm
     WasmExecutionContext.cpp
     WasmModule.cpp
     chaining_util.cpp
+    host_interface_test.cpp
     migration.cpp
 )
 

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -833,6 +833,11 @@ void WasmModule::unmapMemory(uint32_t offset, size_t nBytes)
     }
 }
 
+void WasmModule::doThrowException(std::exception& e)
+{
+    throw std::runtime_error("doThrowException not implemented");
+}
+
 uint8_t* WasmModule::wasmPointerToNative(uint32_t wasmPtr)
 {
     throw std::runtime_error("wasmPointerToNative not implemented");

--- a/src/wasm/host_interface_test.cpp
+++ b/src/wasm/host_interface_test.cpp
@@ -1,0 +1,14 @@
+#include <faabric/util/func.h>
+#include <wasm/host_interface_test.h>
+#include <wasm/WasmExecutionContext.h>
+
+namespace wasm {
+void doHostInterfaceTest(int testNum) {
+    switch (testNum) {
+        case ExceptionPropagationTest: {
+            auto ex = faabric::util::FunctionMigratedException("Migrating MPI rank");
+            getExecutingModule()->doThrowException(ex);
+        }
+    }
+}
+}

--- a/src/wasm/host_interface_test.cpp
+++ b/src/wasm/host_interface_test.cpp
@@ -11,6 +11,10 @@ void doHostInterfaceTest(int testNum)
               faabric::util::FunctionMigratedException("Migrating MPI rank");
             getExecutingModule()->doThrowException(ex);
         }
+        default: {
+            SPDLOG_ERROR("Unrecognised host interface test: {}", testNum);
+            throw std::runtime_error("Unrecognised host interface test!");
+        }
     }
 }
 }

--- a/src/wasm/host_interface_test.cpp
+++ b/src/wasm/host_interface_test.cpp
@@ -1,12 +1,14 @@
 #include <faabric/util/func.h>
-#include <wasm/host_interface_test.h>
 #include <wasm/WasmExecutionContext.h>
+#include <wasm/host_interface_test.h>
 
 namespace wasm {
-void doHostInterfaceTest(int testNum) {
+void doHostInterfaceTest(int testNum)
+{
     switch (testNum) {
         case ExceptionPropagationTest: {
-            auto ex = faabric::util::FunctionMigratedException("Migrating MPI rank");
+            auto ex =
+              faabric::util::FunctionMigratedException("Migrating MPI rank");
             getExecutingModule()->doThrowException(ex);
         }
     }

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -92,8 +92,20 @@ void WAVMWasmModule::reset(faabric::Message& msg,
     clone(cachedModule, snapshotKey);
 }
 
+// To keep API compatibility with WAMR we pass a generic std::exception, so in
+// WAVM we need to re-cast it
 void WAVMWasmModule::doThrowException(std::exception& e)
 {
+    if (dynamic_cast<faabric::util::FunctionMigratedException*>(&e) !=
+        nullptr) {
+        SPDLOG_DEBUG("here!");
+        throw *dynamic_cast<faabric::util::FunctionMigratedException*>(&e);
+    }
+    if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) !=
+        nullptr) {
+        throw *dynamic_cast<faabric::util::QueueTimeoutException*>(&e);
+    }
+
     throw e;
 }
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -92,6 +92,11 @@ void WAVMWasmModule::reset(faabric::Message& msg,
     clone(cachedModule, snapshotKey);
 }
 
+void WAVMWasmModule::doThrowException(std::exception& e)
+{
+    throw e;
+}
+
 Runtime::Instance* WAVMWasmModule::getEnvModule()
 {
     instantiateBaseModules();

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -101,8 +101,7 @@ void WAVMWasmModule::doThrowException(std::exception& e)
         SPDLOG_DEBUG("here!");
         throw *dynamic_cast<faabric::util::FunctionMigratedException*>(&e);
     }
-    if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) !=
-        nullptr) {
+    if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) != nullptr) {
         throw *dynamic_cast<faabric::util::QueueTimeoutException*>(&e);
     }
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -98,7 +98,6 @@ void WAVMWasmModule::doThrowException(std::exception& e)
 {
     if (dynamic_cast<faabric::util::FunctionMigratedException*>(&e) !=
         nullptr) {
-        SPDLOG_DEBUG("here!");
         throw *dynamic_cast<faabric::util::FunctionMigratedException*>(&e);
     }
     if (dynamic_cast<faabric::util::QueueTimeoutException*>(&e) != nullptr) {

--- a/src/wavm/faasm.cpp
+++ b/src/wavm/faasm.cpp
@@ -16,6 +16,7 @@
 #include <faabric/util/state.h>
 #include <wasm/WasmExecutionContext.h>
 #include <wasm/chaining.h>
+#include <wasm/host_interface_test.h>
 #include <wasm/migration.h>
 #include <wavm/WAVMWasmModule.h>
 
@@ -756,5 +757,14 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
     SPDLOG_DEBUG("S - emulatorSetCallStatus {}", success);
     throw std::runtime_error(
       "Should not be calling emulator functions from wasm");
+}
+
+WAVM_DEFINE_INTRINSIC_FUNCTION(env,
+                               "__faasm_host_interface_test",
+                               void,
+                               __faasm_host_interface_test,
+                               I32 testNum)
+{
+    wasm::doHostInterfaceTest(testNum);
 }
 }

--- a/tests/test/faaslet/CMakeLists.txt
+++ b/tests/test/faaslet/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_FILES ${TEST_FILES}
     ${CMAKE_CURRENT_LIST_DIR}/test_dynamic_linking.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_env.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_errors.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/test_exceptions.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_exec_graph.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_filesystem.cpp
     ${CMAKE_CURRENT_LIST_DIR}/test_flushing.cpp

--- a/tests/test/faaslet/test_exceptions.cpp
+++ b/tests/test/faaslet/test_exceptions.cpp
@@ -20,6 +20,7 @@ TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
     faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
     faaslet::Faaslet f(msg);
 
-    REQUIRE_THROWS_AS(f.executeTask(0, 0, req), faabric::util::FunctionMigratedException);
+    REQUIRE_THROWS_AS(f.executeTask(0, 0, req),
+                      faabric::util::FunctionMigratedException);
 }
 }

--- a/tests/test/faaslet/test_exceptions.cpp
+++ b/tests/test/faaslet/test_exceptions.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch.hpp>
+
+#include "faasm_fixtures.h"
+
+#include <faaslet/Faaslet.h>
+
+namespace tests {
+TEST_CASE_METHOD(MultiRuntimeFunctionExecTestFixture,
+                 "Test exceptions are propagated from handler to runtime",
+                 "[faaslet]")
+{
+    SECTION("WAVM") { conf.wasmVm = "wavm"; }
+
+    SECTION("WAVM") { conf.wasmVm = "wamr"; }
+
+    // TODO: make this default executeFunction in utils
+    std::shared_ptr<faabric::BatchExecuteRequest> req =
+      faabric::util::batchExecFactory("demo", "exception", 1);
+    faabric::Message& msg = req->mutable_messages()->at(0);
+    faabric::scheduler::ExecutorContext::set(nullptr, req, 0);
+    faaslet::Faaslet f(msg);
+
+    REQUIRE_THROWS_AS(f.executeTask(0, 0, req), faabric::util::FunctionMigratedException);
+}
+}


### PR DESCRIPTION
Faasm relies on exceptions being propagated from native function calls (i.e. host interface functions called from WASM) to the runtime code. For example, WASM code may call `__faasm_migrate_point` which, in turn, will throw a `faabric::util::FunctionMigratedException`. A very simplfied call stack would look something like the following:

```
<__faasm_migrate_point> -> throws exception
<functionDef2> -> WASM function
<functionDef1> -> WASM function
<WASM runtime call to invoke WASM> -> PROBLEM: may be written in C
<Faasm's runtime call to WASM runtime> -> try/catch exception
```

The previous works fine when the WASM runtime is implemented in C++ (e..g WAVM), as C++ exceptions are correctly propagated. Unfortunately, WAMR is written in C, so exceptions are not correctly propagated, and they are impossible to catch.

To work around this issue, we make use of `setjmp`/`longjmp`, inspired from  [here](http://groups.di.unipi.it/~nids/docs/longjump_try_trow_catch.html). This may feel like a big hack, but I don't think there's another way around it. This also means that we need to add a layer of indirection when throwing exceptions from native function calls (and potentially a number of `dynamic_cast`s), but exception throwing and catching is not really performance critical (for now) so we can bear the cost.

In the process I homogeneise the interface to execute WASM functions with WAMR (i.e. making call by name and call by pointer use the same low-level functions).