### PR TITLE
cmake: separate release/debug and sgx build dirs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ${FAASM_BUILD_DIR}:${FAASM_BUILD_MOUNT}
     environment:
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=${FAASM_LOG_LEVEL:-debug}
       - PLANNER_PORT=${PLANNER_DOCKER_PORT}
 
   minio:
@@ -55,13 +55,13 @@ services:
       - ./dev/faasm-local/object/:${FAASM_LOCAL_MOUNT}/object
     environment:
       - DEPLOYMENT_TYPE=${FAASM_DEPLOYMENT_TYPE:-compose}
-      - LOG_LEVEL=info
+      - LOG_LEVEL=${FAASM_LOG_LEVEL:-info}
       - PLANNER_HOST=planner
       - PLANNER_PORT=${PLANNER_DOCKER_PORT}
       - PYTHON_CODEGEN=${PYTHON_CODEGEN:-off}
       - REDIS_QUEUE_HOST=redis-queue
       - REDIS_STATE_HOST=redis-state
-      - LD_LIBRARY_PATH=/build/faasm/third-party/lib:/usr/local/lib
+      - LD_LIBRARY_PATH=/usr/local/lib
       - FAASM_WASM_VM=${FAASM_WASM_VM:-wamr}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8002/ping"]
@@ -91,8 +91,8 @@ services:
       - DEPLOYMENT_TYPE=${FAASM_DEPLOYMENT_TYPE:-compose}
       - FAASM_WASM_VM=${FAASM_WASM_VM:-wamr}
       - GLOBAL_MESSAGE_TIMEOUT=600000
-      - LD_LIBRARY_PATH=/build/faasm/third-party/lib:/usr/local/lib
-      - LOG_LEVEL=debug
+      - LD_LIBRARY_PATH=/usr/local/lib
+      - LOG_LEVEL=${FAASM_LOG_LEVEL:-debug}
       - MAX_NET_NAMESPACES=100
       - NETNS_MODE=off
       - OVERRIDE_CPU_COUNT=${FAASM_OVERRIDE_CPU_COUNT:-8}
@@ -140,8 +140,8 @@ services:
       - AZDCAP_DEBUG_LOG_LEVEL=info
       - DEPLOYMENT_TYPE=${FAASM_DEPLOYMENT_TYPE:-compose}
       - FAASM_WASM_VM=${FAASM_WASM_VM:-wamr}
-      - LD_LIBRARY_PATH=/build/faasm/third-party/lib:/usr/local/lib
-      - LOG_LEVEL=debug
+      - LD_LIBRARY_PATH=/usr/local/lib
+      - LOG_LEVEL=${FAASM_LOG_LEVEL:-debug}
       - PLANNER_HOST=planner
       - PLANNER_PORT=${PLANNER_DOCKER_PORT}
       - REDIS_QUEUE_HOST=redis-queue
@@ -188,7 +188,7 @@ services:
       - FAASM_WASM_VM=${FAASM_WASM_VM:-wamr}
       - GLOBAL_MESSAGE_TIMEOUT=120000
       - LD_LIBRARY_PATH=/usr/local/lib
-      - LOG_LEVEL=debug
+      - LOG_LEVEL=${FAASM_LOG_LEVEL:-debug}
       - OVERRIDE_CPU_COUNT=${FAASM_OVERRIDE_CPU_COUNT:-4}
       - PLANNER_HOST=planner
       - PLANNER_PORT=${PLANNER_DOCKER_PORT}

--- a/src/enclave/inside/CMakeLists.txt
+++ b/src/enclave/inside/CMakeLists.txt
@@ -159,6 +159,7 @@ add_custom_command(TARGET enclave_trusted
     ${ENCLAVE_TRUSTED_C_FLAGS}
     -I${SGX_SDK_PATH}/include
     -I${SGX_SDK_PATH}/include/tlibc
+    -I${WAMR_ROOT_DIR}/core/iwasm/include
     -c ${ENCLAVE_EDL_FILENAME}_t.c
     -o ${ENCLAVE_EDL_FILENAME}_t.o
 )

