### PR TITLE
 openmp: add basic WAMR support for OpenMP

### DIFF
--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -2,6 +2,7 @@
 
 #include <wamr/WAMRModuleMixin.h>
 #include <wasm/WasmModule.h>
+
 #include <wasm_runtime_common.h>
 
 #include <setjmp.h>
@@ -44,6 +45,10 @@ class WAMRWasmModule final
     void doBindToFunction(faabric::Message& msg, bool cache) override;
 
     int32_t executeFunction(faabric::Message& msg) override;
+
+    int32_t executeOMPThread(int threadPoolIdx,
+                             uint32_t stackTop,
+                             faabric::Message& msg) override;
 
     // ----- Exception handling -----
     void doThrowException(std::exception& e) override;

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -85,19 +85,20 @@ class WAMRWasmModule final
     std::vector<uint8_t> wasmBytes;
     WASMModuleCommon* wasmModule;
     WASMModuleInstanceCommon* moduleInstance;
-    // WAMR's execution environments are not thread-safe, so this execution
-    // environment should only be used by the main thread. Child threads use
-    // application-specific structures (e.g. OpenMP context vector)
-    WASMExecEnv* execEnv = nullptr;
-
+    // WAMR's execution environments are not thread-safe. Thus, we create an
+    // array of them at the beginning, each thread will access a different
+    // position in the array, so we do not need a mutex
+    std::vector<WASMExecEnv*> execEnvs;
 
     jmp_buf wamrExceptionJmpBuf;
 
-    int executeWasmFunction(const std::string& funcName);
+    int executeWasmFunction(int threadPoolIdx, const std::string& funcName);
 
-    int executeWasmFunctionFromPointer(faabric::Message& msg);
+    int executeWasmFunctionFromPointer(int threadPoolIdx,
+                                       faabric::Message& msg);
 
-    bool executeCatchException(WASMFunctionInstanceCommon* func,
+    bool executeCatchException(int threadPoolIdx,
+                               WASMFunctionInstanceCommon* func,
                                int wasmFuncPtr,
                                int argc,
                                std::vector<uint32_t>& argv);
@@ -105,8 +106,6 @@ class WAMRWasmModule final
     void bindInternal(faabric::Message& msg);
 
     bool doGrowMemory(uint32_t pageChange) override;
-
-    std::vector<WASMExecEnv*> openMPContexts;
 };
 
 WAMRWasmModule* getExecutingWAMRModule();

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -100,6 +100,8 @@ class WAMRWasmModule final
     void bindInternal(faabric::Message& msg);
 
     bool doGrowMemory(uint32_t pageChange) override;
+
+    std::vector<WASMExecEnv*> openMPContexts;
 };
 
 WAMRWasmModule* getExecutingWAMRModule();

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -88,6 +88,9 @@ class WAMRWasmModule final
     // WAMR's execution environments are not thread-safe. Thus, we create an
     // array of them at the beginning, each thread will access a different
     // position in the array, so we do not need a mutex
+    // TODO: decide if we need a lock or not!
+    std::shared_mutex execEnvsMx;
+    // TODO: maybe make this uniqueptrs with a destructor
     std::vector<WASMExecEnv*> execEnvs;
 
     jmp_buf wamrExceptionJmpBuf;

--- a/include/wamr/WAMRWasmModule.h
+++ b/include/wamr/WAMRWasmModule.h
@@ -85,6 +85,11 @@ class WAMRWasmModule final
     std::vector<uint8_t> wasmBytes;
     WASMModuleCommon* wasmModule;
     WASMModuleInstanceCommon* moduleInstance;
+    // WAMR's execution environments are not thread-safe, so this execution
+    // environment should only be used by the main thread. Child threads use
+    // application-specific structures (e.g. OpenMP context vector)
+    WASMExecEnv* execEnv = nullptr;
+
 
     jmp_buf wamrExceptionJmpBuf;
 

--- a/include/wamr/native.h
+++ b/include/wamr/native.h
@@ -57,6 +57,8 @@ uint32_t getFaasmMemoryApi(NativeSymbol** nativeSymbols);
 
 uint32_t getFaasmMpiApi(NativeSymbol** nativeSymbols);
 
