### PR TITLE
openmp: implement real openmp fork/join model

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@ FAASM_VERSION=0.18.0
 FAASM_CLI_IMAGE=faasm.azurecr.io/cli:0.18.0
 FAASM_WORKER_IMAGE=faasm.azurecr.io/worker:0.18.0
 
-FAABRIC_VERSION=0.12.0
-FAABRIC_PLANNER_IMAGE=faasm.azurecr.io/planner:0.12.0
+FAABRIC_VERSION=0.13.0
+FAABRIC_PLANNER_IMAGE=faasm.azurecr.io/planner:0.13.0
 
 CPP_VERSION=0.3.1
 CPP_CLI_IMAGE=faasm.azurecr.io/cpp-sysroot:0.3.1

--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -56,7 +56,7 @@ jobs:
           ./bin/inv_wrapper.sh cluster.credentials --name ${{ env.CLUSTER_NAME }}
         working-directory: ${{ github.workspace }}/experiment-base
       - name: "Install faasmctl"
-        run: source ./bin/workon.sh && pip3 install faasmctl==0.24.0
+        run: source ./bin/workon.sh && pip3 install faasmctl==0.25.0
         working-directory: ${{ github.workspace }}/experiment-base
       - name: "Deploy Faasm on k8s cluster"
         run: source ./bin/workon.sh && faasmctl deploy.k8s --workers=4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -547,7 +547,7 @@ jobs:
         with:
           submodules: true
       - name: "Install faasmctl"
-        run: pip3 install faasmctl==0.24.0
+        run: pip3 install faasmctl==0.25.0
       # Cache contains architecture-specific machine code
       - name: "Get CPU model name"
         run: echo "CPU_MODEL=$(./bin/print_cpu.sh)" >> $GITHUB_ENV
@@ -620,7 +620,7 @@ jobs:
           build-type: release
         if: matrix.detached == false
       - name: "Install faasmctl"
-        run: pip3 install faasmctl==0.24.0
+        run: pip3 install faasmctl==0.25.0
       - name: "Fetch python's CPP submodulle"
         run: git submodule update --init -f third-party/cpp
         working-directory: ${{ github.workspace }}/clients/python

--- a/deploy/k8s-common/planner.yml
+++ b/deploy/k8s-common/planner.yml
@@ -11,7 +11,7 @@ metadata:
 spec:
   containers:
     - name: planner
-      image: faasm.azurecr.io/planner:0.12.0
+      image: faasm.azurecr.io/planner:0.13.0
       ports:
         - containerPort: 8081
       env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black>=23.12.0
 breathe>=4.35.0
-faasmctl==0.24.0
+faasmctl==0.25.0
 flake8>=7.0.0
 invoke>=2.0.0
 myst_parser>=2.0.0

