### PR TITLE
Mock `planner` in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,14 +153,7 @@ jobs:
     needs: [cpp-funcs, py-funcs, conan-cache]
     runs-on: ubuntu-latest
     env:
-      CGROUP_MODE: off
       HOST_TYPE: ci
-      LOG_LEVEL: info
-      NETNS_MODE: off
-      PLANNER_HOST: localhost
-      PLANNER_PORT: 8080
-      REDIS_QUEUE_HOST: redis
-      REDIS_STATE_HOST: redis
     container:
       image: faasm.azurecr.io/cli:0.9.9
       credentials:
@@ -236,7 +229,7 @@ jobs:
         run: ./bin/inv_wrapper.sh python.clear-runtime-pyc
       # Test run
       - name: "Run the tests"
-        run: /build/faasm/bin/tests
+        run: ./bin/inv_wrapper.sh tests
         env:
           LLVM_PROFILE_FILE: faasm.profraw
       - name: "Generate code coverage report"
@@ -333,7 +326,6 @@ jobs:
         run: ./bin/inv_wrapper.sh dev.cc tests
       # Run tests
       - name: "Run the tests"
-        # TODO: temporarily run in abort, to see if we are missing any env. vars
         run: ./bin/inv_wrapper.sh tests
 
   sgx-tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
       HOST_TYPE: ci
       LOG_LEVEL: info
       NETNS_MODE: off
-      PLANNER_HOST: planner
+      PLANNER_HOST: localhost
       PLANNER_PORT: 8080
       REDIS_QUEUE_HOST: redis
       REDIS_STATE_HOST: redis
@@ -276,8 +276,6 @@ jobs:
         env:
           MINIO_ROOT_USER: minio
           MINIO_ROOT_PASSWORD: minio123
-      planner:
-        image: faasm.azurecr.io/planner:0.4.4
     steps:
       - name: "Conan cache"
         uses: faasm/conan-cache-action@v1

--- a/faasmcli/faasmcli/tasks/tests.py
+++ b/faasmcli/faasmcli/tasks/tests.py
@@ -16,7 +16,7 @@ TEST_ENV = {
     "LD_LIBRARY_PATH": "/build/faasm/third-party/lib:/usr/local/lib",
     "LOG_LEVEL": "info",
     "NETNS_MODE": "off",
-    "PLANNER_HOST": "planner",
+    "PLANNER_HOST": "localhost",
     "PLANNER_PORT": "8080" if IS_CI else "8081",
     "REDIS_QUEUE_HOST": "redis" if IS_CI else "redis-queue",
     "REDIS_STATE_HOST": "redis" if IS_CI else "redis-state",

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -38,7 +38,7 @@ class DistTestsFixture
         redis.flushAll();
 
         // Planner reset
-        faabric::scheduler::Scheduler::getPlannerClient()->ping();
+        sch.getPlannerClient()->ping();
         resetPlanner();
 
         // Clean up the scheduler

--- a/tests/test/faaslet/test_flushing.cpp
+++ b/tests/test/faaslet/test_flushing.cpp
@@ -26,7 +26,9 @@
 
 namespace tests {
 
-class FlushingTestFixture : public FunctionLoaderTestFixture
+class FlushingTestFixture
+  : public FunctionLoaderTestFixture
+  , public PlannerClientServerTestFixture
 {
   public:
     FlushingTestFixture()

--- a/tests/test/faaslet/test_mpi.cpp
+++ b/tests/test/faaslet/test_mpi.cpp
@@ -13,8 +13,10 @@
 namespace tests {
 
 class MPIFuncTestFixture
-  : public FunctionExecTestFixture
-  , public MpiBaseTestFixture
+  : public MpiBaseTestFixture
+  , public WAVMModuleCacheTestFixture
+  , public IRModuleCacheTestFixture
+  , public ExecutorContextTestFixture
 {
   public:
     MPIFuncTestFixture()
@@ -144,16 +146,6 @@ TEST_CASE_METHOD(MPIFuncTestFixture, "Test MPI message ordering", "[mpi]")
     SECTION("WAMR") { faasmConf.wasmVm = "wamr"; }
 
     checkMpiFunc("mpi_order");
-}
-
-// 31/12/21 - Probe support is broken after faasm/faabric#205
-TEST_CASE_METHOD(MPIFuncTestFixture, "Test MPI probe", "[.]")
-{
-    SECTION("WAVM") { faasmConf.wasmVm = "wavm"; }
-
-    SECTION("WAMR") { faasmConf.wasmVm = "wamr"; }
-
-    checkMpiFunc("mpi_probe");
 }
 
 TEST_CASE_METHOD(MPIFuncTestFixture, "Test MPI reduce", "[mpi]")


### PR DESCRIPTION
In this PR we bump the faabric tag to include the planner mocking in the tests.

In practice, we only need to modify a couple of test cases to include the right planner test fixture.