+uint32_t getFaasmOpenMPApi(NativeSymbol** nativeSymbols);
+
 uint32_t getFaasmProcessApi(NativeSymbol** nativeSymbols);
 
 uint32_t getFaasmPthreadApi(NativeSymbol** nativeSymbols);

--- a/include/wasm/openmp.h
+++ b/include/wasm/openmp.h
@@ -82,5 +82,7 @@ int32_t doOpenMPMaster(int32_t loc, int32_t globalTid);
 
 void doOpenMPEndMaster(int32_t loc, int32_t globalTid);
 
+void doOpenMPPushNumThreads(int32_t loc, int32_t globalTid, int32_t numThreads);
+
 void doOpenMPSetNumThreads(int32_t numThreads);
 }

--- a/src/wamr/CMakeLists.txt
+++ b/src/wamr/CMakeLists.txt
@@ -21,6 +21,10 @@ set(WAMR_BUILD_LIBC_BUILTIN 1)
 set(WAMR_BUILD_LIBC_WASI 1)
 set(WAMR_BUILD_LIB_PTHREAD 0)
 
+# Enable APIs to manage low-level thread-local state
+set(WAMR_BUILD_THREAD_MGR 1)
+set(WAMR_BUILD_SHARED_MEMORY 1)
+
 # WAMR features
 set(WAMR_BUILD_SIMD 1)
 

--- a/src/wamr/CMakeLists.txt
+++ b/src/wamr/CMakeLists.txt
@@ -83,6 +83,7 @@ faasm_private_lib(wamrmodule
     memory.cpp
     mpi.cpp
     native.cpp
+    openmp.cpp
     process.cpp
     pthread.cpp
     signals.cpp

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -168,7 +168,14 @@ void WAMRWasmModule::bindInternal(faabric::Message& msg)
     // Set up thread stacks
     createThreadStacks();
 
-    // TODO: allocate a pool of OPenMP contexts here?
+    // TODO: allocate a pool of OpenMP contexts here?
+    // TODO: allocate them lazily?
+    // openMPContexts = std::vector<WASMExecEnv*>(threadPoolSize, nullptr);
+    /*
+    for (int i = 0; i < threadPoolSize; i++) {
+        openMPContexts.at(i) = wasm_exec_env_create(moduleInstance, STACK_SIZE);
+    }
+    */
 }
 
 int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