--- a/src/runner/MicrobenchRunner.cpp
+++ b/src/runner/MicrobenchRunner.cpp
@@ -63,7 +63,7 @@ int MicrobenchRunner::doRun(std::ofstream& outFs,
 
     auto req = createBatchRequest(user, function, inputData);
     faabric::Message msg = req->messages().at(0);
-    req->set_singlehost(true);
+    req->set_singlehosthint(true);
 
     // Check files have been uploaded
     storage::FileLoader& loader = storage::getFileLoader();

--- a/src/runner/MicrobenchRunner.cpp
+++ b/src/runner/MicrobenchRunner.cpp
@@ -63,6 +63,7 @@ int MicrobenchRunner::doRun(std::ofstream& outFs,
 
     auto req = createBatchRequest(user, function, inputData);
     faabric::Message msg = req->messages().at(0);
+    req->set_singlehost(true);
 
     // Check files have been uploaded
     storage::FileLoader& loader = storage::getFileLoader();

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -554,8 +554,9 @@ int WasmModule::awaitPthreadCall(faabric::Message* msg, int pthreadPtr)
 
         // Execute the threads and await results
         faabric::planner::getPlannerClient().callFunctions(req);
-        lastPthreadResults = faabric::scheduler::getScheduler().awaitThreadResults(
-          req, 10 * faabric::util::getSystemConfig().boundTimeout);
+        lastPthreadResults =
+          faabric::scheduler::getScheduler().awaitThreadResults(
+            req, 10 * faabric::util::getSystemConfig().boundTimeout);
 
         // Empty the queue
         queuedPthreadCalls.clear();

--- a/src/wasm/WasmModule.cpp
+++ b/src/wasm/WasmModule.cpp
@@ -520,10 +520,10 @@ int WasmModule::awaitPthreadCall(faabric::Message* msg, int pthreadPtr)
         req->set_type(faabric::BatchExecuteRequest::THREADS);
         req->set_subtype(wasm::ThreadRequestType::PTHREAD);
 
-        // In the local tests, we always set the single-host flag to avoid
+        // In the local tests, we always set the single-host hint to avoid
         // having to synchronise snapshots
         if (faabric::util::isTestMode()) {
-            req->set_singlehost(true);
+            req->set_singlehosthint(true);
         }
 
         for (int i = 0; i < nPthreadCalls; i++) {

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -185,7 +185,6 @@ void doOpenMPFork(int32_t loc,
     }
 
     // Invoke all non-main threads
-    // std::shared_ptr<faabric::
     faabric::batch_scheduler::SchedulingDecision decision(req->appid(), 0);
     if (req->messages_size() > 0) {
         decision = faabric::planner::getPlannerClient().callFunctions(req);

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -166,6 +166,7 @@ void doOpenMPFork(int32_t loc,
     // Preload the schedulign decisions in local test mode to avoid having to
     // distribute the snapshots
     // TODO: can we skip this?
+    /*
     auto& plannerCli = faabric::planner::getPlannerClient();
     if (faabric::util::isTestMode()) {
         SPDLOG_INFO(
@@ -183,6 +184,7 @@ void doOpenMPFork(int32_t loc,
 
         req->set_singlehost(true);
     }
+    */
 
     // Invoke all non-main threads
     faabric::batch_scheduler::SchedulingDecision decision(req->appid(), 0);

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -207,6 +207,7 @@ void doOpenMPFork(int32_t loc,
     thisThreadReq->set_subtype(ThreadRequestType::OPENMP);
     thisThreadReq->set_contextdata(serialisedLevel.data(),
                                    serialisedLevel.size());
+    thisThreadReq->set_singlehost(parentReq->singlehost());
     // Update the group and batch id for inter-thread communication
     faabric::util::updateBatchExecAppId(thisThreadReq, parentCall->appid());
     faabric::util::updateBatchExecGroupId(thisThreadReq, decision.groupId);

--- a/src/wasm/openmp.cpp
+++ b/src/wasm/openmp.cpp
@@ -236,6 +236,7 @@ void doOpenMPFork(int32_t loc,
     thisThreadReq->set_contextdata(serialisedLevel.data(),
                                    serialisedLevel.size());
     thisThreadReq->set_singlehost(parentReq->singlehost());
+    thisThreadReq->set_singlehosthint(parentReq->singlehosthint());
     // Update the group and batch id for inter-thread communication
     faabric::util::updateBatchExecAppId(thisThreadReq, parentCall->appid());
     faabric::util::updateBatchExecGroupId(thisThreadReq, decision.groupId);

--- a/tests/dist/fixtures.h
+++ b/tests/dist/fixtures.h
@@ -73,6 +73,7 @@ class DistTestsFixture
         localResources->set_slots(nLocalSlots);
         localResources->set_usedslots(nLocalUsedSlots);
         sch.addHostToGlobalSet(getDistTestMasterIp(), localResources);
+        conf.overrideCpuCount = nLocalSlots;
 
         auto remoteResources = std::make_shared<faabric::HostResources>();
         remoteResources->set_slots(nRemoteSlots);

--- a/tests/dist/threads/test_openmp.cpp
+++ b/tests/dist/threads/test_openmp.cpp
@@ -13,8 +13,6 @@ TEST_CASE_METHOD(DistTestsFixture,
                  "Test OpenMP across hosts",
                  "[threads][openmp]")
 {
-    conf.overrideCpuCount = 6;
-
     // TODO(wamr-omp)
     if (faasmConf.wasmVm == "wamr") {
         return;

--- a/tests/dist/threads/test_pthreads.cpp
+++ b/tests/dist/threads/test_pthreads.cpp
@@ -9,8 +9,6 @@ namespace tests {
 
 TEST_CASE_METHOD(DistTestsFixture, "Test pthreads across hosts", "[scheduler]")
 {
-    conf.overrideCpuCount = 6;
-
     // TODO(wamr-omp)
     if (faasmConf.wasmVm == "wamr") {
         return;

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -226,10 +226,5 @@ TEST_CASE_METHOD(OpenMPTestFixture,
 
     // Get result
     REQUIRE(result.returnvalue() > 0);
-
-    std::string expectedOutput = fmt::format(
-      "Task {} threw exception. What: OpenMP threads failed", msg.id());
-    const std::string actualOutput = result.outputdata();
-    REQUIRE(actualOutput == expectedOutput);
 }
 }

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -221,7 +221,7 @@ TEST_CASE_METHOD(OpenMPTestFixture,
     sch.setThisHostResources(res);
 
     auto req = faabric::util::batchExecFactory("omp", "nested_parallel", 1);
-    auto& msg = *req->mutable_messages(0);
+    req->set_singlehosthint(true);
     faabric::Message result = executeWithPool(req, 1000, false).at(0);
 
     // Get result

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -37,6 +37,7 @@ class OpenMPTestFixture
     {
         faabric::Message msg = faabric::util::messageFactory("omp", function);
         auto req = faabric::util::batchExecFactory("omp", function, 1);
+        req->set_singlehost(true);
         faabric::Message result =
           executeWithPool(req, OMP_TEST_TIMEOUT_MS).at(0);
 

--- a/tests/test/wasm/test_openmp.cpp
+++ b/tests/test/wasm/test_openmp.cpp
@@ -37,7 +37,7 @@ class OpenMPTestFixture
     {
         faabric::Message msg = faabric::util::messageFactory("omp", function);
         auto req = faabric::util::batchExecFactory("omp", function, 1);
-        req->set_singlehost(true);
+        req->set_singlehosthint(true);
         faabric::Message result =
           executeWithPool(req, OMP_TEST_TIMEOUT_MS).at(0);
 


### PR DESCRIPTION
Before, when we wanted to spawn 10 OpenMP threads, the main executing thread would spawn 10 threads, and wait for their result. In the true OpenMP fork/join model, the parent thread is part of the 10 remaining threads.

The latter logic makes it simpler to implement in terms of SCALE_UP or DIST_CHANGE decisions wrt the planner, so we do so here.