### PR TITLE
enclave: fix overflow

### DIFF
--- a/include/enclave/inside/EnclaveWasmModule.h
+++ b/include/enclave/inside/EnclaveWasmModule.h
@@ -27,7 +27,10 @@ class EnclaveWasmModule : public WAMRModuleMixin<EnclaveWasmModule>
     // instance of the _same_ function.
     bool reset();
 
-    bool doBindToFunction(const char* user, const char* function, void* wasmOpCodePtr, uint32_t wasmOpCodeSize);
+    bool doBindToFunction(const char* user,
+                          const char* function,
+                          void* wasmOpCodePtr,
+                          uint32_t wasmOpCodeSize);
 
     uint32_t callFunction(uint32_t argcIn, char** argvIn);
 

--- a/include/enclave/inside/EnclaveWasmModule.h
+++ b/include/enclave/inside/EnclaveWasmModule.h
@@ -20,15 +20,14 @@ class EnclaveWasmModule : public WAMRModuleMixin<EnclaveWasmModule>
   public:
     static bool initialiseWAMRGlobally();
 
-    EnclaveWasmModule(const std::string& user, const std::string& func);
-
+    EnclaveWasmModule();
     ~EnclaveWasmModule();
 
     // Called after every execution, leaves the module ready to execute another
     // instance of the _same_ function.
     bool reset();
 
-    bool doBindToFunction(void* wasmOpCodePtr, uint32_t wasmOpCodeSize);
+    bool doBindToFunction(const char* user, const char* function, void* wasmOpCodePtr, uint32_t wasmOpCodeSize);
 
     uint32_t callFunction(uint32_t argcIn, char** argvIn);
 
@@ -36,6 +35,8 @@ class EnclaveWasmModule : public WAMRModuleMixin<EnclaveWasmModule>
     int executeWasmFunction(const std::string& funcName);
 
     WASMModuleInstanceCommon* getModuleInstance();
+
+    bool isBound() const { return _isBound; };
 
     std::string getBoundUser() const { return user; }
 
@@ -90,14 +91,17 @@ class EnclaveWasmModule : public WAMRModuleMixin<EnclaveWasmModule>
     uint8_t* dataXferPtr = nullptr;
     size_t dataXferSize = 0;
 
+    uint8_t* dataXferAuxPtr = nullptr;
+    size_t dataXferAuxSize = 0;
+
   private:
     char errorBuffer[WAMR_ERROR_BUFFER_SIZE];
 
     WASMModuleCommon* wasmModule;
     WASMModuleInstanceCommon* moduleInstance;
 
-    const std::string user;
-    const std::string function;
+    std::string user;
+    std::string function;
 
     bool _isBound = false;
     bool bindInternal();
@@ -116,13 +120,13 @@ class EnclaveWasmModule : public WAMRModuleMixin<EnclaveWasmModule>
 // Data structure to keep track of the module currently loaded in the enclave.
 // Needs to have external definition as it needs to be accessed both when
 // running an ECall and resolving a WAMR native symbol
-extern std::shared_ptr<wasm::EnclaveWasmModule> enclaveWasmModule;
+// extern std::shared_ptr<wasm::EnclaveWasmModule> enclaveWasmModule;
+extern "C" EnclaveWasmModule* getExecutingEnclaveWasmModule();
 
 // Return the EnclaveWasmModule that is executing in a given WASM execution
 // environment. This method relies on `wasm_exec_env_t` having a `module_inst`
 // property, pointint to the instantiated module.
-std::shared_ptr<wasm::EnclaveWasmModule> getExecutingEnclaveWasmModule(
-  wasm_exec_env_t execEnv);
+EnclaveWasmModule* getExecutingEnclaveWasmModule(wasm_exec_env_t execEnv);
 }
 
 // Given that we can not throw exceptions, we wrap the call to the method to
