### PR TITLE
Fix Azure Integration Tests

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -34,6 +34,8 @@ jobs:
         wasm_vm: [wamr, wavm, sgx]
     env:
       CLUSTER_NAME_BASE: gha-cluster
+      FAASM_INI_FILE: ./faasm.ini
+      FAASM_VERSION: 0.10.2
       WASM_VM: ${{ matrix.wasm_vm }}
     steps:
       - name: "Check out the experiment-base code"
@@ -59,8 +61,6 @@ jobs:
         run: faasmctl deploy.k8s --workers=4
       - name: "Build, upload and run a simple CPP function"
         run:  faasmctl cli.cpp --cmd "./bin/inv_wrapper.sh func demo hello func.upload demo hello func.invoke demo hello"
-        env:
-          FAASM_INI_FILE: ./faasm.ini
       - name: "Always delete AKS cluster"
         if: always()
         run: ./bin/inv_wrapper.sh cluster.delete --name ${{ env.CLUSTER_NAME }}

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -54,7 +54,7 @@ jobs:
           ./bin/inv_wrapper.sh cluster.credentials --name ${{ env.CLUSTER_NAME }}
         working-directory: ${{ github.workspace }}/experiment-base
       - name: "Install faasmctl"
-        run: pip3 install faasmctl==0.8.3
+        run: pip3 install faasmctl==0.9.1
       - name: "Deploy Faasm on k8s cluster"
         run: faasmctl deploy.k8s --workers=4
       - name: "Build, upload and run a simple CPP function"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -548,7 +548,7 @@ jobs:
         with:
           submodules: true
       - name: "Install faasmctl"
-        run: pip3 install faasmctl==0.8.3
+        run: pip3 install faasmctl==0.9.1
       # Cache contains architecture-specific machine code
       - name: "Get CPU model name"
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
@@ -618,7 +618,7 @@ jobs:
           build-type: release
         if: matrix.detached == false
       - name: "Install faasmctl"
-        run: pip3 install faasmctl==0.8.3
+        run: pip3 install faasmctl==0.9.1
       - name: "Fetch python's CPP submodulle"
         run: git submodule update --init -f third-party/cpp
         working-directory: ${{ github.workspace }}/clients/python

--- a/faasmcli/requirements.txt
+++ b/faasmcli/requirements.txt
@@ -3,7 +3,7 @@ breathe==4.32.0
 configparser==5.0.2
 cryptography==41.0.2
 docker==5.0.0
-faasmctl==0.8.3
+faasmctl==0.9.1
 flake8==3.9.2
 gunicorn==20.1.0
 hiredis==2.0.0


### PR DESCRIPTION
With #779 we added a task to purge old ACR images. We then deleted the images that the `faasmctl` version used in Faasm was pinned to. 

The fix has two parts:
* Bump `faasmctl` to a new enough version that supports setting the Faasm version
* Set the Faasm version as an env. variable for the Azure integration tests