--- a/src/enclave/inside/enclave.edl
+++ b/src/enclave/inside/enclave.edl
@@ -1,17 +1,11 @@
-// Annoyingly we have to redefine these here
-#define FAASM_SGX 1
-#define FAASM_SGX_WAMR_WASI_LIBC 1
-
 enclave{
     include "/usr/local/code/faasm/include/enclave/error.h"
-    include "/build/faasm/_deps/wamr_ext-src/core/iwasm/include/wasm_export.h"
+    include "wasm_export.h"
     include "sgx_report.h"
 
     from "sgx_tstdc.edl" import *;
     from "sgx_pthread.edl" import *;
-#if(FAASM_SGX_WAMR_WASI_LIBC)
     from "sgx_wamr.edl" import *;
-#endif
 
     trusted{
         public faasm_sgx_status_t ecallCreateReport(

--- a/src/enclave/outside/CMakeLists.txt
+++ b/src/enclave/outside/CMakeLists.txt
@@ -134,6 +134,7 @@ add_custom_command(TARGET enclave_untrusted
     PRE_BUILD COMMAND gcc
     ${ENCLAVE_UNTRUSTED_C_FLAGS}
     -I${SGX_SDK_PATH}/include
+    -I${WAMR_ROOT_DIR}/core/iwasm/include
     -c ${ENCLAVE_EDL_FILENAME}_u.c
     -o ${ENCLAVE_EDL_FILENAME}_u.o
 )

--- a/src/wamr/CMakeLists.txt
+++ b/src/wamr/CMakeLists.txt
@@ -51,6 +51,7 @@ faasm_private_lib(wamrlib "${WAMR_RUNTIME_LIB_SOURCE}")
 
 # Disable WAMR warnings
 target_compile_options(wamrlib PRIVATE
+    -Wno-macro-redefined
     -Wno-typedef-redefinition
     -Wno-unused-but-set-variable
     -Wno-unused-command-line-argument

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -1,6 +1,6 @@
 from faasmtools.build import FAASM_RUNTIME_ENV_DICT, get_dict_as_cmake_vars
 from invoke import task
-from os import makedirs
+from os import listdir, makedirs
 from os.path import exists, getmtime, join
 from subprocess import run
 from sys import exit
@@ -45,9 +45,9 @@ def get_build_dir(build_type, sgx_mode):
 
     if sgx_mode != FAASM_SGX_MODE_DISABLED:
         if sgx_mode == FAASM_SGX_MODE_SIM:
-            build_dir += "/sgx-sim"
+            build_dir += "-sgx-sim"
         elif sgx_mode == FAASM_SGX_MODE_HARDWARE:
-            build_dir += "/sgx-hw"
+            build_dir += "-sgx-hw"
         else:
             print(f"ERROR: unrecognised sgx mode: {sgx_mode}")
             exit(1)
@@ -59,27 +59,15 @@ def get_current_target_build_dir():
     """
     Infer the correct build dir based on the last modified directory.
     """
-    debug_dir = join(FAASM_BUILD_DIR, "debug")
-    release_dir = join(FAASM_BUILD_DIR, "release")
+    # List all `/build/faasm/debug-*` or `/build/faasm/release-*` directories
+    build_dirs = [
+        join(FAASM_BUILD_DIR, entry)
+        for entry in listdir(FAASM_BUILD_DIR)
+        if entry.startswith("debug") or entry.startswith("release")
+    ]
 
-    if not exists(release_dir):
-        if exists(debug_dir):
-            return debug_dir
-
-        print(f"ERROR: neither {release_dir} nor {debug_dir} exist!")
-        exit(1)
-
-    if not exists(debug_dir):
-        if exists(release_dir):
-            return release_dir
-
-        print(f"ERROR: neither {release_dir} nor {debug_dir} exist!")
-        exit(1)
-
-    if getmtime(debug_dir) > getmtime(release_dir):
-        return debug_dir
-
-    return release_dir
+    # Pick the one that was modified the latest
+    return max(build_dirs, key=getmtime)
 
 
 def soft_link_bin_dir(build_dir):

--- a/tasks/dev.py
+++ b/tasks/dev.py
@@ -1,12 +1,15 @@
 from faasmtools.build import FAASM_RUNTIME_ENV_DICT, get_dict_as_cmake_vars
 from invoke import task
 from os import makedirs
-from os.path import exists, join
+from os.path import exists, getmtime, join
 from subprocess import run
+from sys import exit
 from tasks.util.env import (
     FAASM_BUILD_DIR,
     FAASM_INSTALL_DIR,
     FAASM_SGX_MODE_DISABLED,
+    FAASM_SGX_MODE_HARDWARE,
+    FAASM_SGX_MODE_SIM,
     LLVM_MAJOR_VERSION,
     PROJ_ROOT,
 )
@@ -27,6 +30,70 @@ DEV_TARGETS = [
 SANITISER_NONE = "None"
 
 
+def check_build_type(build):
+    build_types = ["Debug", "Release"]
+    if build not in build_types:
+        print(
+            f"ERROR: unrecognised build type: {build}. must be one in: {build_types}"
+        )
+        exit(1)
+
+
+def get_build_dir(build_type, sgx_mode):
+    build_type = build_type.lower()
+    build_dir = f"{FAASM_BUILD_DIR}/{build_type}"
+
+    if sgx_mode != FAASM_SGX_MODE_DISABLED:
+        if sgx_mode == FAASM_SGX_MODE_SIM:
+            build_dir += "/sgx-sim"
+        elif sgx_mode == FAASM_SGX_MODE_HARDWARE:
+            build_dir += "/sgx-hw"
+        else:
+            print(f"ERROR: unrecognised sgx mode: {sgx_mode}")
+            exit(1)
+
+    return build_dir
+
+
+def get_current_target_build_dir():
+    """
+    Infer the correct build dir based on the last modified directory.
+    """
+    debug_dir = join(FAASM_BUILD_DIR, "debug")
+    release_dir = join(FAASM_BUILD_DIR, "release")
+
+    if not exists(release_dir):
+        if exists(debug_dir):
+            return debug_dir
+
+        print(f"ERROR: neither {release_dir} nor {debug_dir} exist!")
+        exit(1)
+
+    if not exists(debug_dir):
+        if exists(release_dir):
+            return release_dir
+
+        print(f"ERROR: neither {release_dir} nor {debug_dir} exist!")
+        exit(1)
+
+    if getmtime(debug_dir) > getmtime(release_dir):
+        return debug_dir
+
+    return release_dir
+
+
+def soft_link_bin_dir(build_dir):
+    """
+    Irrespective of the build type, it is convenient to have the Faasm binaries
+    in `/build/faasm/bin`. This makes it possible to hot-patch a binary using
+    `faasmctl restart -s <service>` even if we change the build type or SGX
+    mode. Thus, after any build, we soft-link `/build/faasm/bin` to whatever
+    is the last `bin` directory we have written to. This also prevents
+    accidentally using binaries compiled in different modes.
+    """
+    run(f"ln -sf {build_dir}/bin {FAASM_BUILD_DIR}", shell=True, check=True)
+
+
 @task
 def cmake(
     ctx,
@@ -43,11 +110,19 @@ def cmake(
     """
     Configures the CMake build
     """
-    if clean and exists(FAASM_BUILD_DIR):
-        run("rm -rf {}/*".format(FAASM_BUILD_DIR), shell=True, check=True)
+    check_build_type(build)
+    build_dir = get_build_dir(build, sgx)
 
-    if not exists(FAASM_BUILD_DIR):
-        makedirs(FAASM_BUILD_DIR)
+    if clean and exists(build_dir):
+        run("rm -rf {}/*".format(build_dir), shell=True, check=True)
+        run(
+            f"rm -rf {FAASM_BUILD_DIR}/bin".format(build_dir),
+            shell=True,
+            check=True,
+        )
+
+    if not exists(build_dir):
+        makedirs(build_dir)
 
     if not exists(FAASM_INSTALL_DIR):
         makedirs(FAASM_INSTALL_DIR)
@@ -78,7 +153,9 @@ def cmake(
     cmd_str = " ".join(cmd)
     print(cmd_str)
 
-    run(cmd_str, shell=True, check=True, cwd=FAASM_BUILD_DIR)
+    run(cmd_str, shell=True, check=True, cwd=build_dir)
+
+    soft_link_bin_dir(build_dir)
 
 
 @task
@@ -98,6 +175,8 @@ def tools(
     if sgx != FAASM_SGX_MODE_DISABLED and sanitiser != SANITISER_NONE:
         raise RuntimeError("SGX and sanitised builds are incompatible!")
 
+    build_dir = get_build_dir(build, sgx)
+
     cmake(
         ctx,
         clean=clean,
@@ -116,10 +195,12 @@ def tools(
     print(cmake_cmd)
     run(
         cmake_cmd,
-        cwd=FAASM_BUILD_DIR,
+        cwd=build_dir,
         shell=True,
         check=True,
     )
+
+    soft_link_bin_dir(build_dir)
 
 
 @task
@@ -127,6 +208,8 @@ def cc(ctx, target, clean=False, parallel=0):
     """
     Compiles the given CMake target
     """
+    build_dir = get_current_target_build_dir()
+
     if clean:
         cmake(ctx, clean=True)
 
@@ -141,7 +224,7 @@ def cc(ctx, target, clean=False, parallel=0):
 
     run(
         cmake_cmd,
-        cwd=FAASM_BUILD_DIR,
+        cwd=build_dir,
         shell=True,
         check=True,
     )
@@ -167,7 +250,7 @@ def coverage_report(ctx, file_in, file_out):
     llvm_cmd = [
         "llvm-cov-{} show".format(LLVM_MAJOR_VERSION),
         "--ignore-filename-regex=/usr/local/code/faasm/tests/*",
-        join(FAASM_BUILD_DIR, "bin", "tests"),
+        join(FAASM_BUILD_DIR, "debug", "bin", "tests"),
         "-instr-profile={}".format(tmp_file),
         "> {}".format(file_out),
     ]


### PR DESCRIPTION
This should make it possible to cache build artifacts across different deployment types (with --mount-source).

Closes #902