@@ -130,8 +134,7 @@ std::shared_ptr<wasm::EnclaveWasmModule> getExecutingEnclaveWasmModule(
 // be used in the implementation of native symbols, where returning 1 is
 // interpreted as a failure.
 #define GET_EXECUTING_MODULE_AND_CHECK(execEnv)                                \
-    std::shared_ptr<wasm::EnclaveWasmModule> module =                          \
-      wasm::getExecutingEnclaveWasmModule(execEnv);                            \
+    auto* module = wasm::getExecutingEnclaveWasmModule(execEnv);               \
     if (module == nullptr) {                                                   \
         ocallLogError(                                                         \
           "Error linking execution environment to registered modules");        \

--- a/include/enclave/inside/ocalls.h
+++ b/include/enclave/inside/ocalls.h
@@ -182,13 +182,17 @@ extern "C"
                                                      int32_t bufferSize);
 
     extern sgx_status_t SGX_CDECL ocallS3GetNumKeys(int32_t* returnValue,
-                                                    const char* bucketName);
+                                                    const char* bucketName,
+                                                    const char* prefix,
+                                                    int32_t* totalSize,
+                                                    bool cache);
 
     extern sgx_status_t SGX_CDECL ocallS3ListKeys(int32_t* returnValue,
                                                   const char* bucketName,
-                                                  uint8_t* buffer,
-                                                  uint8_t* bufferLens,
-                                                  int32_t bufferSize);
+                                                  const char* prefix);
+                                                  // uint8_t* buffer,
+                                                  // uint8_t* bufferLens,
+                                                  // int32_t bufferSize);
 
     extern sgx_status_t SGX_CDECL ocallS3AddKeyBytes(int32_t* returnValue,
                                                      const char* bucketName,

--- a/include/enclave/inside/ocalls.h
+++ b/include/enclave/inside/ocalls.h
@@ -190,9 +190,6 @@ extern "C"
     extern sgx_status_t SGX_CDECL ocallS3ListKeys(int32_t* returnValue,
                                                   const char* bucketName,
                                                   const char* prefix);
-                                                  // uint8_t* buffer,
-                                                  // uint8_t* bufferLens,
-                                                  // int32_t bufferSize);
 
     extern sgx_status_t SGX_CDECL ocallS3AddKeyBytes(int32_t* returnValue,
                                                      const char* bucketName,

--- a/include/enclave/inside/ocalls.h
+++ b/include/enclave/inside/ocalls.h
@@ -195,7 +195,8 @@ extern "C"
                                                      const char* bucketName,
                                                      const char* keyName,
                                                      uint8_t* keyBuffer,
-                                                     int32_t keyBufferLen);
+                                                     int32_t keyBufferLen,
+                                                     bool overwrite);
 
     extern sgx_status_t SGX_CDECL ocallS3GetKeySize(int32_t* returnValue,
                                                     const char* bucketName,

--- a/include/enclave/outside/ecalls.h
+++ b/include/enclave/outside/ecalls.h
@@ -41,7 +41,9 @@ extern "C"
     extern sgx_status_t ecallCopyDataIn(sgx_enclave_id_t enclaveId,
                                         faasm_sgx_status_t* retVal,
                                         uint8_t* buffer,
-                                        uint32_t bufferSize);
+                                        uint32_t bufferSize,
+                                        uint8_t* auxBuffer,
+                                        uint32_t auxBufferSize);
 
     extern sgx_status_t ecallRunInternalTest(sgx_enclave_id_t enclaveId,
                                              faasm_sgx_status_t* retVal,

--- a/include/storage/S3Wrapper.h
+++ b/include/storage/S3Wrapper.h
@@ -27,7 +27,7 @@ class S3Wrapper
 
     std::vector<std::string> listBuckets();
 
-    std::vector<std::string> listKeys(const std::string& bucketName);
+    std::vector<std::string> listKeys(const std::string& bucketName, const std::string& prefix = "");
 
     void deleteKey(const std::string& bucketName, const std::string& keyName);
 

--- a/include/storage/S3Wrapper.h
+++ b/include/storage/S3Wrapper.h
@@ -27,7 +27,8 @@ class S3Wrapper
 
     std::vector<std::string> listBuckets();
 
-    std::vector<std::string> listKeys(const std::string& bucketName, const std::string& prefix = "");
+    std::vector<std::string> listKeys(const std::string& bucketName,
+                                      const std::string& prefix = "");
 
     void deleteKey(const std::string& bucketName, const std::string& keyName);
 

--- a/include/wasm/s3.h
+++ b/include/wasm/s3.h
@@ -8,5 +8,6 @@ int doS3GetNumKeys(const char* bucketName, const char* prefix = "");
 void doS3AddKeyBytes(const char* bucketName,
                      const char* keyName,
                      void* keyBuffer,
-                     int keyBufferLen);
+                     int keyBufferLen,
+                     bool overwrite = false);
 }