@@ -222,11 +229,16 @@ int32_t WAMRWasmModule::executeOMPThread(int threadPoolIdx,
                                          uint32_t stackTop,
                                          faabric::Message& msg)
 {
+    // TODO: probably need  a mutex here
+
     auto funcStr = faabric::util::funcToString(msg, false);
     int wasmFuncPtr = msg.funcptr();
     SPDLOG_DEBUG("Executing OpenMP thread {} for {}", threadPoolIdx, funcStr);
 
     auto ompLevel = threads::getCurrentOpenMPLevel();
+    if (ompLevel == nullptr) {
+        SPDLOG_ERROR("null OMP level!");
+    }
     int argc = ompLevel->nSharedVarOffsets;
     std::vector<uint32_t> argv(argc + 1);
     // The first element in the argv is used for the return value in WAMR
@@ -245,9 +257,50 @@ int32_t WAMRWasmModule::executeOMPThread(int threadPoolIdx,
     // argc
     auto originalArgv = argv;
     // TODO: in WAVM we modify the exec_env (created inside executeCatchException)
-    // to change the stack top. It seems that we createa different exec_env
+    // to change the stack top. It seems that we create a different exec_env
     // every time so maybe we don't have to do it?
-    bool success = executeCatchException(nullptr, wasmFuncPtr, argc, argv);
+    // bool success = executeCatchException(nullptr, wasmFuncPtr, argc, argv);
+    // FIXME: duplicate the code from executeCatchException here see if we can
+    // get it to work
+
+    // NOTE: i am thinking a new "thread" wants a new moduleInstance, and a new
+    // eecution environment (different threads then just share the same Wasm
+    // Module)
+    // Create a copy of the module instance for this ephemeral thread
+    // WASMModuleInstanceCommon* newModuleInstance =
+        // wasm_runtime_instantiate(wasmModule, STACK_SIZE_KB, 0, errorBuffer, ERROR_BUFFER_SIZE);
+
+    auto execEnvDtor = [&](WASMExecEnv* execEnv) {
+        if (execEnv != nullptr) {
+            wasm_runtime_destroy_exec_env(execEnv);
+        }
+        wasm_runtime_set_exec_env_tls(nullptr);
+    };
+    bool success = false;
+    // Use existing thread-local execution environment if it exists
+    auto* currentExecEnv = wasm_runtime_get_exec_env_tls();
+    if (currentExecEnv != nullptr) {
+        SPDLOG_WARN("re-using exec env!");
+        success = wasm_runtime_call_indirect(currentExecEnv, wasmFuncPtr, argc, argv.data());
+    } else {
+        std::unique_ptr<WASMExecEnv, decltype(execEnvDtor)> execEnv(
+            wasm_exec_env_create(moduleInstance, STACK_SIZE_KB),
+          execEnvDtor);
+        if (execEnv == nullptr) {
+            throw std::runtime_error("Error creating execution environment");
+        }
+        wasm_exec_env_set_thread_info(execEnv.get());
+        success = wasm_runtime_call_indirect(execEnv.get(), wasmFuncPtr, argc, argv.data());
+    }
+
+    // Create a copy of the module instance for this ephemeral thread
+    /*
+    WASMModuleInstanceCommon* newModuleInstance =
+        wasm_runtime_instantiate(wasmModule, STACK_SIZE_KB, 0, errorBuffer, ERROR_BUFFER_SIZE);
+    wasm_runtime_set_custom_data_internal(newModuleInstance, wasm_runtime_get_custom_data(moduleInstance));
+    wasm_native_inherit_contexts(newModuleInstance, moduleInstance);
+    */
+    // TODO: end of duplicated section
 
     if (!success) {
         SPDLOG_ERROR("Error executing OpenMP func {}: {}",

--- a/src/wamr/WAMRWasmModule.cpp
+++ b/src/wamr/WAMRWasmModule.cpp
@@ -105,7 +105,8 @@ void WAMRWasmModule::reset(faabric::Message& msg,
     std::string funcStr = faabric::util::funcToString(msg, true);
     SPDLOG_DEBUG("WAMR resetting after {} (snap key {})", funcStr, snapshotKey);
 
-    wasm_runtime_destroy_exec_env(execEnv);
+    // TODO: FIXME: does every thread call reset, or just once?
+    // wasm_runtime_destroy_exec_env(execEnv);
     wasm_runtime_deinstantiate(moduleInstance);
     bindInternal(msg);
 }
@@ -166,24 +167,30 @@ void WAMRWasmModule::bindInternal(faabric::Message& msg)
     }
     currentBrk.store(getMemorySizeBytes(), std::memory_order_release);
 
-    // Create the execution environemnt for this thread
-    execEnv = wasm_runtime_create_exec_env(moduleInstance, STACK_SIZE_KB);
-    if (execEnv == nullptr) {
-        SPDLOG_ERROR("Error creating execution environment!");
-        throw std::runtime_error("Error creating execution environment");
-    }
-
     // Set up thread stacks
+    // TODO: we want to connect the stack top in the thread stack to the
+    // execution environment that we are creating below!
     createThreadStacks();
 
-    // TODO: allocate contexts lazily?
-    // TODO: maybe we do not need to set the thread idx 0?
-    openMPContexts = std::vector<WASMExecEnv*>(threadPoolSize, nullptr);
-    for (int i = 0; i < threadPoolSize; i++) {
-        openMPContexts.at(i) = wasm_runtime_spawn_exec_env(execEnv);
-        if (openMPContexts.at(i) == nullptr) {
-            SPDLOG_ERROR("Failed to spawn thread execution env. for thread {}", i);
-            throw std::runtime_error("Failed to spawn thread execution environment");
+    // Create the execution environemnt for all the potential threads
+    execEnvs = std::vector<WASMExecEnv*>(threadPoolSize, nullptr);
+
+    // Execution environment for the main thread
+    execEnvs.at(0) =
+      wasm_runtime_create_exec_env(moduleInstance, STACK_SIZE_KB);
+    if (execEnvs.at(0) == nullptr) {
+        SPDLOG_ERROR("Error allocating execution environment for main thread!");
+    }
+
+    // Execution environment for all subsequent threads. We deliberately do
+    // not initialise these lazily to avoid race conditions with the main
+    // thread exec env (which we clone from)
+    for (int i = 1; i < threadPoolSize; i++) {
+        execEnvs.at(i) = wasm_runtime_spawn_exec_env(execEnvs.at(0));
+        if (execEnvs.at(i) == nullptr) {
+            SPDLOG_ERROR(
+              "Error allocating execution environment for thread {}!", i);
+            throw std::runtime_error("Error allocating exec. env!");
         }
     }
 }
@@ -192,18 +199,21 @@ int32_t WAMRWasmModule::executeFunction(faabric::Message& msg)
 {
     SPDLOG_DEBUG("WAMR executing message {}", msg.id());
 
+    // If we are calling this function, we know we are thread pool 0
+    int thisThreadPoolIdx = 0;
+
     // Make sure context is set
     WasmExecutionContext ctx(this);
     int returnValue = 0;
 
     if (msg.funcptr() > 0) {
         // Run the function from the pointer
-        returnValue = executeWasmFunctionFromPointer(msg);
+        returnValue = executeWasmFunctionFromPointer(thisThreadPoolIdx, msg);
     } else {
         prepareArgcArgv(msg);
 
         // Run the main function
-        returnValue = executeWasmFunction(ENTRY_FUNC_NAME);
+        returnValue = executeWasmFunction(thisThreadPoolIdx, ENTRY_FUNC_NAME);
     }
 
     // Record the return value
@@ -239,8 +249,6 @@ int32_t WAMRWasmModule::executeOMPThread(int threadPoolIdx,
                                          uint32_t stackTop,
                                          faabric::Message& msg)
 {
-    // TODO: probably need  a mutex here
-
     auto funcStr = faabric::util::funcToString(msg, false);
     int wasmFuncPtr = msg.funcptr();
     SPDLOG_DEBUG("Executing OpenMP thread {} for {}", threadPoolIdx, funcStr);
@@ -255,68 +263,27 @@ int32_t WAMRWasmModule::executeOMPThread(int threadPoolIdx,
     argv[0] = { 0 };
 
     // The rest of the arguments are the ones corresponding to OpenMP
-    for (int i =0; i < argc; i++) {
+    for (int i = 0; i < argc; i++) {
         argv.at(i + 1) = ompLevel->sharedVarOffsets[i];
     }
 
     // Work-out if the function reutrns a value or returns void
-    AOTFuncType* funcType = getFuncTypeFromFuncPtr(wasmModule, moduleInstance, wasmFuncPtr);
+    AOTFuncType* funcType =
+      getFuncTypeFromFuncPtr(wasmModule, moduleInstance, wasmFuncPtr);
     bool returnsVoid = funcType->result_count == 0;
 
     // Note that, even if argv.size() == argc + 1, this method takes the _real_
     // argc
     auto originalArgv = argv;
-    // TODO: in WAVM we modify the exec_env (created inside executeCatchException)
-    // to change the stack top. It seems that we create a different exec_env
-    // every time so maybe we don't have to do it?
-    // bool success = executeCatchException(nullptr, wasmFuncPtr, argc, argv);
-    // FIXME: duplicate the code from executeCatchException here see if we can
-    // get it to work
-
-    // NOTE: i am thinking a new "thread" wants a new moduleInstance, and a new
-    // eecution environment (different threads then just share the same Wasm
-    // Module)
-    // Create a copy of the module instance for this ephemeral thread
-    // WASMModuleInstanceCommon* newModuleInstance =
-        // wasm_runtime_instantiate(wasmModule, STACK_SIZE_KB, 0, errorBuffer, ERROR_BUFFER_SIZE);
-
-    auto execEnvDtor = [&](WASMExecEnv* execEnv) {
-        if (execEnv != nullptr) {
-            wasm_runtime_destroy_exec_env(execEnv);
-        }
-        wasm_runtime_set_exec_env_tls(nullptr);
-    };
-    bool success = false;
-    // Use existing thread-local execution environment if it exists
-    auto* currentExecEnv = wasm_runtime_get_exec_env_tls();
-    if (currentExecEnv != nullptr) {
-        SPDLOG_WARN("re-using exec env!");
-        success = wasm_runtime_call_indirect(currentExecEnv, wasmFuncPtr, argc, argv.data());
-    } else {
-        std::unique_ptr<WASMExecEnv, decltype(execEnvDtor)> execEnv(
-            wasm_exec_env_create(moduleInstance, STACK_SIZE_KB),
-          execEnvDtor);
-        if (execEnv == nullptr) {
-            throw std::runtime_error("Error creating execution environment");
-        }
-        wasm_exec_env_set_thread_info(execEnv.get());
-        success = wasm_runtime_call_indirect(execEnv.get(), wasmFuncPtr, argc, argv.data());
-    }
-
-    // Create a copy of the module instance for this ephemeral thread
-    /*
-    WASMModuleInstanceCommon* newModuleInstance =
-        wasm_runtime_instantiate(wasmModule, STACK_SIZE_KB, 0, errorBuffer, ERROR_BUFFER_SIZE);
-    wasm_runtime_set_custom_data_internal(newModuleInstance, wasm_runtime_get_custom_data(moduleInstance));
-    wasm_native_inherit_contexts(newModuleInstance, moduleInstance);
-    */
-    // TODO: end of duplicated section
+    bool success =
+      executeCatchException(threadPoolIdx, nullptr, wasmFuncPtr, argc, argv);
 
     if (!success) {
         SPDLOG_ERROR("Error executing OpenMP func {}: {}",
                      wasmFuncPtr,
                      wasm_runtime_get_exception(moduleInstance));
-        throw std::runtime_error("Error executing WASM OpenMP func ptr with WAMR");
+        throw std::runtime_error(
+          "Error executing WASM OpenMP func ptr with WAMR");
     }
 
     // If we are calling a void function by pointer with some arguments, the
@@ -328,11 +295,13 @@ int32_t WAMRWasmModule::executeOMPThread(int threadPoolIdx,
         returnValue = 0;
     }
 
-    SPDLOG_DEBUG("WAMR finished executing OMP thread {} for {}", threadPoolIdx, funcStr);
+    SPDLOG_DEBUG(
+      "WAMR finished executing OMP thread {} for {}", threadPoolIdx, funcStr);
     return returnValue;
 }
 
-int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
+int WAMRWasmModule::executeWasmFunctionFromPointer(int threadPoolIdx,
+                                                   faabric::Message& msg)
 {
     // WASM function pointers are indices into the module's function table
     int wasmFuncPtr = msg.funcptr();
@@ -342,7 +311,8 @@ int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
                  wasmFuncPtr,
                  inputData);
 
-    AOTFuncType* funcType = getFuncTypeFromFuncPtr(wasmModule, moduleInstance, wasmFuncPtr);
+    AOTFuncType* funcType =
+      getFuncTypeFromFuncPtr(wasmModule, moduleInstance, wasmFuncPtr);
     int argCount = funcType->param_count;
     int resultCount = funcType->result_count;
     SPDLOG_DEBUG("WAMR Function pointer has {} arguments and returns {} value",
@@ -378,7 +348,8 @@ int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
         }
     }
     std::vector<uint32_t> originalArgv = argv;
-    bool success = executeCatchException(nullptr, wasmFuncPtr, argCount, argv);
+    bool success = executeCatchException(
+      threadPoolIdx, nullptr, wasmFuncPtr, argCount, argv);
 
     if (!success) {
         SPDLOG_ERROR("Error executing {}: {}",
@@ -400,7 +371,8 @@ int WAMRWasmModule::executeWasmFunctionFromPointer(faabric::Message& msg)
     return returnValue;
 }
 
-int WAMRWasmModule::executeWasmFunction(const std::string& funcName)
+int WAMRWasmModule::executeWasmFunction(int threadPoolIdx,
+                                        const std::string& funcName)
 {
     SPDLOG_DEBUG("WAMR executing function from string {}", funcName);
 
@@ -418,7 +390,8 @@ int WAMRWasmModule::executeWasmFunction(const std::string& funcName)
     // pass it, therefore we should provide a single integer argv even though
     // it's not actually used
     std::vector<uint32_t> argv = { 0 };
-    bool success = executeCatchException(func, NO_WASM_FUNC_PTR, 0, argv);
+    bool success =
+      executeCatchException(threadPoolIdx, func, NO_WASM_FUNC_PTR, 0, argv);
     uint32_t returnValue = argv[0];
 
     if (!success) {
@@ -435,7 +408,8 @@ int WAMRWasmModule::executeWasmFunction(const std::string& funcName)
 // Low-level method to call a WASM function in WAMR and catch any thrown
 // exceptions. This method is shared both if we call a function by pointer or
 // by name
-bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
+bool WAMRWasmModule::executeCatchException(int threadPoolIdx,
+                                           WASMFunctionInstanceCommon* func,
                                            int wasmFuncPtr,
                                            int argc,
                                            std::vector<uint32_t>& argv)
@@ -450,23 +424,15 @@ bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
           "Incorrect combination of arguments to execute WAMR function");
     }
 
-    /*
-    auto execEnvDtor = [&](WASMExecEnv* execEnv) {
-        if (execEnv != nullptr) {
-            wasm_runtime_destroy_exec_env(execEnv);
-        }
-        // wasm_runtime_set_exec_env_tls(nullptr);
-    };
-    */
-
-    // Create an execution environment
-    /*
-    std::unique_ptr<WASMExecEnv, decltype(execEnvDtor)> execEnv(
-      wasm_runtime_create_exec_env(moduleInstance, STACK_SIZE_KB), execEnvDtor);
-      */
-
-    // Set thread handle and stack boundary (required by WAMR)
-    // wasm_exec_env_set_thread_info(execEnv.get());
+    // Prepare thread execution environment
+    WASMExecEnv* thisThreadExecEnv = thisThreadExecEnv =
+      execEnvs.at(threadPoolIdx);
+    if (thisThreadExecEnv == nullptr) {
+        SPDLOG_ERROR("Null execution environment for thread: {}!",
+                     threadPoolIdx);
+        throw std::runtime_error("Null execution environment!");
+    }
+    wasm_runtime_init_thread_env();
 
     bool success;
     {
@@ -478,10 +444,10 @@ bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
             case 0: {
                 if (isIndirect) {
                     success = wasm_runtime_call_indirect(
-                      execEnv, wasmFuncPtr, argc, argv.data());
+                      thisThreadExecEnv, wasmFuncPtr, argc, argv.data());
                 } else {
                     success = wasm_runtime_call_wasm(
-                      execEnv, func, argc, argv.data());
+                      thisThreadExecEnv, func, argc, argv.data());
                 }
                 break;
             }
@@ -489,21 +455,28 @@ bool WAMRWasmModule::executeCatchException(WASMFunctionInstanceCommon* func,
             // a longjmp (and returns a value different than 0) as local
             // variables in the stack could be corrupted
             case WAMRExceptionTypes::FunctionMigratedException: {
+                wasm_runtime_destroy_thread_env();
                 throw faabric::util::FunctionMigratedException(
                   "Migrating MPI rank");
             }
             case WAMRExceptionTypes::QueueTimeoutException: {
+                wasm_runtime_destroy_thread_env();
                 throw std::runtime_error("Timed-out dequeueing!");
             }
             case WAMRExceptionTypes::DefaultException: {
+                wasm_runtime_destroy_thread_env();
                 throw std::runtime_error("Default WAMR exception");
             }
             default: {
                 SPDLOG_ERROR("WAMR exception handler reached unreachable case");
+                wasm_runtime_destroy_thread_env();
                 throw std::runtime_error("Unreachable WAMR exception handler");
             }
         }
     }
+
+    // Clean-up thread execution environment
+    wasm_runtime_destroy_thread_env();
 
     return success;
 }

--- a/src/wamr/native.cpp
+++ b/src/wamr/native.cpp
@@ -26,6 +26,7 @@ void initialiseWAMRNatives()
     doSymbolRegistration(getFaasmFunctionsApi);
     doSymbolRegistration(getFaasmMemoryApi);
     doSymbolRegistration(getFaasmMpiApi);
+    doSymbolRegistration(getFaasmOpenMPApi);
     doSymbolRegistration(getFaasmProcessApi);
     doSymbolRegistration(getFaasmPthreadApi);
     doSymbolRegistration(getFaasmSignalApi);

--- a/src/wamr/openmp.cpp
+++ b/src/wamr/openmp.cpp
@@ -77,6 +77,14 @@ static int32_t __kmpc_master_wrapper(wasm_exec_env_t exec_env,
     return wasm::doOpenMPMaster(loc, globalTid);
 }
 
+static void __kmpc_push_num_threads_wrapper(wasm_exec_env_t execEnv,
+                                            int32_t loc,
+                                            int32_t globalTid,
+                                            int32_t numThreads)
+{
+    wasm::doOpenMPPushNumThreads(loc, globalTid, numThreads);
+}
+
 static int32_t omp_get_num_threads_wrapper(wasm_exec_env_t exec_env)
 {
     return wasm::doOpenMPGetNumThreads();
@@ -107,6 +115,7 @@ static NativeSymbol ns[] = {
     REG_NATIVE_FUNC(__kmpc_fork_call, "(iiii)"),
     REG_NATIVE_FUNC(__kmpc_global_thread_num, "(i)i"),
     REG_NATIVE_FUNC(__kmpc_master, "(ii)i"),
+    REG_NATIVE_FUNC(__kmpc_push_num_threads, "(iii)"),
     REG_NATIVE_FUNC(omp_get_num_threads, "()i"),
     REG_NATIVE_FUNC(omp_get_thread_num, "()i"),
     REG_NATIVE_FUNC(omp_get_wtime, "()F"),

--- a/src/wamr/openmp.cpp
+++ b/src/wamr/openmp.cpp
@@ -85,22 +85,22 @@ static void __kmpc_push_num_threads_wrapper(wasm_exec_env_t execEnv,
     wasm::doOpenMPPushNumThreads(loc, globalTid, numThreads);
 }
 
-static int32_t omp_get_num_threads_wrapper(wasm_exec_env_t exec_env)
+static int32_t omp_get_num_threads_wrapper(wasm_exec_env_t execEnv)
 {
     return wasm::doOpenMPGetNumThreads();
 }
 
-static int32_t omp_get_thread_num_wrapper(wasm_exec_env_t exec_env)
+static int32_t omp_get_thread_num_wrapper(wasm_exec_env_t execEnv)
 {
     return wasm::doOpenMPGetThreadNum();
 }
 
-static double omp_get_wtime_wrapper(wasm_exec_env_t exec_env)
+static double omp_get_wtime_wrapper(wasm_exec_env_t execEnv)
 {
     return wasm::doOpenMPGetWTime();
 }
 
-static void omp_set_num_threads_wrapper(wasm_exec_env_t exec_env,
+static void omp_set_num_threads_wrapper(wasm_exec_env_t execEnv,
                                         int32_t numThreads)
 {
     wasm::doOpenMPSetNumThreads(numThreads);

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -150,9 +150,6 @@ void doOpenMPFork(int32_t loc,
     req->set_contextdata(serialisedLevel.data(), serialisedLevel.size());
 
     // Configure the mesages
-    parentCall->set_appidx(0);
-    parentCall->set_groupidx(0);
-    parentCall->set_funcptr(microTask);
     for (int i = 0; i < req->messages_size(); i++) {
         faabric::Message& m = req->mutable_messages()->at(i);
 
@@ -568,6 +565,16 @@ int32_t doOpenMPMaster(int32_t loc, int32_t globalTid)
     OMP_FUNC_ARGS("__kmpc_master {} {}", loc, globalTid);
 
     return localThreadNum == 0;
+}
+
+void doOpenMPPushNumThreads(int32_t loc, int32_t globalTid, int32_t numThreads)
+{
+    OMP_FUNC_ARGS(
+      "__kmpc_push_num_threads {} {} {}", loc, globalTid, numThreads);
+
+    if (numThreads > 0) {
+        level->pushedThreads = numThreads;
+    }
 }
 
 void doOpenMPEndMaster(int32_t loc, int32_t globalTid)

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -284,7 +284,6 @@ void doOpenMPFork(int32_t loc,
             throw std::runtime_error("OpenMP threads failed");
         }
     }
-    */
 
     // Perform snapshot updates if not on single host. Note that, here we know
     // for sure that we must do dirty tracking, and are the last thread in

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -150,6 +150,9 @@ void doOpenMPFork(int32_t loc,
     req->set_contextdata(serialisedLevel.data(), serialisedLevel.size());
 
     // Configure the mesages
+    parentCall->set_appidx(0);
+    parentCall->set_groupidx(0);
+    parentCall->set_funcptr(microTask);
     for (int i = 0; i < req->messages_size(); i++) {
         faabric::Message& m = req->mutable_messages()->at(i);
 
@@ -281,6 +284,7 @@ void doOpenMPFork(int32_t loc,
             throw std::runtime_error("OpenMP threads failed");
         }
     }
+    */
 
     // Perform snapshot updates if not on single host. Note that, here we know
     // for sure that we must do dirty tracking, and are the last thread in

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -997,7 +997,10 @@ int32_t WAVMWasmModule::executeOMPThread(int threadPoolIdx,
     executeWasmFunction(ctx, funcInstance, invokeArgs, returnValue);
     msg.set_returnvalue(returnValue.i32);
 
-    SPDLOG_INFO("Finished OpenMP thread {} for {} (ret: {})", threadPoolIdx, funcStr, returnValue.i32);
+    SPDLOG_INFO("Finished OpenMP thread {} for {} (ret: {})",
+                threadPoolIdx,
+                funcStr,
+                returnValue.i32);
     return returnValue.i32;
 }
 

--- a/src/wavm/WAVMWasmModule.cpp
+++ b/src/wavm/WAVMWasmModule.cpp
@@ -969,7 +969,7 @@ int32_t WAVMWasmModule::executeOMPThread(int threadPoolIdx,
     Runtime::Function* funcInstance = getFunctionFromPtr(msg.funcptr());
 
     std::string funcStr = faabric::util::funcToString(msg, false);
-    SPDLOG_DEBUG("Executing OpenMP thread {} for {}", threadPoolIdx, funcStr);
+    SPDLOG_INFO("Executing OpenMP thread {} for {}", threadPoolIdx, funcStr);
 
     // Set up function args
     // NOTE: an OpenMP microtask takes the following arguments:
@@ -997,6 +997,7 @@ int32_t WAVMWasmModule::executeOMPThread(int threadPoolIdx,
     executeWasmFunction(ctx, funcInstance, invokeArgs, returnValue);
     msg.set_returnvalue(returnValue.i32);
 
+    SPDLOG_INFO("Finished OpenMP thread {} for {} (ret: {})", threadPoolIdx, funcStr, returnValue.i32);
     return returnValue.i32;
 }
 

--- a/src/wavm/openmp.cpp
+++ b/src/wavm/openmp.cpp
@@ -110,12 +110,7 @@ WAVM_DEFINE_INTRINSIC_FUNCTION(env,
                                I32 globalTid,
                                I32 numThreads)
 {
-    OMP_FUNC_ARGS(
-      "__kmpc_push_num_threads {} {} {}", loc, globalTid, numThreads);
-
-    if (numThreads > 0) {
-        level->pushedThreads = numThreads;
-    }
+    wasm::doOpenMPPushNumThreads(loc, globalTid, numThreads);
 }
 
 WAVM_DEFINE_INTRINSIC_FUNCTION(env,

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -21,6 +21,7 @@ namespace tests {
 class OpenMPTestFixture
   : public FunctionExecTestFixture
   , public SnapshotRegistryFixture
+  , public FaasmConfTestFixture
   , public ConfFixture
 {
   public:
@@ -38,6 +39,11 @@ class OpenMPTestFixture
         faabric::Message msg = faabric::util::messageFactory("omp", function);
         auto req = faabric::util::batchExecFactory("omp", function, 1);
         req->set_singlehosthint(true);
+
+        SECTION("WAVM") { faasmConf.wasmVm = "wavm"; }
+
+        SECTION("WAMR") { faasmConf.wasmVm = "wamr"; }
+
         faabric::Message result =
           executeWithPool(req, OMP_TEST_TIMEOUT_MS).at(0);
 

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -40,7 +40,7 @@ class OpenMPTestFixture
         auto req = faabric::util::batchExecFactory("omp", function, 1);
         req->set_singlehosthint(true);
 
-        SECTION("WAVM") { faasmConf.wasmVm = "wavm"; }
+        // SECTION("WAVM") { faasmConf.wasmVm = "wavm"; }
 
         SECTION("WAMR") { faasmConf.wasmVm = "wamr"; }
 


### PR DESCRIPTION
WARNING: probably our OpenMP errors are due to the fact that we do not enable WASM's atomics, and we may be running into a race condition when multiple threads operate on the same WASM module.

WAVM seems to be happy with this, but WAMR does not allow threads to share a module's memory unless the module has been compiled with the `--shared-memory` flag, which requires building `wasi-libc` and the toolchain with `atomics` and `bulk-memory`.

https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/embed_wamr.md#execute-wasm-functions-in-multiple-threads