--- a/include/wasm/s3.h
+++ b/include/wasm/s3.h
@@ -3,7 +3,7 @@
 namespace wasm {
 int doS3GetNumBuckets();
 
-int doS3GetNumKeys(const char* bucketName);
+int doS3GetNumKeys(const char* bucketName, const char* prefix = "");
 
 void doS3AddKeyBytes(const char* bucketName,
                      const char* keyName,

--- a/src/enclave/inside/EnclaveWasmModule.cpp
+++ b/src/enclave/inside/EnclaveWasmModule.cpp
@@ -8,8 +8,6 @@
 
 namespace wasm {
 
-// std::shared_ptr<wasm::EnclaveWasmModule> enclaveWasmModule = nullptr;
-
 static bool wamrInitialised = false;
 
 bool EnclaveWasmModule::initialiseWAMRGlobally()
@@ -87,10 +85,8 @@ bool EnclaveWasmModule::doBindToFunction(const char* user,
       wasmBytes.data(), wasmBytes.size(), errorBuffer, WAMR_ERROR_BUFFER_SIZE);
 
     if (wasmModule == nullptr) {
-        SPDLOG_ERROR_SGX("Error loading WASM for %s/%s: %s",
-                         user,
-                         function,
-                         errorBuffer);
+        SPDLOG_ERROR_SGX(
+          "Error loading WASM for %s/%s: %s", user, function, errorBuffer);
         return false;
     }
 
@@ -464,8 +460,7 @@ EnclaveWasmModule* getExecutingEnclaveWasmModule()
     return &enclaveWasmModule;
 }
 
-EnclaveWasmModule* getExecutingEnclaveWasmModule(
-  wasm_exec_env_t execEnv)
+EnclaveWasmModule* getExecutingEnclaveWasmModule(wasm_exec_env_t execEnv)
 {
     auto* enclaveWasmModule = getExecutingEnclaveWasmModule();
 

--- a/src/enclave/inside/ecalls.cpp
+++ b/src/enclave/inside/ecalls.cpp
@@ -70,7 +70,8 @@ extern "C"
         SPDLOG_DEBUG_SGX("module has size: %u", wasmBytesSize);
 
         auto* enclaveWasmModule = wasm::getExecutingEnclaveWasmModule();
-        if (!enclaveWasmModule->doBindToFunction(user, func, wasmBytes, wasmBytesSize)) {
+        if (!enclaveWasmModule->doBindToFunction(
+              user, func, wasmBytes, wasmBytesSize)) {
             SPDLOG_ERROR_SGX(
               "Error binding SGX-WAMR module to %s/%s", user, func);
             return FAASM_SGX_WAMR_MODULE_LOAD_FAILED;
@@ -115,8 +116,10 @@ extern "C"
         return FAASM_SGX_SUCCESS;
     }
 
-    faasm_sgx_status_t ecallCopyDataIn(
-        uint8_t* buffer, uint32_t bufferSize, uint8_t* auxBuffer, uint32_t auxBufferSize)
+    faasm_sgx_status_t ecallCopyDataIn(uint8_t* buffer,
+                                       uint32_t bufferSize,
+                                       uint8_t* auxBuffer,
+                                       uint32_t auxBufferSize)
     {
         auto* enclaveWasmModule = wasm::getExecutingEnclaveWasmModule();
         if (enclaveWasmModule == nullptr) {
@@ -140,7 +143,8 @@ extern "C"
             // Check if we need to malloc, or it has been malloc-ed for us
             // in advance
             if (enclaveWasmModule->dataXferAuxPtr == nullptr) {
-                enclaveWasmModule->dataXferAuxPtr = (uint8_t*)malloc(auxBufferSize);
+                enclaveWasmModule->dataXferAuxPtr =
+                  (uint8_t*)malloc(auxBufferSize);
                 enclaveWasmModule->dataXferAuxSize = auxBufferSize;
             }
 

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -227,14 +227,18 @@ enclave{
         );
 
         int32_t ocallS3GetNumKeys(
-            [in, string]   const char* bucketName
+            [in, string]    const char* bucketName,
+            [in, string]    const char* prefix,
+            [out]           int32_t* totalSize,
+                            bool cache
         );
 
         int32_t ocallS3ListKeys(
             [in, string]            const char* bucketName,
-            [out, size=bufferSize]  uint8_t* buffer,
-            [out, size=bufferSize]  uint8_t* bufferLens,
-                                    int32_t bufferSize
+            [in, string]            const char* prefix
+            // [out, size=bufferSize]  uint8_t* buffer,
+            // [out, size=bufferSize]  uint8_t* bufferLens,
+                                    // int32_t bufferSize
         ) allow(ecallCopyDataIn);
 
         int32_t ocallS3AddKeyBytes(

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -45,8 +45,10 @@ enclave{
         // As a consequence, if we need to transfer large amounts of data into
         // the enclave, we need to use an ECall, and not a pointer in an OCall.
         public faasm_sgx_status_t ecallCopyDataIn(
-            [in, size=bufferSize]   uint8_t* buffer,
-            uint32_t                bufferSize
+            [in, size=bufferSize]       uint8_t* buffer,
+                                        uint32_t bufferSize,
+            [in, size=auxBufferSize]    uint8_t* auxBuffer,
+                                        uint32_t auxBufferSize
         );
 
         public faasm_sgx_status_t ecallRunInternalTest(

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -236,9 +236,6 @@ enclave{
         int32_t ocallS3ListKeys(
             [in, string]            const char* bucketName,
             [in, string]            const char* prefix
-            // [out, size=bufferSize]  uint8_t* buffer,
-            // [out, size=bufferSize]  uint8_t* bufferLens,
-                                    // int32_t bufferSize
         ) allow(ecallCopyDataIn);
 
         int32_t ocallS3AddKeyBytes(

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -242,7 +242,8 @@ enclave{
             [in, string]            const char* bucketName,
             [in, string]            const char* keyName,
             [in, size=keyBufferLen] uint8_t* keyBuffer,
-                                    int32_t keyBufferLen
+                                    int32_t keyBufferLen,
+                                    bool overwrite
         );
 
         int32_t ocallS3GetKeySize(

--- a/src/enclave/inside/enclave_hw.config
+++ b/src/enclave/inside/enclave_hw.config
@@ -2,13 +2,13 @@
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
 
-  <StackMinSize>0x2000</StackMinSize>
-  <StackMaxSize>0x100000</StackMaxSize>
+  <StackMinSize>0x200000</StackMinSize>
+  <StackMaxSize>0x1000000</StackMaxSize>
 
-  <HeapMinSize>0x4000</HeapMinSize>
-  <HeapInitSize>0x4000</HeapInitSize>
+  <HeapMinSize>0x40000</HeapMinSize>
+  <HeapInitSize>0x4000000</HeapInitSize>
   <!-- 3 GB max heap size -->
-  <HeapMaxSize>0xC0000000</HeapMaxSize>
+  <HeapMaxSize>0xD0000000</HeapMaxSize>
 
   <!-- ReservedMem feature is for legacy non-dynamic MM, so do not set it -->
   <!-- Instead, we need to set the memory region to dynamically allocate memory from -->

--- a/src/enclave/inside/s3.cpp
+++ b/src/enclave/inside/s3.cpp
@@ -274,16 +274,20 @@ static int32_t faasm_s3_add_key_bytes_wrapper(wasm_exec_env_t execEnv,
                                               const char* bucketName,
                                               const char* keyName,
                                               uint8_t* keyBuffer,
-                                              int32_t keyBufferLen)
+                                              int32_t keyBufferLen,
+                                              bool overwrite)
 {
     SPDLOG_DEBUG_SGX(
       "faasm_s3_add_key_bytes (bucket: %s, key: %s)", bucketName, keyName);
 
     sgx_status_t sgxReturnValue;
     int32_t returnValue;
-    if ((sgxReturnValue = ocallS3AddKeyBytes(
-           &returnValue, bucketName, keyName, keyBuffer, keyBufferLen)) !=
-        SGX_SUCCESS) {
+    if ((sgxReturnValue = ocallS3AddKeyBytes(&returnValue,
+                                             bucketName,
+                                             keyName,
+                                             keyBuffer,
+                                             keyBufferLen,
+                                             overwrite)) != SGX_SUCCESS) {
         SET_ERROR(FAASM_SGX_OCALL_ERROR(sgxReturnValue));
     }
 
@@ -393,7 +397,7 @@ static NativeSymbol s3Ns[] = {
     REG_FAASM_NATIVE_FUNC(faasm_s3_get_num_keys_with_prefix, "($$)i"),
     REG_FAASM_NATIVE_FUNC(faasm_s3_list_keys, "($**)"),
     REG_FAASM_NATIVE_FUNC(faasm_s3_list_keys_with_prefix, "($$**)"),
-    REG_FAASM_NATIVE_FUNC(faasm_s3_add_key_bytes, "($$*~)i"),
+    REG_FAASM_NATIVE_FUNC(faasm_s3_add_key_bytes, "($$*~i)i"),
     REG_FAASM_NATIVE_FUNC(faasm_s3_get_key_bytes, "($$**)i"),
 };
 

--- a/src/enclave/outside/ocalls.cpp
+++ b/src/enclave/outside/ocalls.cpp
@@ -594,10 +594,11 @@ extern "C"
     int32_t ocallS3AddKeyBytes(const char* bucketName,
                                const char* keyName,
                                uint8_t* keyBuffer,
-                               int32_t keyBufferLen)
+                               int32_t keyBufferLen,
+                               bool overwrite)
     {
         wasm::doS3AddKeyBytes(
-          bucketName, keyName, (void*)keyBuffer, keyBufferLen);
+          bucketName, keyName, (void*)keyBuffer, keyBufferLen, overwrite);
 
         return 0;
     }

--- a/src/enclave/outside/ocalls.cpp
+++ b/src/enclave/outside/ocalls.cpp
@@ -584,6 +584,7 @@ extern "C"
         // If we need to use an ECall to transfer data overwrite the provided
         // buffer by a big-enough buffer. Part of it will still be copied as
         // a result of the OCall, but just 1 KB
+        // TODO: right now we MUST always USE aux
         bool mustUseECall = totalSize > MAX_OCALL_BUFFER_SIZE;
         std::vector<uint8_t> auxBuffer;
         if (mustUseECall) {
@@ -598,6 +599,7 @@ extern "C"
 
         // We may also need to use an aux. ECall to transfer the lengths of
         // all keys. This may happen if we have many keys
+        // TODO: we now ALWAYS USE ECall (revert?)
         bool mustUseAuxECall = totalLensSize > MAX_OCALL_BUFFER_SIZE;
         std::vector<uint8_t> auxLensBuffer;
         if (mustUseAuxECall) {
@@ -630,7 +632,6 @@ extern "C"
             faasm_sgx_status_t returnValue;
             auto enclaveId =
               wasm::getExecutingEnclaveInterface()->getEnclaveId();
-            mustUseAuxECall = false;
             sgx_status_t sgxReturnValue = ecallCopyDataIn(
                 enclaveId,
                 &returnValue,

--- a/src/enclave/outside/system.cpp
+++ b/src/enclave/outside/system.cpp
@@ -101,6 +101,7 @@ void destroyEnclave(sgx_enclave_id_t enclaveId)
     processECallErrors("Unable to destroy enclave", sgxReturnValue);
 }
 
+// TODO: make this return an int, don't throw exceptions in WAMR
 void processECallErrors(std::string errorMessage,
                         sgx_status_t sgxReturnValue,
                         faasm_sgx_status_t faasmReturnValue)
@@ -108,7 +109,7 @@ void processECallErrors(std::string errorMessage,
     if (sgxReturnValue != SGX_SUCCESS) {
         std::string errorText = "(SGX Error) " + errorMessage;
         SPDLOG_ERROR("{}: {}", errorText, sgxErrorString(sgxReturnValue));
-        throw std::runtime_error(errorText);
+        // throw std::runtime_error(errorText);
     }
 
     if (faasmReturnValue != FAASM_SGX_SUCCESS) {

--- a/src/enclave/outside/system.cpp
+++ b/src/enclave/outside/system.cpp
@@ -109,7 +109,7 @@ void processECallErrors(std::string errorMessage,
     if (sgxReturnValue != SGX_SUCCESS) {
         std::string errorText = "(SGX Error) " + errorMessage;
         SPDLOG_ERROR("{}: {}", errorText, sgxErrorString(sgxReturnValue));
-        // throw std::runtime_error(errorText);
+        throw std::runtime_error(errorText);
     }
 
     if (faasmReturnValue != FAASM_SGX_SUCCESS) {

--- a/src/storage/S3Wrapper.cpp
+++ b/src/storage/S3Wrapper.cpp
@@ -165,7 +165,8 @@ std::vector<std::string> S3Wrapper::listBuckets()
     return bucketNames;
 }
 
-std::vector<std::string> S3Wrapper::listKeys(const std::string& bucketName, const std::string& prefix)
+std::vector<std::string> S3Wrapper::listKeys(const std::string& bucketName,
+                                             const std::string& prefix)
 {
     SPDLOG_TRACE("Listing keys in bucket {} (prefix: {})", bucketName, prefix);
 

--- a/src/storage/S3Wrapper.cpp
+++ b/src/storage/S3Wrapper.cpp
@@ -165,12 +165,15 @@ std::vector<std::string> S3Wrapper::listBuckets()
     return bucketNames;
 }
 
-std::vector<std::string> S3Wrapper::listKeys(const std::string& bucketName)
+std::vector<std::string> S3Wrapper::listKeys(const std::string& bucketName, const std::string& prefix)
 {
-    SPDLOG_TRACE("Listing keys in bucket {}", bucketName);
+    SPDLOG_TRACE("Listing keys in bucket {} (prefix: {})", bucketName, prefix);
 
     minio::s3::ListObjectsArgs args;
     args.bucket = bucketName;
+    if (!prefix.empty()) {
+        args.prefix = prefix;
+    }
     args.recursive = true;
     auto response = client.ListObjects(args);
 

--- a/src/wamr/s3.cpp
+++ b/src/wamr/s3.cpp
@@ -126,10 +126,12 @@ static int32_t __faasm_s3_add_key_bytes_wrapper(wasm_exec_env_t execEnv,
                                                 const char* bucketName,
                                                 const char* keyName,
                                                 void* keyBuffer,
-                                                int32_t keyBufferLen)
+                                                int32_t keyBufferLen,
+                                                bool overwrite)
 {
     try {
-        wasm::doS3AddKeyBytes(bucketName, keyName, keyBuffer, keyBufferLen);
+        wasm::doS3AddKeyBytes(
+          bucketName, keyName, keyBuffer, keyBufferLen, overwrite);
     } catch (std::exception& e) {
         auto* module = getExecutingWAMRModule();
         module->doThrowException(e);
@@ -186,7 +188,7 @@ static NativeSymbol s3_ns[] = {
     REG_NATIVE_FUNC(__faasm_s3_get_num_keys_with_prefix, "($$)i"),
     REG_NATIVE_FUNC(__faasm_s3_list_keys, "($**)"),
     REG_NATIVE_FUNC(__faasm_s3_list_keys_with_prefix, "($$**)"),
-    REG_NATIVE_FUNC(__faasm_s3_add_key_bytes, "($$*~)i"),
+    REG_NATIVE_FUNC(__faasm_s3_add_key_bytes, "($$*~i)i"),
     REG_NATIVE_FUNC(__faasm_s3_get_key_bytes, "($$**)i"),
 };
 

--- a/src/wamr/s3.cpp
+++ b/src/wamr/s3.cpp
@@ -57,11 +57,13 @@ static int32_t __faasm_s3_get_num_keys_wrapper(wasm_exec_env_t execEnv,
     return wasm::doS3GetNumKeys(bucketName);
 }
 
-static int32_t __faasm_s3_get_num_keys_with_prefix_wrapper(wasm_exec_env_t execEnv,
-                                                           const char* bucketName,
-                                                           const char* prefix)
+static int32_t __faasm_s3_get_num_keys_with_prefix_wrapper(
+  wasm_exec_env_t execEnv,
+  const char* bucketName,
+  const char* prefix)
 {
-    SPDLOG_DEBUG("S - faasm_s3_get_num_keys (bucket: {}, prefix: {})", bucketName, prefix);
+    SPDLOG_DEBUG(
+      "S - faasm_s3_get_num_keys (bucket: {}, prefix: {})", bucketName, prefix);
 
     return wasm::doS3GetNumKeys(bucketName, prefix);
 }
@@ -72,7 +74,8 @@ void doListKeys(wasm_exec_env_t execEnv,
                 int32_t* keysBuffer,
                 int32_t* keysBufferLen)
 {
-    SPDLOG_DEBUG("S - faasm_s3_list_keys (bucket: {}, prefix: {})", bucketName, prefix);
+    SPDLOG_DEBUG(
+      "S - faasm_s3_list_keys (bucket: {}, prefix: {})", bucketName, prefix);
 
     storage::S3Wrapper s3cli;
     auto keyList = s3cli.listKeys(bucketName, prefix);

--- a/src/wamr/s3.cpp
+++ b/src/wamr/s3.cpp
@@ -57,15 +57,25 @@ static int32_t __faasm_s3_get_num_keys_wrapper(wasm_exec_env_t execEnv,
     return wasm::doS3GetNumKeys(bucketName);
 }
 
-static void __faasm_s3_list_keys_wrapper(wasm_exec_env_t execEnv,
-                                         char* bucketName,
-                                         int32_t* keysBuffer,
-                                         int32_t* keysBufferLen)
+static int32_t __faasm_s3_get_num_keys_with_prefix_wrapper(wasm_exec_env_t execEnv,
+                                                           const char* bucketName,
+                                                           const char* prefix)
 {
-    SPDLOG_DEBUG("S - faasm_s3_list_keys (bucket: {})", bucketName);
+    SPDLOG_DEBUG("S - faasm_s3_get_num_keys (bucket: {}, prefix: {})", bucketName, prefix);
+
+    return wasm::doS3GetNumKeys(bucketName, prefix);
+}
+
+void doListKeys(wasm_exec_env_t execEnv,
+                const char* bucketName,
+                const char* prefix,
+                int32_t* keysBuffer,
+                int32_t* keysBufferLen)
+{
+    SPDLOG_DEBUG("S - faasm_s3_list_keys (bucket: {}, prefix: {})", bucketName, prefix);
 
     storage::S3Wrapper s3cli;
-    auto keyList = s3cli.listKeys(bucketName);
+    auto keyList = s3cli.listKeys(bucketName, prefix);
 
     auto* module = getExecutingWAMRModule();
     for (int i = 0; i < keyList.size(); i++) {
@@ -90,6 +100,23 @@ static void __faasm_s3_list_keys_wrapper(wasm_exec_env_t execEnv,
         // allocated string
         keysBuffer[i] = wasmOffset;
     }
+}
+
+static void __faasm_s3_list_keys_wrapper(wasm_exec_env_t execEnv,
+                                         const char* bucketName,
+                                         int32_t* keysBuffer,
+                                         int32_t* keysBufferLen)
+{
+    doListKeys(execEnv, bucketName, "", keysBuffer, keysBufferLen);
+}
+
+static void __faasm_s3_list_keys_with_prefix_wrapper(wasm_exec_env_t execEnv,
+                                                     const char* bucketName,
+                                                     const char* prefix,
+                                                     int32_t* keysBuffer,
+                                                     int32_t* keysBufferLen)
+{
+    doListKeys(execEnv, bucketName, prefix, keysBuffer, keysBufferLen);
 }
 
 static int32_t __faasm_s3_add_key_bytes_wrapper(wasm_exec_env_t execEnv,
@@ -153,7 +180,9 @@ static NativeSymbol s3_ns[] = {
     REG_NATIVE_FUNC(__faasm_s3_get_num_buckets, "()i"),
     REG_NATIVE_FUNC(__faasm_s3_list_buckets, "(**)"),
     REG_NATIVE_FUNC(__faasm_s3_get_num_keys, "($)i"),
+    REG_NATIVE_FUNC(__faasm_s3_get_num_keys_with_prefix, "($$)i"),
     REG_NATIVE_FUNC(__faasm_s3_list_keys, "($**)"),
+    REG_NATIVE_FUNC(__faasm_s3_list_keys_with_prefix, "($$**)"),
     REG_NATIVE_FUNC(__faasm_s3_add_key_bytes, "($$*~)i"),
     REG_NATIVE_FUNC(__faasm_s3_get_key_bytes, "($$**)i"),
 };

--- a/src/wasm/chaining_util.cpp
+++ b/src/wasm/chaining_util.cpp
@@ -111,9 +111,9 @@ faabric::Message awaitChainedCallOutput(unsigned int messageId)
 
     faabric::Message result;
     try {
-        auto msg = exec->getChainedMessage(messageId);
+        int appId = exec->getBoundMessage().appid();
         auto& plannerCli = faabric::planner::getPlannerClient();
-        result = plannerCli.getMessageResult(msg, callTimeoutMs);
+        result = plannerCli.getMessageResult(appId, messageId, callTimeoutMs);
     } catch (faabric::executor::ChainedCallException& e) {
         SPDLOG_ERROR(
           "Error awaiting for chained call {}: {}", messageId, e.what());

--- a/src/wasm/faasm.cpp
+++ b/src/wasm/faasm.cpp
@@ -132,7 +132,7 @@ void doFaasmSmReduce(int32_t varPtr,
 
 int32_t doFaasmReadInput(char* inBuff, int32_t inBuffLen)
 {
-    SPDLOG_DEBUG("S - faasm_read_input {} {}", inBuff, inBuffLen);
+    SPDLOG_DEBUG("S - faasm_read_input (len: {})", inBuffLen);
 
     faabric::Message& call =
       faabric::executor::ExecutorContext::get()->getMsg();

--- a/src/wasm/s3.cpp
+++ b/src/wasm/s3.cpp
@@ -19,11 +19,16 @@ int doS3GetNumKeys(const char* bucketName, const char* prefix)
 void doS3AddKeyBytes(const char* bucketName,
                      const char* keyName,
                      void* keyBuffer,
-                     int keyBufferLen)
+                     int keyBufferLen,
+                     bool overwrite)
 {
     storage::S3Wrapper s3cli;
     std::vector<uint8_t> data;
     data.assign((uint8_t*)keyBuffer, (uint8_t*)keyBuffer + keyBufferLen);
+
+    if (overwrite) {
+        s3cli.deleteKey(bucketName, keyName);
+    }
 
     s3cli.addKeyBytes(bucketName, keyName, data);
 }

--- a/src/wasm/s3.cpp
+++ b/src/wasm/s3.cpp
@@ -9,11 +9,11 @@ int doS3GetNumBuckets()
     return s3cli.listBuckets().size();
 }
 
-int doS3GetNumKeys(const char* bucketName)
+int doS3GetNumKeys(const char* bucketName, const char* prefix)
 {
     storage::S3Wrapper s3cli;
 
-    return s3cli.listKeys(bucketName).size();
+    return s3cli.listKeys(bucketName, prefix).size();
 }
 
 void doS3AddKeyBytes(const char* bucketName,


### PR DESCRIPTION
There is a strange issue with `S3ListKeys` where, for very long lists of keys (i.e. ~40 KB), the OCall + ECall combination seems to corrupt some enclave state, in a way that SGX's `malloc` overwrites some state in the EnclaveWasmModule.

In this PR I polish some tangential issues, making this work for relatively long keys (but not aribtrarily long ones). I will address the latter in follow-up PRs.